### PR TITLE
fix: 5 critical bugs breaking unbrowse capture pipeline

### DIFF
--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -20,8 +20,8 @@ pub const EventBuffer = struct {
             self.items[self.len] = event;
             self.len += 1;
         } else {
-            // Ring buffer: overwrite oldest
-            self.allocator.free(self.items[0].?);
+            // Ring buffer: overwrite oldest, don't free — events may be
+            // arena-allocated by different request threads
             var i: usize = 0;
             while (i < 31) : (i += 1) {
                 self.items[i] = self.items[i + 1];
@@ -86,8 +86,14 @@ pub const CdpClient = struct {
     }
 
     /// Connect to Chrome CDP WebSocket endpoint.
+    /// Connect to Chrome CDP WebSocket endpoint.
     pub fn connectWs(self: *CdpClient) !void {
         if (self.connected) return;
+        // Close stale WS before reconnecting
+        if (self.ws) |*ws| {
+            ws.close();
+            self.ws = null;
+        }
         self.ws = WebSocketClient.connect(
             self.allocator,
             self.cdp_url,
@@ -97,35 +103,47 @@ pub const CdpClient = struct {
         self.connected = true;
     }
 
-    /// Send a CDP command and receive the response. Allocates result.
     /// Send a CDP command and receive the matching response. Allocates result.
     /// Skips CDP events (messages without matching id) and correlates by command ID.
+    /// Auto-reconnects on connection failure.
     pub fn send(self: *CdpClient, allocator: std.mem.Allocator, method: []const u8, params_json: ?[]const u8) ![]const u8 {
-        if (!self.connected) try self.connectWs();
+        // Try up to 2 times — reconnect on first failure
+        var retry: u32 = 0;
+        while (retry < 2) : (retry += 1) {
+            if (!self.connected) self.connectWs() catch return error.ConnectionRefused;
 
-        var ws = &(self.ws orelse return error.ConnectionRefused);
+            var ws = &(self.ws orelse return error.ConnectionRefused);
 
-        const msg = try self.buildMessage(allocator, method, params_json);
-        const sent_id = self.next_id.load(.monotonic) - 1; // ID we just used
-        defer allocator.free(msg);
+            const msg = try self.buildMessage(allocator, method, params_json);
+            const sent_id = self.next_id.load(.monotonic) - 1;
+            defer allocator.free(msg);
 
-        ws.sendText(msg) catch return error.ConnectionRefused;
-
-        // Read responses, buffer events, max 100 attempts
-        // (needs headroom for event-heavy operations like cookies/network)
-        var attempts: u32 = 0;
-        while (attempts < 100) : (attempts += 1) {
-            const response = ws.receiveMessageAlloc(allocator, 2 * 1024 * 1024) catch |err| switch (err) {
-                error.ConnectionClosed => return error.ConnectionRefused,
-                else => return error.ConnectionRefused,
+            ws.sendText(msg) catch {
+                // Connection died — mark disconnected and retry
+                self.connected = false;
+                continue;
             };
 
-            if (matchesResponseId(response, sent_id)) {
-                return response;
+            // Read responses, buffer events, max 100 attempts
+            var attempts: u32 = 0;
+            while (attempts < 100) : (attempts += 1) {
+                const response = ws.receiveMessageAlloc(allocator, 2 * 1024 * 1024) catch {
+                    // Connection died during read — mark disconnected and retry
+                    self.connected = false;
+                    break;
+                };
+
+                if (matchesResponseId(response, sent_id)) {
+                    return response;
+                }
+
+                // Buffer event instead of discarding
+                self.event_buf.push(response);
             }
 
-            // Buffer event instead of discarding
-            self.event_buf.push(response);
+            // If we broke out of the read loop due to disconnect, retry
+            if (!self.connected) continue;
+            return error.ConnectionRefused;
         }
 
         return error.ConnectionRefused;

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -43,7 +43,7 @@ fn handleConnection(gpa: std.mem.Allocator, bridge: *Bridge, cfg: Config, conn: 
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var read_buf: [8192]u8 = undefined;
+    var read_buf: [65536]u8 = undefined;
     var net_reader = net.Stream.Reader.init(conn.stream, &read_buf);
     var write_buf: [8192]u8 = undefined;
     var net_writer = net.Stream.Writer.init(conn.stream, &write_buf);
@@ -662,9 +662,25 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         resp.sendError(request, 400, "Missing tab_id parameter");
         return;
     };
-    const expr = getQueryParam(target, "expression") orelse {
-        resp.sendError(request, 400, "Missing expression parameter");
-        return;
+
+    // Support both query param and POST body for expression.
+    // POST body is preferred for large scripts that exceed URL length limits.
+    const expr = blk: {
+        // Try POST body first (JSON: {"expression": "..."} or raw text)
+        if (readRequestBody(request, arena)) |body| {
+            if (body.len > 0) {
+                if (extractSimpleJsonString(body, 0, "\"expression\"")) |s| {
+                    break :blk s;
+                }
+                // Treat entire body as raw expression
+                break :blk body;
+            }
+        }
+        // Fall back to query param
+        break :blk getQueryParam(target, "expression") orelse {
+            resp.sendError(request, 400, "Missing expression parameter — send as POST body or ?expression= query param");
+            return;
+        };
     };
 
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -672,8 +688,13 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         return;
     };
 
+    // JSON-escape the expression to handle quotes, backslashes, newlines etc.
+    const escaped = jsonEscapeAlloc(arena, expr) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
     const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{expr}) catch {
+        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -699,8 +720,10 @@ fn handleBrowdie(request: *std.http.Server.Request) void {
 }
 
 fn handleDiscover(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, cfg: Config) void {
-    const cdp_base = cfg.cdp_url orelse {
-        resp.sendError(request, 400, "No CDP_URL configured");
+    // Accept cdp_url as query param (overrides env), fall back to config
+    const target = request.head.target;
+    const cdp_base = getQueryParam(target, "cdp_url") orelse cfg.cdp_url orelse {
+        resp.sendError(request, 400, "No CDP_URL configured. Pass ?cdp_url=ws://host:port or set CDP_URL env var.");
         return;
     };
 


### PR DESCRIPTION
## Summary

Fixes 5 bugs that caused unbrowse's browser capture to crash or silently fail on most sites:

1. **`/discover` accepts `cdp_url` query param** — when Kuri is already running (e.g. started by npm global install without `CDP_URL` env var), the client can now pass the Chrome CDP URL dynamically. Previously returned "No CDP_URL configured" and discovered 0 tabs.

2. **HTTP read buffer 8KB → 64KB** — the fetch/XHR interceptor script (~4.3KB raw, ~7.5KB URL-encoded) overflowed the 8KB read buffer, causing Kuri to crash with a segfault on every capture attempt.

3. **`/evaluate` supports POST body + JSON-escapes expressions** — large JS expressions can now be sent via POST body instead of query params. The expression is now properly JSON-escaped before embedding in the CDP `Runtime.evaluate` payload, fixing broken quotes/backslashes.

4. **EventBuffer: don't free on ring buffer overflow** — events buffered during `CdpClient.send()` are arena-allocated by different request threads. Freeing them from the wrong allocator caused `Invalid free` panic when >32 CDP events accumulated.

5. **CdpClient auto-reconnects on WebSocket failure** — previously `connected` stayed `true` after WS died, so all subsequent CDP calls silently failed with `ConnectionRefused`. Now marks disconnected and retries once with a fresh connection.

## Test plan
- [ ] `zig build -Doptimize=ReleaseFast` succeeds
- [ ] `zig build test` passes
- [ ] Evaluate with large JS expression (>4KB) via POST doesn't crash
- [ ] `/discover?cdp_url=ws://127.0.0.1:9222` discovers tabs without env var
- [ ] Multiple sequential captures don't cause `Invalid free` or `ConnectionRefused`

🤖 Generated with [Claude Code](https://claude.com/claude-code)