### PR TITLE
fix: harden managed browser replay

### DIFF
--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -268,6 +268,10 @@ fn cmdUse(arena: std.mem.Allocator, ws_url: []const u8) !void {
 
 /// Launch a visible (non-headless) Chrome with CDP, wait for it, auto-attach.
 /// This is the "human mode" — real browser, real user, agent rides alongside.
+fn getenv(allocator: std.mem.Allocator, name: []const u8) ?[]const u8 {
+    return std.process.getEnvVarOwned(allocator, name) catch null;
+}
+
 fn cmdOpen(arena: std.mem.Allocator, port: u16, url: ?[]const u8) !void {
     // 1. Check if Chrome CDP is already available on this port
     if (tryAttach(arena, port, url)) return;
@@ -283,7 +287,7 @@ fn cmdOpen(arena: std.mem.Allocator, port: u16, url: ?[]const u8) !void {
     const port_flag = try std.fmt.allocPrint(arena, "--remote-debugging-port={d}", .{port});
     try argv.append(arena, port_flag);
     // Chrome requires a data dir for CDP; use default profile so cookies/logins persist
-    const home = std.posix.getenv("HOME") orelse "/tmp";
+    const home = getenv(arena, "HOME") orelse "/tmp";
     const data_dir = try std.fmt.allocPrint(arena, "--user-data-dir={s}/.kuri/chrome-profile", .{home});
     try argv.append(arena, data_dir);
     if (url) |u| try argv.append(arena, u);
@@ -673,7 +677,7 @@ fn cmdScreenshot(arena: std.mem.Allocator, client: *CdpClient, out_path: ?[]cons
 
     // Determine output path — default to ~/.kuri/screenshots/<timestamp>.png
     const path: []const u8 = out_path orelse blk: {
-        const home = std.posix.getenv("HOME") orelse ".";
+        const home = getenv(arena, "HOME") orelse ".";
         const shots_dir = try std.fmt.allocPrint(arena, "{s}/.kuri/screenshots", .{home});
         std.fs.cwd().makePath(shots_dir) catch {};
         const ts = std.time.timestamp();
@@ -1126,7 +1130,7 @@ fn cmdProbe(arena: std.mem.Allocator, client: *CdpClient, tmpl: []const u8, star
 // ── Session I/O ───────────────────────────────────────────────────────────────
 
 fn sessionPath(arena: std.mem.Allocator) ![]const u8 {
-    const home = std.posix.getenv("HOME") orelse ".";
+    const home = getenv(arena, "HOME") orelse ".";
     return std.fmt.allocPrint(arena, "{s}/{s}", .{ home, SESSION_FILE });
 }
 
@@ -1206,7 +1210,7 @@ fn saveSession(arena: std.mem.Allocator, session: *Session) !void {
     const path = try sessionPath(arena);
 
     // Ensure ~/.kuri exists
-    const home = std.posix.getenv("HOME") orelse ".";
+    const home = getenv(arena, "HOME") orelse ".";
     const dir_path = try std.fmt.allocPrint(arena, "{s}/.kuri", .{home});
     std.fs.cwd().makeDir(dir_path) catch |err| switch (err) {
         error.PathAlreadyExists => {},

--- a/src/bridge/config.zig
+++ b/src/bridge/config.zig
@@ -13,33 +13,37 @@ pub const Config = struct {
     headless: bool,
 };
 
+fn getenv(name: []const u8) ?[]const u8 {
+    return std.process.getEnvVarOwned(std.heap.page_allocator, name) catch null;
+}
+
 pub fn load() Config {
     return .{
-        .host = std.posix.getenv("HOST") orelse "127.0.0.1",
+        .host = getenv("HOST") orelse "127.0.0.1",
         .port = parsePort() orelse 8080,
-        .cdp_url = std.posix.getenv("CDP_URL"),
-        .auth_secret = std.posix.getenv("BROWDIE_SECRET"),
-        .state_dir = std.posix.getenv("STATE_DIR") orelse ".browdie",
+        .cdp_url = getenv("CDP_URL"),
+        .auth_secret = getenv("BROWDIE_SECRET"),
+        .state_dir = getenv("STATE_DIR") orelse ".browdie",
         .stale_tab_interval_s = parseU32("STALE_TAB_INTERVAL_S") orelse 30,
         .request_timeout_ms = parseU32("REQUEST_TIMEOUT_MS") orelse 30_000,
         .navigate_timeout_ms = parseU32("NAVIGATE_TIMEOUT_MS") orelse 30_000,
-        .extensions = std.posix.getenv("BROWDIE_EXTENSIONS"),
+        .extensions = getenv("BROWDIE_EXTENSIONS"),
         .headless = parseBool("HEADLESS") orelse true,
     };
 }
 
 fn parsePort() ?u16 {
-    const val = std.posix.getenv("PORT") orelse return null;
+    const val = getenv("PORT") orelse return null;
     return std.fmt.parseInt(u16, val, 10) catch null;
 }
 
 fn parseU32(name: []const u8) ?u32 {
-    const val = std.posix.getenv(name) orelse return null;
+    const val = getenv(name) orelse return null;
     return std.fmt.parseInt(u32, val, 10) catch null;
 }
 
 fn parseBool(name: []const u8) ?bool {
-    const val = std.posix.getenv(name) orelse return null;
+    const val = getenv(name) orelse return null;
     if (std.mem.eql(u8, val, "false") or std.mem.eql(u8, val, "0")) return false;
     return true;
 }

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -665,11 +665,15 @@ fn truncateUrl(url: []const u8, max: usize) []const u8 {
     return url[0..max];
 }
 
+fn getenv(name: []const u8) ?[]const u8 {
+    return std.process.getEnvVarOwned(std.heap.page_allocator, name) catch null;
+}
+
 fn shouldUseColor() bool {
-    if (std.posix.getenv("NO_COLOR")) |v| {
+    if (getenv("NO_COLOR")) |v| {
         if (v.len > 0) return false;
     }
-    if (std.posix.getenv("TERM")) |term| {
+    if (getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
     return std.posix.isatty(std.fs.File.stderr().handle);

--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -30,6 +30,11 @@ pub const EventBuffer = struct {
         }
     }
 
+    pub fn pushCopy(self: *EventBuffer, event: []const u8) !void {
+        const owned = try self.allocator.dupe(u8, event);
+        self.push(owned);
+    }
+
     /// Check if any buffered event matches a method name.
     pub fn hasEvent(self: *EventBuffer, method: []const u8) bool {
         for (self.items[0..self.len]) |item| {
@@ -125,7 +130,9 @@ pub const CdpClient = struct {
             }
 
             // Buffer event instead of discarding
-            self.event_buf.push(response);
+            errdefer allocator.free(response);
+            try self.event_buf.pushCopy(response);
+            allocator.free(response);
         }
 
         return error.ConnectionRefused;
@@ -181,7 +188,11 @@ pub const CdpClient = struct {
                 allocator.free(response);
                 return true;
             }
-            self.event_buf.push(response);
+            self.event_buf.pushCopy(response) catch {
+                allocator.free(response);
+                return false;
+            };
+            allocator.free(response);
         }
         return false;
     }
@@ -246,4 +257,18 @@ test "EventBuffer drain frees all" {
     try std.testing.expectEqual(@as(usize, 2), buf.len);
     buf.drain();
     try std.testing.expectEqual(@as(usize, 0), buf.len);
+}
+
+test "EventBuffer pushCopy owns memory from another allocator" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var buf = EventBuffer.init(std.testing.allocator);
+    defer buf.deinit();
+
+    const arena_event = try arena.dupe(u8, "{\"method\":\"Runtime.consoleAPICalled\"}");
+    try buf.pushCopy(arena_event);
+    try std.testing.expectEqual(@as(usize, 1), buf.len);
+    try std.testing.expect(buf.hasEvent("Runtime.consoleAPICalled"));
 }

--- a/src/chrome/launcher.zig
+++ b/src/chrome/launcher.zig
@@ -106,7 +106,7 @@ pub const Launcher = struct {
             try argv_list.append(self.allocator, "--disable-gpu");
         } else {
             // Visible mode: needs a data dir for CDP to work on macOS
-            const home = std.posix.getenv("HOME") orelse "/tmp";
+            const home = std.process.getEnvVarOwned(self.allocator, "HOME") catch "/tmp";
             const data_dir = try std.fmt.allocPrint(self.allocator, "--user-data-dir={s}/.kuri/chrome-profile", .{home});
             try argv_list.append(self.allocator, data_dir);
         }
@@ -134,10 +134,7 @@ pub const Launcher = struct {
         try child.spawn();
         self.child = child;
 
-        std.log.info("launched Chrome (pid={d}) on CDP port {d}", .{
-            child.id,
-            self.cdp_port,
-        });
+        std.log.info("launched Chrome on CDP port {d}", .{self.cdp_port});
         // Give Chrome a moment to start
         std.Thread.sleep(500 * std.time.ns_per_ms);
     }

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -197,12 +197,16 @@ fn elapsed(start: i128) u64 {
     return if (diff > 0) @as(u64, @intCast(diff)) / std.time.ns_per_ms else 0;
 }
 
+fn getenv(name: []const u8) ?[]const u8 {
+    return std.process.getEnvVarOwned(std.heap.page_allocator, name) catch null;
+}
+
 fn shouldUseColor(force_no_color: bool) bool {
     if (force_no_color) return false;
-    if (std.posix.getenv("NO_COLOR")) |v| {
+    if (getenv("NO_COLOR")) |v| {
         if (v.len > 0) return false;
     }
-    if (std.posix.getenv("TERM")) |term| {
+    if (getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
     return std.posix.isatty(std.fs.File.stderr().handle);

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,7 @@ pub fn main() !void {
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
-    const cfg = config.load();
+    var cfg = config.load();
 
     std.log.info("kuri v0.1.0", .{});
     std.log.info("listening on {s}:{d}", .{ cfg.host, cfg.port });
@@ -28,6 +28,9 @@ pub fn main() !void {
         std.log.warn("Chrome launch failed: {s}, continuing without Chrome", .{@errorName(err)});
         break :blk @as(u16, 9222);
     };
+    ensureRuntimeCdpUrl(gpa, &cfg, cdp_port) catch |err| {
+        std.log.warn("failed to derive runtime CDP URL: {s}", .{@errorName(err)});
+    };
     std.log.info("CDP port: {d}", .{cdp_port});
 
     // Initialize bridge (central state)
@@ -36,6 +39,46 @@ pub fn main() !void {
 
     // Start HTTP server
     try server.run(gpa, &bridge, cfg);
+}
+
+fn ensureRuntimeCdpUrl(allocator: std.mem.Allocator, cfg: *config.Config, cdp_port: u16) !void {
+    if (cfg.cdp_url != null) return;
+    cfg.cdp_url = try std.fmt.allocPrint(allocator, "ws://127.0.0.1:{d}", .{cdp_port});
+}
+
+test "ensureRuntimeCdpUrl backfills managed CDP URL" {
+    var cfg = config.Config{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .cdp_url = null,
+        .auth_secret = null,
+        .state_dir = ".browdie",
+        .stale_tab_interval_s = 30,
+        .request_timeout_ms = 30_000,
+        .navigate_timeout_ms = 30_000,
+        .extensions = null,
+        .headless = true,
+    };
+    try ensureRuntimeCdpUrl(std.testing.allocator, &cfg, 9333);
+    defer std.testing.allocator.free(cfg.cdp_url.?);
+    try std.testing.expectEqualStrings("ws://127.0.0.1:9333", cfg.cdp_url.?);
+}
+
+test "ensureRuntimeCdpUrl preserves explicit CDP URL" {
+    var cfg = config.Config{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .cdp_url = "ws://127.0.0.1:9223",
+        .auth_secret = null,
+        .state_dir = ".browdie",
+        .stale_tab_interval_s = 30,
+        .request_timeout_ms = 30_000,
+        .navigate_timeout_ms = 30_000,
+        .extensions = null,
+        .headless = true,
+    };
+    try ensureRuntimeCdpUrl(std.testing.allocator, &cfg, 9333);
+    try std.testing.expectEqualStrings("ws://127.0.0.1:9223", cfg.cdp_url.?);
 }
 
 test {

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -248,6 +248,11 @@ fn getQueryParam(target: []const u8, key: []const u8) ?[]const u8 {
     return null;
 }
 
+fn getDecodedQueryParam(arena: std.mem.Allocator, target: []const u8, key: []const u8) ?[]const u8 {
+    const raw = getQueryParam(target, key) orelse return null;
+    return urlDecodeAlloc(arena, raw);
+}
+
 fn urlDecodeAlloc(arena: std.mem.Allocator, input: []const u8) ?[]const u8 {
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(arena);
@@ -326,10 +331,11 @@ fn handleTabs(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
 
 fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, cfg: Config) void {
     const target = request.head.target;
-    const url = getQueryParam(target, "url") orelse {
+    const raw_url = getQueryParam(target, "url") orelse {
         resp.sendError(request, 400, "Missing url parameter");
         return;
     };
+    const url = getDecodedQueryParam(arena, target, "url") orelse raw_url;
     const tab_id = getQueryParam(target, "tab_id");
 
     // If we have a tab, use its CDP client
@@ -695,9 +701,15 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         resp.sendError(request, 400, "Missing tab_id parameter");
         return;
     };
-    const expr = getQueryParam(target, "expression") orelse {
-        resp.sendError(request, 400, "Missing expression parameter");
-        return;
+    const expr = blk: {
+        if (readRequestBody(request, arena)) |body| {
+            if (body.len > 0) break :blk body;
+        }
+        const raw_expr = getQueryParam(target, "expression") orelse {
+            resp.sendError(request, 400, "Missing expression parameter");
+            return;
+        };
+        break :blk getDecodedQueryParam(arena, target, "expression") orelse raw_expr;
     };
 
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -705,8 +717,12 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         return;
     };
 
+    const escaped_expr = jsonEscapeAlloc(arena, expr) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
     const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{expr}) catch {
+        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -1010,7 +1026,7 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
             while (flush_read < 200) : (flush_read += 1) {
                 const msg = ws.receiveMessageAlloc(arena, 2 * 1024 * 1024) catch break;
                 rec.handleCdpEvent(msg);
-                client.event_buf.push(msg);
+                client.event_buf.pushCopy(msg) catch break;
             }
             std.log.info("HAR: read {d} pending WS messages", .{flush_read});
 
@@ -1219,9 +1235,28 @@ fn handleCookies(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
     if (name != null and value != null) {
         // Set cookie
-        const domain = getQueryParam(target, "domain") orelse "localhost";
+        const decoded_name = getDecodedQueryParam(arena, target, "name") orelse name.?;
+        const decoded_value = getDecodedQueryParam(arena, target, "value") orelse value.?;
+        const domain = getDecodedQueryParam(arena, target, "domain") orelse "localhost";
+        const path = getDecodedQueryParam(arena, target, "path") orelse "/";
+        const escaped_name = jsonEscapeAlloc(arena, decoded_name) orelse {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const escaped_value = jsonEscapeAlloc(arena, decoded_value) orelse {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const escaped_domain = jsonEscapeAlloc(arena, domain) orelse {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const escaped_path = jsonEscapeAlloc(arena, path) orelse {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
         const params = std.fmt.allocPrint(arena,
-            "{{\"name\":\"{s}\",\"value\":\"{s}\",\"domain\":\"{s}\",\"path\":\"/\"}}", .{ name.?, value.?, domain }) catch {
+            "{{\"name\":\"{s}\",\"value\":\"{s}\",\"domain\":\"{s}\",\"path\":\"{s}\"}}", .{ escaped_name, escaped_value, escaped_domain, escaped_path }) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -1660,6 +1695,25 @@ test "resolveDiscoverCdpBase prefers decoded query override" {
 
     const resolved = resolveDiscoverCdpBase("/discover?cdp_url=ws%3A%2F%2F127.0.0.1%3A9333", arena, cfg).?;
     try std.testing.expectEqualStrings("ws://127.0.0.1:9333", resolved);
+}
+
+test "getDecodedQueryParam decodes encoded cookie payload" {
+    const decoded_name = getDecodedQueryParam(std.testing.allocator, "/cookies?tab_id=t1&name=li_at&value=AQEDAS%2Fwith%3Ddelims%26more&domain=.linkedin.com&path=%2F", "name").?;
+    defer std.testing.allocator.free(decoded_name);
+    const decoded_value = getDecodedQueryParam(std.testing.allocator, "/cookies?tab_id=t1&name=li_at&value=AQEDAS%2Fwith%3Ddelims%26more&domain=.linkedin.com&path=%2F", "value").?;
+    defer std.testing.allocator.free(decoded_value);
+    const decoded_path = getDecodedQueryParam(std.testing.allocator, "/cookies?tab_id=t1&name=li_at&value=AQEDAS%2Fwith%3Ddelims%26more&domain=.linkedin.com&path=%2F", "path").?;
+    defer std.testing.allocator.free(decoded_path);
+
+    try std.testing.expectEqualStrings("li_at", decoded_name);
+    try std.testing.expectEqualStrings("AQEDAS/with=delims&more", decoded_value);
+    try std.testing.expectEqualStrings("/", decoded_path);
+}
+
+test "getDecodedQueryParam decodes encoded navigate URL" {
+    const decoded = getDecodedQueryParam(std.testing.allocator, "/navigate?tab_id=t1&url=https%3A%2F%2Fwww.linkedin.com%2Fsearch%2Fresults%2Fpeople%2F%3Fkeywords%3Dopenai", "url").?;
+    defer std.testing.allocator.free(decoded);
+    try std.testing.expectEqualStrings("https://www.linkedin.com/search/results/people/?keywords=openai", decoded);
 }
 
 test "resolveDiscoverCdpBase falls back to config" {

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -248,6 +248,39 @@ fn getQueryParam(target: []const u8, key: []const u8) ?[]const u8 {
     return null;
 }
 
+fn urlDecodeAlloc(arena: std.mem.Allocator, input: []const u8) ?[]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(arena);
+
+    var i: usize = 0;
+    while (i < input.len) : (i += 1) {
+        const ch = input[i];
+        if (ch == '%' and i + 2 < input.len) {
+            const hi = std.fmt.charToDigit(input[i + 1], 16) catch {
+                out.append(arena, ch) catch return null;
+                continue;
+            };
+            const lo = std.fmt.charToDigit(input[i + 2], 16) catch {
+                out.append(arena, ch) catch return null;
+                continue;
+            };
+            out.append(arena, hi * 16 + lo) catch return null;
+            i += 2;
+            continue;
+        }
+        out.append(arena, if (ch == '+') ' ' else ch) catch return null;
+    }
+
+    return out.toOwnedSlice(arena) catch null;
+}
+
+fn resolveDiscoverCdpBase(target: []const u8, arena: std.mem.Allocator, cfg: Config) ?[]const u8 {
+    if (getQueryParam(target, "cdp_url")) |raw| {
+        return urlDecodeAlloc(arena, raw) orelse raw;
+    }
+    return cfg.cdp_url;
+}
+
 fn readRequestBody(request: *std.http.Server.Request, arena: std.mem.Allocator) ?[]const u8 {
     if (!request.head.method.requestHasBody()) return null;
     if (request.head.expect != null) return null;
@@ -699,7 +732,7 @@ fn handleBrowdie(request: *std.http.Server.Request) void {
 }
 
 fn handleDiscover(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, cfg: Config) void {
-    const cdp_base = cfg.cdp_url orelse {
+    const cdp_base = resolveDiscoverCdpBase(request.head.target, arena, cfg) orelse {
         resp.sendError(request, 400, "No CDP_URL configured");
         return;
     };
@@ -1605,6 +1638,46 @@ test "getQueryParam" {
     try std.testing.expectEqualStrings("123", getQueryParam("/test?a=1&tab_id=123&b=2", "tab_id").?);
     try std.testing.expect(getQueryParam("/test?foo=bar", "baz") == null);
     try std.testing.expect(getQueryParam("/test", "foo") == null);
+}
+
+test "resolveDiscoverCdpBase prefers decoded query override" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const cfg = Config{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .cdp_url = "ws://127.0.0.1:9222",
+        .auth_secret = null,
+        .state_dir = ".browdie",
+        .stale_tab_interval_s = 30,
+        .request_timeout_ms = 30_000,
+        .navigate_timeout_ms = 30_000,
+        .extensions = null,
+        .headless = true,
+    };
+
+    const resolved = resolveDiscoverCdpBase("/discover?cdp_url=ws%3A%2F%2F127.0.0.1%3A9333", arena, cfg).?;
+    try std.testing.expectEqualStrings("ws://127.0.0.1:9333", resolved);
+}
+
+test "resolveDiscoverCdpBase falls back to config" {
+    const cfg = Config{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .cdp_url = "ws://127.0.0.1:9222",
+        .auth_secret = null,
+        .state_dir = ".browdie",
+        .stale_tab_interval_s = 30,
+        .request_timeout_ms = 30_000,
+        .navigate_timeout_ms = 30_000,
+        .extensions = null,
+        .headless = true,
+    };
+
+    const resolved = resolveDiscoverCdpBase("/discover", std.testing.allocator, cfg).?;
+    try std.testing.expectEqualStrings("ws://127.0.0.1:9222", resolved);
 }
 
 test "emulate query param parsing" {

--- a/src/storage/r2.zig
+++ b/src/storage/r2.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+fn getenv(name: []const u8) ?[]const u8 {
+    return std.process.getEnvVarOwned(std.heap.page_allocator, name) catch null;
+}
+
 pub const R2Config = struct {
     endpoint_url: []const u8,
     access_key: []const u8,
@@ -8,10 +12,10 @@ pub const R2Config = struct {
 };
 
 pub fn loadConfig() ?R2Config {
-    const endpoint = std.posix.getenv("R2_ENDPOINT_URL") orelse return null;
-    const access_key = std.posix.getenv("R2_ACCESS_KEY") orelse return null;
-    const secret_key = std.posix.getenv("R2_SECRET_KEY") orelse return null;
-    const bucket = std.posix.getenv("R2_BUCKET_NAME") orelse return null;
+    const endpoint = getenv("R2_ENDPOINT_URL") orelse return null;
+    const access_key = getenv("R2_ACCESS_KEY") orelse return null;
+    const secret_key = getenv("R2_SECRET_KEY") orelse return null;
+    const bucket = getenv("R2_BUCKET_NAME") orelse return null;
 
     return .{
         .endpoint_url = endpoint,


### PR DESCRIPTION
## Summary
- backfill `cfg.cdp_url` in managed mode after Chrome launch so `/discover` can register managed tabs
- let `/discover`, `/navigate`, `/cookies`, and `/evaluate` consume decoded request params / POST bodies, which matches encoded callers from Unbrowse
- copy buffered CDP / HAR events into Kuri-owned memory so allocator lifetimes stay valid under browser replay
- add regression coverage for encoded query decoding and event-buffer ownership

## What broke downstream
These bugs showed up in packaged Unbrowse LinkedIn replay:
- `No tabs available and failed to create one`
- `CDP command failed` during origin pre-nav / script injection
- `Invalid free` panics in buffered CDP event handling / HAR stop

## Verification
- `zig build`
- standalone managed-mode flow now passes:
  - `GET /health`
  - `PUT http://127.0.0.1:<cdp>/json/new?about:blank`
  - `GET /discover`
  - `GET /tabs`
  - `GET /evaluate?tab_id=<id>&expression=1`
- direct encoded replay steps now pass:
  - encoded `/navigate`
  - encoded `/cookies`
  - GET and POST `/evaluate`
- downstream packaged Unbrowse LinkedIn execute now returns `status_code: 200` with extracted people rows

## Notes
- this updates the earlier managed-discover PR with the later replay / allocator fixes too
- `zig test src/main.zig` still reports the pre-existing leak in `snapshot/a11y.zig`
