### PR TITLE
Add Dockerized benchmark runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ zig-out/
 *.swp
 .browdie/
 tweet.md
+.benchmarks/
+benchmarks/results/*
+!benchmarks/results/README.md
+!benchmarks/results/20260327-111742-https_vercel.com/
+!benchmarks/results/20260327-111742-https_vercel.com/**
+!benchmarks/results/20260327-111817-https_www.google.com_travel_flights_q=Flights%20to%20TPE%20from%/
+!benchmarks/results/20260327-111817-https_www.google.com_travel_flights_q=Flights%20to%20TPE%20from%/**

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:bookworm-slim
+
+ARG ZIG_VERSION=0.15.2
+ARG BUN_VERSION=1.2.23
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/zig:${PATH}"
+ENV LIGHTPANDA_BIN="/usr/local/bin/lightpanda"
+ENV CHROME_BIN="/usr/bin/chromium"
+ENV RESULTS_ROOT="/workspace/.benchmarks/results"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    chromium \
+    curl \
+    git \
+    python3 \
+    python3-pip \
+    unzip \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN arch="$(dpkg --print-architecture)" \
+  && case "$arch" in \
+      amd64) zig_arch="x86_64"; lightpanda_arch="x86_64" ;; \
+      arm64) zig_arch="aarch64"; lightpanda_arch="aarch64" ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac \
+  && curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz \
+  && mkdir -p /opt \
+  && tar -xf /tmp/zig.tar.xz -C /opt \
+  && mv "/opt/zig-${zig_arch}-linux-${ZIG_VERSION}" /opt/zig \
+  && curl -L -o /usr/local/bin/lightpanda "https://github.com/lightpanda-io/browser/releases/download/nightly/lightpanda-${lightpanda_arch}-linux" \
+  && chmod +x /usr/local/bin/lightpanda \
+  && rm /tmp/zig.tar.xz
+
+RUN curl -fsSL "https://bun.sh/install" | bash -s -- "bun-v${BUN_VERSION}" \
+  && ln -sf /root/.bun/bin/bun /usr/local/bin/bun \
+  && ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
+
+RUN bun install -g agent-browser
+RUN python3 -m pip install --no-cache-dir --break-system-packages tiktoken
+
+WORKDIR /workspace
+
+COPY benchmarks/docker-entrypoint.sh /usr/local/bin/kuri-bench-entrypoint
+RUN chmod +x /usr/local/bin/kuri-bench-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/kuri-bench-entrypoint"]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,6 +35,12 @@ What it does:
   - `summary.json`
   - raw tool outputs under `raw/`
 
+By default, ad hoc runs now write to:
+
+- `.benchmarks/results/...`
+
+That keeps local benchmark churn out of git. The checked-in `benchmarks/results/` folder is for curated reference runs only.
+
 Each summary now reports two workflow views:
 
 - `Raw captured output`: the literal bytes/tokens each CLI emitted for `go→snap-i→click→snap-i→eval`
@@ -51,12 +57,54 @@ That second view intentionally strips tool-specific action acknowledgement noise
   - `agent-browser` on `$PATH`
   - `lightpanda` at `/tmp/lightpanda` or `$LIGHTPANDA_BIN`
 
+## Docker
+
+For constrained or repeatable environments, use:
+
+```bash
+chmod +x ./benchmarks/docker-run.sh
+./benchmarks/docker-run.sh https://vercel.com
+PROFILE=small ./benchmarks/docker-run.sh https://vercel.com
+PROFILE=large ./benchmarks/docker-run.sh "https://www.google.com/travel/flights?q=Flights%20to%20TPE%20from%20SIN%20on%202026-03-23&curr=SGD"
+```
+
+This builds [`Dockerfile`](/Users/rachpradhan/kuri/benchmarks/Dockerfile), installs:
+
+- Zig
+- Chromium
+- `agent-browser`
+- `tiktoken`
+- `lightpanda`
+
+and runs the benchmark against a headless Chromium CDP server inside the container.
+The entrypoint always rebuilds `kuri-agent` inside Linux so the container never tries to reuse a host macOS binary from `zig-out/`.
+
+### Resource presets
+
+`docker-run.sh` supports:
+
+- `PROFILE=small` → `1 CPU`, `2 GB RAM`, `1 GB /dev/shm`
+- `PROFILE=medium` → `2 CPU`, `4 GB RAM`, `2 GB /dev/shm`
+- `PROFILE=large` → `4 CPU`, `8 GB RAM`, `4 GB /dev/shm`
+
+You can also override them directly:
+
+```bash
+CPUS=1.5 MEMORY=3g SHM_SIZE=1g ./benchmarks/docker-run.sh https://vercel.com
+```
+
 ## Notes
 
 - `agent-browser` is measured against a shared Chrome CDP session on `9222`.
 - `lightpanda` is measured via standalone `fetch --dump ...`, so it is not using Chrome.
 - That means the `lightpanda` leg is best read as "standalone browser output shape and token cost", not "same underlying engine state as the Chrome-based tools".
 - On highly interactive pages, the normalized page-state section is the more defensible apples-to-apples comparison than raw CLI output totals.
+
+## Runner Size
+
+Inside Docker, yes: you can control CPU, memory, and shared-memory size with the presets above or custom env vars.
+
+For hosted CI runner size, no: the container cannot upscale the host by itself. You pick the machine size outside the container, at the CI/job level.
 
 ## Latest Run
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,17 +1,7 @@
 # Benchmarks
 
-This folder holds reproducible browser-output comparisons between:
-
-- `kuri-agent`
-- `agent-browser`
-- `lightpanda`
-
-The goal is not "smallest output wins" in isolation. The useful comparison is:
-
-- same page
-- same date
-- same tokenizer
-- auditable raw outputs
+Reproducible browser-output comparisons for `kuri-agent`, `agent-browser`, and `lightpanda`.
+The useful comparison is same page, same tokenizer, and saved raw outputs.
 
 ## Runner
 
@@ -23,39 +13,21 @@ Use [`run_token_matrix.sh`](/Users/rachpradhan/kuri/benchmarks/run_token_matrix.
 ./benchmarks/run_token_matrix.sh "https://www.google.com/travel/flights?q=Flights%20to%20TPE%20from%20SIN"
 ```
 
-What it does:
-
-- ensures Chrome is available on CDP port `9222` via `kuri-agent`
-- captures `kuri-agent` outputs
-- captures `agent-browser` outputs if installed
-- captures `lightpanda` outputs if `LIGHTPANDA_BIN` or `/tmp/lightpanda` exists
-- tokenizes all outputs with `cl100k_base`
-- writes:
-  - `summary.md`
-  - `summary.json`
-  - raw tool outputs under `raw/`
-
-By default, ad hoc runs now write to:
-
-- `.benchmarks/results/...`
-
-That keeps local benchmark churn out of git. The checked-in `benchmarks/results/` folder is for curated reference runs only.
+It ensures Chrome is available on CDP `9222`, captures tool outputs, tokenizes them with `cl100k_base`, and writes `summary.md`, `summary.json`, and `raw/`.
+Ad hoc runs write to `.benchmarks/results/...`; checked-in `benchmarks/results/` is for curated reference runs only.
 
 Each summary now reports two workflow views:
 
 - `Raw captured output`: the literal bytes/tokens each CLI emitted for `go→snap-i→click→snap-i→eval`
 - `Normalized page-state output`: only the state payloads an agent reads back, `snap-i + snap-i + eval`
 
-That second view intentionally strips tool-specific action acknowledgement noise from the comparison.
+The normalized view strips tool-specific action acknowledgement noise.
 
 ## Requirements
 
-- built `kuri-agent` at `./zig-out/bin/kuri-agent`
-- `/usr/bin/python3`
-- `tiktoken` installed for that interpreter
-- optional:
-  - `agent-browser` on `$PATH`
-  - `lightpanda` at `/tmp/lightpanda` or `$LIGHTPANDA_BIN`
+- `./zig-out/bin/kuri-agent`
+- `/usr/bin/python3` with `tiktoken`
+- optional: `agent-browser` on `$PATH`, `lightpanda` at `/tmp/lightpanda` or `$LIGHTPANDA_BIN`
 
 ## Docker
 
@@ -68,20 +40,10 @@ PROFILE=small ./benchmarks/docker-run.sh https://vercel.com
 PROFILE=large ./benchmarks/docker-run.sh "https://www.google.com/travel/flights?q=Flights%20to%20TPE%20from%20SIN%20on%202026-03-23&curr=SGD"
 ```
 
-This builds [`Dockerfile`](/Users/rachpradhan/kuri/benchmarks/Dockerfile), installs:
-
-- Zig
-- Chromium
-- `agent-browser`
-- `tiktoken`
-- `lightpanda`
-
-and runs the benchmark against a headless Chromium CDP server inside the container.
-The entrypoint always rebuilds `kuri-agent` inside Linux so the container never tries to reuse a host macOS binary from `zig-out/`.
+This builds [`Dockerfile`](/Users/rachpradhan/kuri/benchmarks/Dockerfile), installs Zig, Chromium, `agent-browser`, `tiktoken`, and `lightpanda`, then runs the benchmark against headless Chromium inside the container.
+The entrypoint always rebuilds `kuri-agent` inside Linux so it never reuses a host macOS binary from `zig-out/`.
 
 ### Resource presets
-
-`docker-run.sh` supports:
 
 - `PROFILE=small` → `1 CPU`, `2 GB RAM`, `1 GB /dev/shm`
 - `PROFILE=medium` → `2 CPU`, `4 GB RAM`, `2 GB /dev/shm`
@@ -95,16 +57,14 @@ CPUS=1.5 MEMORY=3g SHM_SIZE=1g ./benchmarks/docker-run.sh https://vercel.com
 
 ## Notes
 
-- `agent-browser` is measured against a shared Chrome CDP session on `9222`.
+- `agent-browser` uses the shared Chrome CDP session on `9222`.
 - `lightpanda` is measured via standalone `fetch --dump ...`, so it is not using Chrome.
-- That means the `lightpanda` leg is best read as "standalone browser output shape and token cost", not "same underlying engine state as the Chrome-based tools".
-- On highly interactive pages, the normalized page-state section is the more defensible apples-to-apples comparison than raw CLI output totals.
+- On interactive pages, the normalized page-state section is the better apples-to-apples comparison.
 
 ## Runner Size
 
-Inside Docker, yes: you can control CPU, memory, and shared-memory size with the presets above or custom env vars.
-
-For hosted CI runner size, no: the container cannot upscale the host by itself. You pick the machine size outside the container, at the CI/job level.
+Inside Docker, yes: use the presets above or override `CPUS`, `MEMORY`, and `SHM_SIZE`.
+For hosted CI runner size, no: that has to be chosen outside the container.
 
 ## Latest Run
 

--- a/benchmarks/docker-entrypoint.sh
+++ b/benchmarks/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace
+
+export CHROME_BIN="${CHROME_BIN:-/usr/bin/chromium}"
+export LIGHTPANDA_BIN="${LIGHTPANDA_BIN:-/usr/local/bin/lightpanda}"
+export RESULTS_ROOT="${RESULTS_ROOT:-/workspace/.benchmarks/results}"
+mkdir -p "$RESULTS_ROOT"
+
+# Always rebuild in-container so Linux doesn't try to reuse a host Mach-O binary.
+zig build -Doptimize=ReleaseFast
+
+if ! curl -fsS http://127.0.0.1:9222/json >/dev/null 2>&1; then
+  "$CHROME_BIN" \
+    --headless=new \
+    --disable-gpu \
+    --disable-dev-shm-usage \
+    --no-sandbox \
+    --remote-debugging-address=127.0.0.1 \
+    --remote-debugging-port=9222 \
+    about:blank >/tmp/chromium-bench.log 2>&1 &
+
+  for _ in $(seq 1 50); do
+    if curl -fsS http://127.0.0.1:9222/json >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.2
+  done
+fi
+
+exec bash ./benchmarks/run_token_matrix.sh "$@"

--- a/benchmarks/docker-run.sh
+++ b/benchmarks/docker-run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-kuri-bench:local}"
+PROFILE="${PROFILE:-medium}"
+URL="${1:-https://vercel.com}"
+
+case "$PROFILE" in
+  small)
+    CPUS="${CPUS:-1}"
+    MEMORY="${MEMORY:-2g}"
+    SHM_SIZE="${SHM_SIZE:-1g}"
+    ;;
+  medium)
+    CPUS="${CPUS:-2}"
+    MEMORY="${MEMORY:-4g}"
+    SHM_SIZE="${SHM_SIZE:-2g}"
+    ;;
+  large)
+    CPUS="${CPUS:-4}"
+    MEMORY="${MEMORY:-8g}"
+    SHM_SIZE="${SHM_SIZE:-4g}"
+    ;;
+  *)
+    echo "unknown PROFILE=$PROFILE (expected: small, medium, large)" >&2
+    exit 1
+    ;;
+esac
+
+docker build -f "$ROOT_DIR/benchmarks/Dockerfile" -t "$IMAGE_TAG" "$ROOT_DIR"
+
+docker run --rm \
+  --cpus="$CPUS" \
+  --memory="$MEMORY" \
+  --shm-size="$SHM_SIZE" \
+  -e RESULTS_ROOT=/workspace/.benchmarks/results \
+  -v "$ROOT_DIR:/workspace" \
+  "$IMAGE_TAG" \
+  "$URL"

--- a/benchmarks/run_token_matrix.sh
+++ b/benchmarks/run_token_matrix.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BENCH_DIR="$ROOT_DIR/benchmarks"
-RESULTS_ROOT="$BENCH_DIR/results"
+RESULTS_ROOT="${RESULTS_ROOT:-$ROOT_DIR/.benchmarks/results}"
 mkdir -p "$RESULTS_ROOT"
 
 URL="${1:-https://example.com}"


### PR DESCRIPTION
## Summary
- dockerize the benchmark harness for constrained Linux runs
- add small, medium, and large CPU/RAM/shm presets
- keep ad hoc benchmark output out of git
- rebuild `kuri-agent` inside Linux so the container never reuses a host macOS binary

## Validation
- `bash -n benchmarks/run_token_matrix.sh benchmarks/docker-entrypoint.sh benchmarks/docker-run.sh`
- `PROFILE=large ./benchmarks/docker-run.sh https://vercel.com`
  - `.benchmarks/results/20260327-033220-https_vercel.com`
