### PR TITLE
fix: HAR recorder returns 0 entries — parse nested CDP JSON (#118)

### DIFF
--- a/src/cdp/har.zig
+++ b/src/cdp/har.zig
@@ -162,12 +162,17 @@ pub const HarRecorder = struct {
     /// Handle a raw CDP event JSON string.
     /// Looks for Network.requestWillBeSent and Network.responseReceived events.
     pub fn handleCdpEvent(self: *HarRecorder, event_json: []const u8) void {
-        if (!self.recording) return;
+        // NOTE: allow events even when recording==false — the stop() flow
+        // flushes buffered events after setting recording=false.
 
         if (std.mem.indexOf(u8, event_json, "\"Network.requestWillBeSent\"") != null) {
+            // CDP shape: {"method":"Network.requestWillBeSent","params":{"requestId":"X","request":{"url":"...","method":"GET",...},...}}
             const request_id = extractField(event_json, "requestId") orelse return;
-            const url = extractField(event_json, "url") orelse return;
-            const method = extractField(event_json, "method") orelse "GET";
+            // url and method are inside the nested "request" object — search after "\"request\":{" to skip the top-level "method" field
+            const request_obj_pos = std.mem.indexOf(u8, event_json, "\"request\":{") orelse return;
+            const request_obj = event_json[request_obj_pos..];
+            const url = extractField(request_obj, "url") orelse return;
+            const method = extractField(request_obj, "method") orelse "GET";
 
             const owned_id = self.allocator.dupe(u8, request_id) catch return;
             const owned_url = self.allocator.dupe(u8, url) catch {
@@ -199,13 +204,15 @@ pub const HarRecorder = struct {
                 self.allocator.free(pending.method);
             }
 
-            // Extract status and mimeType from the response object
-            const status_str = extractField(event_json, "status");
+            // Extract status and mimeType from the nested "response" object
+            const response_obj_pos = std.mem.indexOf(u8, event_json, "\"response\":{");
+            const search_json = if (response_obj_pos) |pos| event_json[pos..] else event_json;
+            const status_str = extractField(search_json, "status");
             const status: u16 = if (status_str) |s|
                 std.fmt.parseInt(u16, s, 10) catch 200
             else
                 200;
-            const mime = extractField(event_json, "mimeType") orelse "application/octet-stream";
+            const mime = extractField(search_json, "mimeType") orelse "application/octet-stream";
             const status_text = if (status >= 200 and status < 300) "OK" else if (status >= 300 and status < 400) "Redirect" else if (status >= 400) "Error" else "Unknown";
 
             self.addEntry(.{
@@ -335,20 +342,26 @@ test "HarRecorder handleCdpEvent processes request and response" {
     var rec = HarRecorder.init(std.testing.allocator);
     defer rec.deinit();
 
-    // Not recording — should be ignored
-    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"1\",\"url\":\"https://example.com\",\"method\":\"GET\"}}");
-    try std.testing.expectEqual(@as(usize, 0), rec.entryCount());
+    // Events are processed even when recording==false (needed for stop() flush flow)
+    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"req1\",\"request\":{\"url\":\"https://example.com/page\",\"method\":\"GET\"}}}");
+    try std.testing.expectEqual(@as(usize, 1), rec.pending_requests.count());
 
     // Start recording
     rec.recording = true;
 
-    // Send requestWillBeSent
-    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"req1\",\"url\":\"https://example.com/page\",\"method\":\"GET\"}}");
+    // Send requestWillBeSent with realistic nested CDP shape
+    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"req2\",\"request\":{\"url\":\"https://example.com/api\",\"method\":\"POST\"}}}");
     try std.testing.expectEqual(@as(usize, 0), rec.entryCount());
+    try std.testing.expectEqual(@as(usize, 2), rec.pending_requests.count());
 
-    // Send responseReceived for the same requestId
-    rec.handleCdpEvent("{\"method\":\"Network.responseReceived\",\"params\":{\"requestId\":\"req1\",\"response\":{\"status\":200}}}");
+    // Send responseReceived with nested "response" object
+    rec.handleCdpEvent("{\"method\":\"Network.responseReceived\",\"params\":{\"requestId\":\"req2\",\"response\":{\"status\":200,\"mimeType\":\"application/json\"}}}");
     try std.testing.expectEqual(@as(usize, 1), rec.entryCount());
+    try std.testing.expectEqual(@as(usize, 1), rec.pending_requests.count());
+
+    // Complete the first request too
+    rec.handleCdpEvent("{\"method\":\"Network.responseReceived\",\"params\":{\"requestId\":\"req1\",\"response\":{\"status\":304,\"mimeType\":\"text/html\"}}}");
+    try std.testing.expectEqual(@as(usize, 2), rec.entryCount());
     try std.testing.expectEqual(@as(usize, 0), rec.pending_requests.count());
 }
 
@@ -366,7 +379,7 @@ test "HarRecorder start clears stale pending requests before enabling network" {
     });
 
     rec.recording = true;
-    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"req1\",\"url\":\"https://example.com/page\",\"method\":\"GET\"}}");
+    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"req1\",\"request\":{\"url\":\"https://example.com/page\",\"method\":\"GET\"}}}");
     try std.testing.expectEqual(@as(usize, 2), rec.pending_requests.count());
 
     var client = CdpClient.init(std.testing.allocator, "ws://127.0.0.1:1/devtools/browser/test");
@@ -390,4 +403,23 @@ test "HarRecorder extractField helper" {
 
     const missing = HarRecorder.extractField(json, "nonexistent");
     try std.testing.expect(missing == null);
+}
+
+test "HarRecorder parses nested CDP request fields" {
+    var rec = HarRecorder.init(std.testing.allocator);
+    defer rec.deinit();
+    rec.recording = true;
+
+    // Real CDP shape: method/url are inside params.request, not at top level
+    rec.handleCdpEvent("{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"42.1\",\"request\":{\"url\":\"https://cdn.example.com/style.css\",\"method\":\"GET\",\"headers\":{}}}}");
+    try std.testing.expectEqual(@as(usize, 1), rec.pending_requests.count());
+
+    rec.handleCdpEvent("{\"method\":\"Network.responseReceived\",\"params\":{\"requestId\":\"42.1\",\"response\":{\"status\":200,\"mimeType\":\"text/css\",\"headers\":{}}}}");
+    try std.testing.expectEqual(@as(usize, 1), rec.entryCount());
+
+    const entry = rec.entries.items[0];
+    try std.testing.expectEqualStrings("https://cdn.example.com/style.css", entry.url);
+    try std.testing.expectEqualStrings("GET", entry.method);
+    try std.testing.expectEqual(@as(u16, 200), entry.status);
+    try std.testing.expectEqualStrings("text/css", entry.mime_type);
 }

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -1153,8 +1153,6 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
     // Flush buffered CDP events and disconnect HAR recorder from CDP client.
     if (bridge.getCdpClient(tab_id)) |client| {
-        // Disconnect HAR recorder from real-time event feeding
-        // HAR recorder disconnect handled by stop()
         // First: read all pending WebSocket messages with a short timeout.
         // Network events arrive asynchronously and queue on the WebSocket.
         if (client.ws) |*ws| {
@@ -1176,7 +1174,9 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         // Second: flush any events already in the buffer from prior send() calls
         flushEventsToHar(client, rec);
 
-        // Third: stop recording (sends Network.disable, which may read more events)
+        // Third: stop recording (sends Network.disable).
+        // NOTE: handleCdpEvent no longer checks self.recording, so events
+        // flushed after stop() are still processed correctly.
         const har_json = rec.stop(client) catch {
             resp.sendError(request, 500, "Failed to generate HAR");
             return;


### PR DESCRIPTION
## Summary

- **extractField matched wrong fields** in nested CDP JSON — the top-level `"method"` (e.g. `Network.requestWillBeSent`) was matched instead of the HTTP method inside `params.request`. Now searches within the nested `"request":{...}` and `"response":{...}` objects specifically.
- **Race condition** — `rec.stop()` set `recording=false` before the second `flushEventsToHar()`, causing those events to hit `if (!self.recording) return`. Removed the recording guard from `handleCdpEvent` since the stop-flush flow needs to process events after recording is disabled.

Fixes #118

## Test plan

- [x] `zig build test` — all tests pass
- [x] New test `HarRecorder parses nested CDP request fields` validates url, method, status, mimeType extraction from realistic CDP shapes
- [x] Updated `handleCdpEvent` test verifies events are processed even when `recording==false`
- [ ] Manual: `/har/start` → navigate → `/har/stop` should return entries > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)