### PR TITLE
fix: preserve HAR recorder state across requests

### DIFF
--- a/src/bridge/bridge.zig
+++ b/src/bridge/bridge.zig
@@ -69,17 +69,19 @@ pub const Bridge = struct {
         }
         self.debug_script_ids.deinit();
 
-        var har_it = self.har_recorders.valueIterator();
-        while (har_it.next()) |rec| {
-            rec.*.deinit();
-            self.allocator.destroy(rec.*);
+        var har_it = self.har_recorders.iterator();
+        while (har_it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.*.deinit();
+            self.allocator.destroy(entry.value_ptr.*);
         }
         self.har_recorders.deinit();
 
-        var cdp_it = self.cdp_clients.valueIterator();
-        while (cdp_it.next()) |client| {
-            client.*.deinit();
-            self.allocator.destroy(client.*);
+        var cdp_it = self.cdp_clients.iterator();
+        while (cdp_it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.*.deinit();
+            self.allocator.destroy(entry.value_ptr.*);
         }
         self.cdp_clients.deinit();
 
@@ -163,10 +165,12 @@ pub const Bridge = struct {
                 freeSnapshot(self.allocator, kv.value);
             }
             if (self.cdp_clients.fetchRemove(tab_id)) |kv| {
+                self.allocator.free(kv.key);
                 kv.value.deinit();
                 self.allocator.destroy(kv.value);
             }
             if (self.har_recorders.fetchRemove(tab_id)) |kv| {
+                self.allocator.free(kv.key);
                 kv.value.deinit();
                 self.allocator.destroy(kv.value);
             }
@@ -187,10 +191,12 @@ pub const Bridge = struct {
             freeSnapshot(self.allocator, kv.value);
         }
         if (self.cdp_clients.fetchRemove(tab_id)) |kv| {
+            self.allocator.free(kv.key);
             kv.value.deinit();
             self.allocator.destroy(kv.value);
         }
         if (self.har_recorders.fetchRemove(tab_id)) |kv| {
+            self.allocator.free(kv.key);
             kv.value.deinit();
             self.allocator.destroy(kv.value);
         }
@@ -227,7 +233,12 @@ pub const Bridge = struct {
 
         const client = self.allocator.create(CdpClient) catch return null;
         client.* = CdpClient.init(self.allocator, tab.ws_url);
-        self.cdp_clients.put(tab_id, client) catch {
+        const owned_key = self.allocator.dupe(u8, tab_id) catch {
+            self.allocator.destroy(client);
+            return null;
+        };
+        self.cdp_clients.put(owned_key, client) catch {
+            self.allocator.free(owned_key);
             self.allocator.destroy(client);
             return null;
         };
@@ -307,7 +318,12 @@ pub const Bridge = struct {
 
         const rec = self.allocator.create(HarRecorder) catch return null;
         rec.* = HarRecorder.init(self.allocator);
-        self.har_recorders.put(tab_id, rec) catch {
+        const owned_key = self.allocator.dupe(u8, tab_id) catch {
+            self.allocator.destroy(rec);
+            return null;
+        };
+        self.har_recorders.put(owned_key, rec) catch {
+            self.allocator.free(owned_key);
             self.allocator.destroy(rec);
             return null;
         };

--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -3,53 +3,61 @@ const protocol = @import("protocol.zig");
 const WebSocketClient = @import("websocket.zig").WebSocketClient;
 
 pub const EventBuffer = struct {
-    items: [32]?[]const u8,
-    len: usize,
+    const BufferedEvent = struct {
+        data: []const u8,
+        owner: std.mem.Allocator,
+    };
+
+    items: std.ArrayListUnmanaged(BufferedEvent),
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) EventBuffer {
         return .{
-            .items = .{null} ** 32,
-            .len = 0,
+            .items = .empty,
             .allocator = allocator,
         };
     }
 
-    pub fn push(self: *EventBuffer, event: []const u8) void {
-        if (self.len < 32) {
-            self.items[self.len] = event;
-            self.len += 1;
-        } else {
-            // Ring buffer: overwrite oldest
-            self.allocator.free(self.items[0].?);
-            var i: usize = 0;
-            while (i < 31) : (i += 1) {
-                self.items[i] = self.items[i + 1];
-            }
-            self.items[31] = event;
+    pub fn len(self: *const EventBuffer) usize {
+        return self.items.items.len;
+    }
+
+    pub fn push(self: *EventBuffer, owner: std.mem.Allocator, event: []const u8) void {
+        if (self.items.items.len >= 256) {
+            const oldest = self.items.items[0];
+            oldest.owner.free(oldest.data);
+            _ = self.items.orderedRemove(0);
         }
+        self.items.append(self.allocator, .{ .data = event, .owner = owner }) catch {
+            owner.free(event);
+        };
     }
 
     /// Check if any buffered event matches a CDP method name exactly.
     pub fn hasEvent(self: *EventBuffer, method: []const u8) bool {
-        for (self.items[0..self.len]) |item| {
-            if (item) |ev| {
-                if (eventMatchesMethod(ev, method)) return true;
-            }
+        for (self.items.items) |item| {
+            if (eventMatchesMethod(item.data, method)) return true;
         }
         return false;
     }
 
     /// Drain all events, freeing memory.
     pub fn drain(self: *EventBuffer) void {
-        for (self.items[0..self.len]) |item| {
-            if (item) |ev| self.allocator.free(ev);
+        for (self.items.items) |item| {
+            item.owner.free(item.data);
         }
-        self.len = 0;
+        self.items.clearRetainingCapacity();
+    }
+
+    pub fn drainTo(self: *EventBuffer, allocator: std.mem.Allocator) ![]BufferedEvent {
+        const out = try allocator.dupe(BufferedEvent, self.items.items);
+        self.items.clearRetainingCapacity();
+        return out;
     }
 
     pub fn deinit(self: *EventBuffer) void {
         self.drain();
+        self.items.deinit(self.allocator);
     }
 };
 
@@ -130,7 +138,7 @@ pub const CdpClient = struct {
             }
 
             // Buffer event instead of discarding
-            self.event_buf.push(response);
+            self.event_buf.push(allocator, response);
         }
 
         return error.ConnectionRefused;
@@ -193,9 +201,26 @@ pub const CdpClient = struct {
                 allocator.free(response);
                 return true;
             }
-            self.event_buf.push(response);
+            self.event_buf.push(allocator, response);
         }
         return false;
+    }
+
+    pub fn drainWsEvents(self: *CdpClient, allocator: std.mem.Allocator, timeout_sec: i32) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+
+        var ws = &(self.ws orelse return);
+        const drain_timeout = std.posix.timeval{ .sec = timeout_sec, .usec = 0 };
+        const orig_timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
+        std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&drain_timeout)) catch {};
+        defer std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&orig_timeout)) catch {};
+
+        var drained: u32 = 0;
+        while (drained < 2000) : (drained += 1) {
+            const msg = ws.receiveMessageAlloc(allocator, 2 * 1024 * 1024) catch break;
+            self.event_buf.push(allocator, msg);
+        }
     }
 
     pub fn deinit(self: *CdpClient) void {
@@ -249,8 +274,8 @@ test "EventBuffer push and hasEvent" {
     defer buf.deinit();
 
     const event = try std.testing.allocator.dupe(u8, "{\"method\":\"Page.loadEventFired\",\"params\":{}}");
-    buf.push(event);
-    try std.testing.expectEqual(@as(usize, 1), buf.len);
+    buf.push(std.testing.allocator, event);
+    try std.testing.expectEqual(@as(usize, 1), buf.len());
     try std.testing.expect(buf.hasEvent("Page.loadEventFired"));
     try std.testing.expect(!buf.hasEvent("Network.responseReceived"));
 }
@@ -261,9 +286,9 @@ test "EventBuffer drain frees all" {
 
     const e1 = try std.testing.allocator.dupe(u8, "event1");
     const e2 = try std.testing.allocator.dupe(u8, "event2");
-    buf.push(e1);
-    buf.push(e2);
-    try std.testing.expectEqual(@as(usize, 2), buf.len);
+    buf.push(std.testing.allocator, e1);
+    buf.push(std.testing.allocator, e2);
+    try std.testing.expectEqual(@as(usize, 2), buf.len());
     buf.drain();
-    try std.testing.expectEqual(@as(usize, 0), buf.len);
+    try std.testing.expectEqual(@as(usize, 0), buf.len());
 }

--- a/src/cdp/har.zig
+++ b/src/cdp/har.zig
@@ -110,10 +110,10 @@ pub const HarRecorder = struct {
 
     /// Stop recording and return the HAR as a JSON string.
     pub fn stop(self: *HarRecorder, client: *CdpClient) ![]const u8 {
-        self.recording = false;
-
         // Disable Network domain
         _ = client.send(self.allocator, "Network.disable", null) catch {};
+
+        self.recording = false;
 
         return self.toJson();
     }

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -398,19 +398,8 @@ fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
             if (rec.isRecording()) {
                 // Wait briefly for network events to start arriving
                 std.Thread.sleep(1500 * std.time.ns_per_ms);
-                if (client.ws) |*ws| {
-                    const short_timeout = std.posix.timeval{ .sec = 2, .usec = 0 };
-                    const orig_timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-                    std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&short_timeout)) catch {};
-                    var drained: u32 = 0;
-                    while (drained < 500) : (drained += 1) {
-                        const msg = ws.receiveMessageAlloc(arena, 2 * 1024 * 1024) catch break;
-                        rec.handleCdpEvent(msg);
-                        client.event_buf.push(msg);
-                    }
-                    std.log.info("navigate: drained {d} events after navigation", .{drained});
-                    std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&orig_timeout)) catch {};
-                }
+                client.drainWsEvents(arena, 2);
+                flushEventsToHar(arena, client, rec);
             }
         }
 
@@ -1157,25 +1146,11 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
     // Flush buffered CDP events and disconnect HAR recorder from CDP client.
     if (bridge.getCdpClient(tab_id)) |client| {
         // First: flush any events already buffered from prior send() calls
-        flushEventsToHar(client, rec);
+        flushEventsToHar(arena, client, rec);
 
         // Second: aggressively drain the WebSocket for any remaining async events.
-        // Use a 2s timeout to catch late-arriving Network events.
-        if (client.ws) |*ws| {
-            const drain_timeout = std.posix.timeval{ .sec = 2, .usec = 0 };
-            const orig_timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-            std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&drain_timeout)) catch {};
-
-            var flush_read: u32 = 0;
-            while (flush_read < 500) : (flush_read += 1) {
-                const msg = ws.receiveMessageAlloc(arena, 2 * 1024 * 1024) catch break;
-                rec.handleCdpEvent(msg);
-                client.event_buf.push(msg);
-            }
-            std.log.info("HAR stop: drained {d} WS messages, recorder has {d} entries", .{ flush_read, rec.entryCount() });
-
-            std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&orig_timeout)) catch {};
-        }
+        client.drainWsEvents(arena, 2);
+        flushEventsToHar(arena, client, rec);
 
         // Third: stop recording (sends Network.disable).
         // handleCdpEvent still processes events after recording=false.
@@ -1185,7 +1160,7 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         };
 
         // Fourth: flush events buffered during the Network.disable send()
-        flushEventsToHar(client, rec);
+        flushEventsToHar(arena, client, rec);
 
         defer rec.allocator.free(har_json);
         // Re-serialize since we may have added entries after stop
@@ -1215,16 +1190,18 @@ fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 }
 
 /// Feed all buffered CDP events from the client's event buffer to the HAR recorder.
-fn flushEventsToHar(client: *CdpClient, rec: *HarRecorder) void {
-    std.log.info("HAR flush: {d} buffered events", .{client.event_buf.len});
+fn flushEventsToHar(arena: std.mem.Allocator, client: *CdpClient, rec: *HarRecorder) void {
+    const buffered = client.event_buf.drainTo(arena) catch return;
+    defer arena.free(buffered);
+
+    std.log.info("HAR flush: {d} buffered events", .{buffered.len});
     var network_events: usize = 0;
-    for (client.event_buf.items[0..client.event_buf.len]) |item| {
-        if (item) |ev| {
-            if (std.mem.indexOf(u8, ev, "Network.") != null) {
-                network_events += 1;
-            }
-            rec.handleCdpEvent(ev);
+    for (buffered) |item| {
+        defer item.owner.free(item.data);
+        if (std.mem.indexOf(u8, item.data, "Network.") != null) {
+            network_events += 1;
         }
+        rec.handleCdpEvent(item.data);
     }
     std.log.info("HAR flush: {d} network events fed to recorder", .{network_events});
 }


### PR DESCRIPTION
## Summary
- fix HAR/CDP cache keys so clients and recorders survive across HTTP requests
- track buffered CDP event ownership so flushed events are freed correctly
- drain WS events under the client mutex and flush buffered events around navigate/har stop
- keep Network.disable buffered events recordable before marking the recorder stopped

## Validation
- zig build test
- zig build -Doptimize=ReleaseFast
- reproduced the original HAR flow against https://httpbin.org/get
- before: `/har/stop` returned `entries: 0`
- after: `/har/stop` returned `entries: 2`

## Notes
- this is intended to replace #122 with the same runtime fix but without the ownership leaks and debug-log noise
