### PR TITLE
fix: verify Chrome binary exists on PATH before returning

### DIFF
--- a/src/chrome/launcher.zig
+++ b/src/chrome/launcher.zig
@@ -246,6 +246,7 @@ pub const Launcher = struct {
     }
 
     /// Find the first Chrome binary that exists on this system.
+    /// Find the first Chrome binary that exists on this system.
     fn findChromeBinary() ?[]const u8 {
         for (chrome_paths) |path| {
             // For absolute paths, check file existence
@@ -253,8 +254,17 @@ pub const Launcher = struct {
                 std.fs.cwd().access(path, .{}) catch continue;
                 return path;
             }
-            // For bare names, assume PATH lookup will work
-            return path;
+            // For bare names, verify the binary exists on PATH
+            const result = std.process.Child.init(
+                &.{ "which", path },
+                std.heap.page_allocator,
+            );
+            var child = result;
+            child.stderr_behavior = .Ignore;
+            child.stdout_behavior = .Ignore;
+            if (child.spawnAndWait()) |term| {
+                if (term.Exited == 0) return path;
+            } else |_| {}
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- `findChromeBinary()` returned the first bare name (`chrome`) without verifying it exists on PATH
- On Ubuntu/Debian where Chrome is `google-chrome`, this caused ENOENT and Kuri failed to start
- Now uses `which` to verify each candidate before returning

## Test
Tested on Ubuntu VM (`lekt8@89.169.121.108`) with Chrome installed as `google-chrome`:
- Before: `execve("chrome", ...) = -1 ENOENT` → Kuri fails
- After: `which chrome` fails → tries `which google-chrome` → succeeds → Chrome launches

Fixes #128

Generated with [Claude Code](https://claude.com/claude-code)