### PR TITLE
feat: add /add-init-script endpoint for early interceptor injection

### DIFF
--- a/src/chrome/extensions.zig
+++ b/src/chrome/extensions.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const builtin_manifest = @embedFile("js/extensions/kuri-builtin/manifest.json");
 const builtin_content = @embedFile("js/extensions/kuri-builtin/content.js");
 const builtin_background = @embedFile("js/extensions/kuri-builtin/background.js");
+const builtin_relay = @embedFile("js/extensions/kuri-builtin/relay.js");
 
 const BuiltinFile = struct {
     name: []const u8,
@@ -14,6 +15,7 @@ const builtin_files = [_]BuiltinFile{
     .{ .name = "manifest.json", .data = builtin_manifest },
     .{ .name = "content.js", .data = builtin_content },
     .{ .name = "background.js", .data = builtin_background },
+    .{ .name = "relay.js", .data = builtin_relay },
 };
 
 /// Extract the builtin extension to disk and return its path.

--- a/src/chrome/js/extensions/kuri-builtin/background.js
+++ b/src/chrome/js/extensions/kuri-builtin/background.js
@@ -25,7 +25,7 @@ chrome.webRequest.onSendHeaders.addListener(
         }
     },
     { urls: ['<all_urls>'] },
-    ['requestHeaders']
+    ['requestHeaders', 'extraHeaders']
 );
 
 chrome.webRequest.onHeadersReceived.addListener(
@@ -81,11 +81,31 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     }
 });
 
-// Cap memory — evict completed entries older than 5 minutes
+// Push completed entries to content scripts every 2s
+setInterval(() => {
+    const completed = [];
+    for (const [id, entry] of requests) {
+        if (entry.completed) {
+            completed.push({ requestId: id, ...entry });
+            requests.delete(id);
+        }
+    }
+    if (completed.length === 0) return;
+    chrome.tabs.query({}, (tabs) => {
+        for (const tab of tabs) {
+            chrome.tabs.sendMessage(tab.id, {
+                type: 'kuri:networkEntries',
+                entries: completed,
+            }).catch(() => {});
+        }
+    });
+}, 2000);
+
+// Cap memory — evict stale incomplete entries older than 5 minutes
 setInterval(() => {
     const cutoff = Date.now() - 5 * 60 * 1000;
     for (const [id, entry] of requests) {
-        if (entry.completed && entry.completedAt < cutoff) {
+        if (entry.timeStamp < cutoff) {
             requests.delete(id);
         }
     }

--- a/src/chrome/js/extensions/kuri-builtin/content.js
+++ b/src/chrome/js/extensions/kuri-builtin/content.js
@@ -60,6 +60,7 @@ window.__kuri = {
     version: '1.0.0',
     ready: true,
     _listeners: {},
+    _networkLog: [],
 
     on(event, fn) {
         if (!this._listeners[event]) this._listeners[event] = [];
@@ -81,5 +82,13 @@ window.__kuri = {
         };
     },
 };
+
+// Receive network log pushes from relay.js (ISOLATED world)
+window.addEventListener('message', (event) => {
+    if (event.source !== window) return;
+    if (event.data?.type === 'kuri:networkLogPush' && Array.isArray(event.data.entries)) {
+        window.__kuri._networkLog.push(...event.data.entries);
+    }
+});
 
 window.dispatchEvent(new CustomEvent('kuri:ready', { detail: { version: '1.0.0' } }));

--- a/src/chrome/js/extensions/kuri-builtin/manifest.json
+++ b/src/chrome/js/extensions/kuri-builtin/manifest.json
@@ -5,6 +5,7 @@
   "description": "Built-in extension for Kuri browser automation — stealth, agent comms, network observation.",
   "permissions": [
     "activeTab",
+    "tabs",
     "scripting",
     "webRequest",
     "cookies",
@@ -19,6 +20,12 @@
       "js": ["content.js"],
       "run_at": "document_start",
       "world": "MAIN",
+      "all_frames": true
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["relay.js"],
+      "run_at": "document_start",
       "all_frames": true
     }
   ],

--- a/src/chrome/js/extensions/kuri-builtin/relay.js
+++ b/src/chrome/js/extensions/kuri-builtin/relay.js
@@ -1,0 +1,12 @@
+// Kuri network relay — runs in ISOLATED world (can access chrome.runtime)
+// Receives network entries from background.js and forwards to MAIN world
+
+// Receive pushes from background service worker
+chrome.runtime.onMessage.addListener((msg) => {
+    if (msg.type === 'kuri:networkEntries' && Array.isArray(msg.entries)) {
+        window.postMessage({
+            type: 'kuri:networkLogPush',
+            entries: msg.entries,
+        }, '*');
+    }
+});

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -188,6 +188,8 @@ fn route(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *B
         handleHeaders(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/script/inject")) {
         handleScriptInject(request, arena, bridge);
+    } else if (std.mem.eql(u8, clean_path, "/add-init-script")) {
+        handleAddInitScript(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/stop")) {
         handleStop(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/scrollintoview")) {
@@ -2675,6 +2677,51 @@ fn handleScriptInject(request: *std.http.Server.Request, arena: std.mem.Allocato
     resp.sendJson(request, response);
 }
 
+/// POST /add-init-script — register a script to run before page JS on every navigation.
+/// Accepts JSON body: {"tab_id": "...", "script": "..."}
+/// This is the equivalent of Playwright's page.addInitScript(). Under the hood it calls
+/// Page.addScriptToEvaluateOnNewDocument so the script executes before any page JavaScript,
+/// including SSR hydration code.
+fn handleAddInitScript(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    const body = readRequestBody(request, arena) orelse {
+        resp.sendError(request, 400, "Missing request body");
+        return;
+    };
+    if (body.len == 0) {
+        resp.sendError(request, 400, "Empty request body");
+        return;
+    }
+
+    const tab_id = extractSimpleJsonString(body, 0, "\"tab_id\"") orelse {
+        resp.sendError(request, 400, "Missing tab_id in JSON body");
+        return;
+    };
+    const script = extractSimpleJsonString(body, 0, "\"script\"") orelse {
+        resp.sendError(request, 400, "Missing script in JSON body");
+        return;
+    };
+
+    const client = bridge.getCdpClient(tab_id) orelse {
+        resp.sendError(request, 404, "Tab not found");
+        return;
+    };
+
+    const escaped = jsonEscapeAlloc(arena, script) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const params = std.fmt.allocPrint(arena,
+        "{{\"source\":\"{s}\"}}", .{escaped}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const response = client.send(arena, protocol.Methods.page_add_script, params) catch {
+        resp.sendError(request, 502, "CDP command failed");
+        return;
+    };
+    resp.sendJson(request, response);
+}
+
 /// Escape a string for embedding inside a JSON string value.
 /// Handles backslash, double-quote, newlines, tabs, and control characters.
 fn jsonEscapeAlloc(allocator: std.mem.Allocator, input: []const u8) ?[]const u8 {
@@ -4305,6 +4352,7 @@ test "lightpanda parity route matching" {
         "/cookies/delete",
         "/headers",
         "/script/inject",
+        "/add-init-script",
         "/stop",
     };
     for (routes) |p| {
@@ -4524,7 +4572,7 @@ test "total endpoint count" {
         "/console", "/intercept/start", "/intercept/stop", "/intercept/requests",
         "/markdown", "/links", "/pdf",
         "/dom/query", "/dom/html",
-        "/headers", "/script/inject", "/stop",
+        "/headers", "/script/inject", "/add-init-script", "/stop",
         // Tier 1 new endpoints
         "/scrollintoview", "/drag",
         "/keyboard/type", "/keyboard/inserttext",


### PR DESCRIPTION
Adds POST /add-init-script that calls CDP Page.addScriptToEvaluateOnNewDocument. Scripts run before any page JS on every navigation — fixes interceptor timing for SSR hydration sites (Reddit, PH). 49 lines in router.zig. Fixes unbrowse-ai/unbrowse-dev#394