### PR TITLE
build: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Zig 0.15.0
+      - name: Install Zig 0.16.0
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
 
       - name: Cache Zig build artifacts
         uses: actions/cache@v4
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Zig 0.15.0
+      - name: Install Zig 0.16.0
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
 
       - name: Install Chrome
         uses: browser-actions/setup-chrome@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
       - name: Build
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast
       - name: Package
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
       - name: Build
         run: zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast
 
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.0
+          version: 0.16.0
       - name: Build
         run: zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast
 

--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the application");
     run_step.dependOn(&run_exe.step);
 
-    // Tests
+    // Tests — all tests compiled from main.zig root (needed for ../compat.zig imports)
     const unit_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
@@ -33,19 +33,25 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&run_unit_tests.step);
+    test_step.dependOn(&b.addRunArtifact(unit_tests).step);
 
 
     // merjs E2E test binary
+    const compat_mod = b.createModule(.{
+        .root_source_file = b.path("src/compat.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const merjs_e2e_mod = b.createModule(.{
+        .root_source_file = b.path("src/test/merjs_e2e.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    merjs_e2e_mod.addImport("compat", compat_mod);
     const merjs_e2e = b.addExecutable(.{
         .name = "merjs-e2e",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/test/merjs_e2e.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+        .root_module = merjs_e2e_mod,
     });
     b.installArtifact(merjs_e2e);
     const run_merjs_e2e = b.addRunArtifact(merjs_e2e);
@@ -69,7 +75,7 @@ pub fn build(b: *std.Build) void {
         .name = "kuri-fetch",
         .root_module = fetch_mod,
     });
-    fetch_exe.linkLibrary(quickjs_dep.artifact("quickjs-ng"));
+    fetch_exe.root_module.linkLibrary(quickjs_dep.artifact("quickjs-ng"));
     b.installArtifact(fetch_exe);
     const run_fetch = b.addRunArtifact(fetch_exe);
     run_fetch.step.dependOn(b.getInstallStep());
@@ -89,7 +95,7 @@ pub fn build(b: *std.Build) void {
     const fetch_tests = b.addTest(.{
         .root_module = fetch_test_mod,
     });
-    fetch_tests.linkLibrary(quickjs_dep.artifact("quickjs-ng"));
+    fetch_tests.root_module.linkLibrary(quickjs_dep.artifact("quickjs-ng"));
     const run_fetch_tests = b.addRunArtifact(fetch_tests);
     const fetch_test_step = b.step("test-fetch", "Run kuri-fetch unit tests");
     fetch_test_step.dependOn(&run_fetch_tests.step);

--- a/build.zig
+++ b/build.zig
@@ -11,6 +11,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -31,6 +32,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     const test_step = b.step("test", "Run unit tests");
@@ -42,11 +44,13 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/compat.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     const merjs_e2e_mod = b.createModule(.{
         .root_source_file = b.path("src/test/merjs_e2e.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     merjs_e2e_mod.addImport("compat", compat_mod);
     const merjs_e2e = b.addExecutable(.{
@@ -69,6 +73,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/fetch_main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     fetch_mod.addImport("quickjs", quickjs_dep.module("quickjs"));
     const fetch_exe = b.addExecutable(.{
@@ -90,6 +95,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/fetch_main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     fetch_test_mod.addImport("quickjs", quickjs_dep.module("quickjs"));
     const fetch_tests = b.addTest(.{
@@ -107,6 +113,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/browse_main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     b.installArtifact(browse_exe);
@@ -124,6 +131,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/browse_main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     const run_browse_tests = b.addRunArtifact(browse_tests);
@@ -137,6 +145,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/bench.zig"),
             .target = target,
             .optimize = .ReleaseFast,
+            .link_libc = true,
         }),
     });
     const run_bench = b.addRunArtifact(bench);
@@ -150,6 +159,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/agent_main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     b.installArtifact(agent_exe);

--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -10,6 +10,7 @@
 ///   click/type    act on @ref from snap     grab <ref> follows popups
 ///   stealth       anti-bot patches          cookies/headers/audit for security
 const std = @import("std");
+const compat = @import("compat.zig");
 const CdpClient = @import("cdp/client.zig").CdpClient;
 const protocol = @import("cdp/protocol.zig");
 const a11y = @import("snapshot/a11y.zig");
@@ -38,16 +39,16 @@ const Session = struct {
     }
 };
 
-pub fn main() !void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
-    const gpa = gpa_impl.allocator();
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    const args = try std.process.argsAlloc(arena);
+    const raw_args = init.minimal.args.toSlice(arena) catch
+        std.process.fatal("failed to get args", .{});
+    const args: []const []const u8 = @ptrCast(raw_args);
     if (args.len < 2) {
         printUsage();
         std.process.exit(1);
@@ -91,28 +92,27 @@ pub fn main() !void {
         try session.extra_headers.put(try arena.dupe(u8, rest[0]), try arena.dupe(u8, rest[1]));
         try saveSession(arena, &session);
         const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"header\":\"{s}\",\"value\":\"{s}\"}}\n", .{ rest[0], rest[1] });
-        std.fs.File.stdout().writeAll(out) catch {};
+        compat.writeToStdout(out);
         return;
     }
     if (std.mem.eql(u8, cmd, "clear-headers")) {
         session.extra_headers.clearRetainingCapacity();
         try saveSession(arena, &session);
-        std.fs.File.stdout().writeAll("{\"ok\":true,\"cleared\":true}\n") catch {};
+        compat.writeToStdout("{\"ok\":true,\"cleared\":true}\n");
         return;
     }
     if (std.mem.eql(u8, cmd, "show-headers")) {
         var hbuf: std.ArrayList(u8) = .empty;
-        const hw = hbuf.writer(arena);
-        hw.writeAll("{\"extra_headers\":{") catch {};
+        hbuf.appendSlice(arena, "{\"extra_headers\":{") catch {};
         var hit = session.extra_headers.iterator();
         var hfirst = true;
         while (hit.next()) |entry| {
-            if (!hfirst) hw.writeAll(",") catch {};
+            if (!hfirst) hbuf.appendSlice(arena, ",") catch {};
             hfirst = false;
-            hw.print("\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
+            hbuf.print(arena, "\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
         }
-        hw.writeAll("}}\n") catch {};
-        std.fs.File.stdout().writeAll(hbuf.items) catch {};
+        hbuf.appendSlice(arena, "}}\n") catch {};
+        compat.writeToStdout(hbuf.items);
         return;
     }
 
@@ -137,7 +137,7 @@ pub fn main() !void {
     if (std.mem.eql(u8, cmd, "go")) {
         if (rest.len < 1) fatal("go: requires <url>\n", .{});
         try cmdNavigate(arena, &client, rest[0]);
-        std.Thread.sleep(1_000_000_000); // let page load
+        compat.threadSleep(1_000_000_000); // let page load
         autoSnap(arena, &client, &session);
     } else if (std.mem.eql(u8, cmd, "snap")) {
         try cmdSnap(arena, &client, &session, rest);
@@ -225,8 +225,7 @@ fn cmdTabs(arena: std.mem.Allocator, port: u16) !void {
 
     // Pretty-print each page tab
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
-    w.writeAll("[\n") catch {};
+    buf.appendSlice(arena, "[\n") catch {};
 
     var first = true;
     var pos: usize = 0;
@@ -245,25 +244,24 @@ fn cmdTabs(arena: std.mem.Allocator, port: u16) !void {
         const url_val = extractString(json, pos, "\"url\"") orelse "";
         const title_val = extractString(json, pos, "\"title\"") orelse "";
 
-        if (!first) w.writeAll(",\n") catch {};
+        if (!first) buf.appendSlice(arena, ",\n") catch {};
         first = false;
-        w.print("  {{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\",\"ws\":\"{s}\"}}", .{
+        buf.print(arena, "  {{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\",\"ws\":\"{s}\"}}", .{
             id_val, url_val, title_val, ws_val,
         }) catch {};
 
         pos = ws_start + ws_val.len + 1;
     }
-    w.writeAll("\n]\n") catch {};
-    std.fs.File.stdout().writeAll(buf.items) catch {};
+    buf.appendSlice(arena, "\n]\n") catch {};
+    compat.writeToStdout(buf.items);
 }
 
 fn cmdUse(arena: std.mem.Allocator, ws_url: []const u8) !void {
     var session = Session.init(arena);
     session.cdp_url = ws_url;
     try saveSession(arena, &session);
-    const stdout = std.fs.File.stdout();
     const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"cdp_url\":\"{s}\"}}\n", .{ws_url});
-    stdout.writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 /// Launch a visible (non-headless) Chrome with CDP, wait for it, auto-attach.
@@ -283,15 +281,28 @@ fn cmdOpen(arena: std.mem.Allocator, port: u16, url: ?[]const u8) !void {
     const port_flag = try std.fmt.allocPrint(arena, "--remote-debugging-port={d}", .{port});
     try argv.append(arena, port_flag);
     // Chrome requires a data dir for CDP; use default profile so cookies/logins persist
-    const home = std.posix.getenv("HOME") orelse "/tmp";
+    const home = compat.getenv("HOME") orelse "/tmp";
     const data_dir = try std.fmt.allocPrint(arena, "--user-data-dir={s}/.kuri/chrome-profile", .{home});
     try argv.append(arena, data_dir);
     if (url) |u| try argv.append(arena, u);
 
-    var child = std.process.Child.init(argv.items, arena);
-    child.spawn() catch {
-        fatal("Failed to launch Chrome. Is it installed?\n", .{});
-    };
+    // Fork and exec Chrome
+    const pid = std.c.fork();
+    if (pid < 0) {
+        fatal("Failed to fork for Chrome launch\n", .{});
+    }
+    if (pid == 0) {
+        // Child process: exec Chrome
+        var c_argv: [64]?[*:0]const u8 = undefined;
+        for (argv.items, 0..) |arg, i| {
+            if (i >= c_argv.len - 1) break;
+            c_argv[i] = @ptrCast(arg.ptr);
+        }
+        c_argv[argv.items.len] = null;
+        const c_execvp = @extern(*const fn ([*:0]const u8, [*:null]const ?[*:0]const u8) callconv(.c) c_int, .{ .name = "execvp" });
+        _ = c_execvp(@ptrCast(argv.items[0].ptr), @ptrCast(&c_argv));
+        std.c._exit(127);
+    }
 
     // 3. Poll for CDP — try the requested port first, then fall back to 9222
     std.debug.print("Launching Chrome...\n", .{});
@@ -302,7 +313,7 @@ fn cmdOpen(arena: std.mem.Allocator, port: u16, url: ?[]const u8) !void {
 
     var attempts: u32 = 0;
     while (attempts < 30) : (attempts += 1) {
-        std.Thread.sleep(500_000_000);
+        compat.threadSleep(500_000_000);
         for (ports_to_try) |p| {
             if (tryAttach(arena, p, url)) return;
         }
@@ -346,15 +357,14 @@ fn tryAttach(arena: std.mem.Allocator, port: u16, url: ?[]const u8) bool {
 
 fn cmdStatus(arena: std.mem.Allocator) !void {
     var session = loadSession(arena) catch {
-        std.fs.File.stdout().writeAll("{\"ok\":false,\"error\":\"no session\"}\n") catch {};
+        compat.writeToStdout("{\"ok\":false,\"error\":\"no session\"}\n");
         return;
     };
     defer session.deinit();
-    const stdout = std.fs.File.stdout();
     const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"cdp_url\":\"{s}\",\"refs\":{d}}}\n", .{
         session.cdp_url, session.refs.count(),
     });
-    stdout.writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn cmdNavigate(arena: std.mem.Allocator, client: *CdpClient, url: []const u8) !void {
@@ -365,7 +375,7 @@ fn cmdNavigate(arena: std.mem.Allocator, client: *CdpClient, url: []const u8) !v
         std.process.exit(1);
     };
     const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"url\":\"{s}\"}}\n", .{escaped_url});
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn cmdSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session, flags: []const []const u8) !void {
@@ -410,37 +420,34 @@ fn cmdSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session, flag
     }
     saveSession(arena, session) catch {};
 
-    const stdout = std.fs.File.stdout();
-
     // --text: legacy indented text
     if (want_text) {
         const text = a11y.formatText(snapshot, arena) catch "{}";
-        stdout.writeAll(text) catch {};
-        stdout.writeAll("\n") catch {};
+        compat.writeToStdout(text);
+        compat.writeToStdout("\n");
         return;
     }
 
     // --json: old JSON array (backward compat)
     if (want_json) {
         var buf: std.ArrayList(u8) = .empty;
-        const w = buf.writer(arena);
-        w.writeAll("[") catch {};
+        buf.appendSlice(arena, "[") catch {};
         for (snapshot, 0..) |node, i| {
-            if (i > 0) w.writeAll(",") catch {};
-            w.print("{{\"ref\":\"{s}\",\"role\":\"{s}\",\"name\":\"{s}\"", .{ node.ref, node.role, node.name }) catch {};
+            if (i > 0) buf.appendSlice(arena, ",") catch {};
+            buf.print(arena, "{{\"ref\":\"{s}\",\"role\":\"{s}\",\"name\":\"{s}\"", .{ node.ref, node.role, node.name }) catch {};
             if (node.value.len > 0) {
-                w.print(",\"value\":\"{s}\"", .{node.value}) catch {};
+                buf.print(arena, ",\"value\":\"{s}\"", .{node.value}) catch {};
             }
-            w.writeAll("}") catch {};
+            buf.appendSlice(arena, "}") catch {};
         }
-        w.writeAll("]\n") catch {};
-        stdout.writeAll(buf.items) catch {};
+        buf.appendSlice(arena, "]\n") catch {};
+        compat.writeToStdout(buf.items);
         return;
     }
 
     // Default: compact text-tree (role "name" @ref)
     const compact = a11y.formatCompact(snapshot, arena) catch "error\n";
-    stdout.writeAll(compact) catch {};
+    compat.writeToStdout(compact);
 }
 
 /// Auto-snap: get URL/title + interactive snapshot. Used after actions and navigation.
@@ -451,8 +458,8 @@ fn autoSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session) voi
     if (url_resp) |resp| {
         const val = extractCdpValue(resp);
         const unescaped = unescapeJson(arena, val);
-        std.fs.File.stdout().writeAll(unescaped) catch {};
-        std.fs.File.stdout().writeAll("\n") catch {};
+        compat.writeToStdout(unescaped);
+        compat.writeToStdout("\n");
     }
 
     // Interactive snap
@@ -479,7 +486,7 @@ fn autoSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session) voi
     saveSession(arena, session) catch {};
 
     const compact = a11y.formatCompact(snapshot, arena) catch return;
-    std.fs.File.stdout().writeAll(compact) catch {};
+    compat.writeToStdout(compact);
 }
 
 fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, action: []const u8, ref: []const u8, value: ?[]const u8) !void {
@@ -553,7 +560,7 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
     };
     const val = extractCdpValue(response);
     const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"{s}\"}}\n", .{val});
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn cmdScroll(arena: std.mem.Allocator, client: *CdpClient) !void {
@@ -563,7 +570,7 @@ fn cmdScroll(arena: std.mem.Allocator, client: *CdpClient) !void {
         std.process.exit(1);
     };
     _ = response;
-    std.fs.File.stdout().writeAll("{\"ok\":true}\n") catch {};
+    compat.writeToStdout("{\"ok\":true}\n");
 }
 
 fn cmdViewport(arena: std.mem.Allocator, client: *CdpClient, args: []const []const u8) !void {
@@ -617,7 +624,7 @@ fn cmdViewport(arena: std.mem.Allocator, client: *CdpClient, args: []const []con
     const out = try std.fmt.allocPrint(arena,
         "{{\"ok\":true,\"width\":{d},\"height\":{d},\"dpr\":{d},\"mobile\":{s}}}\n",
         .{ width, height, dpr, if (mobile) "true" else "false" });
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn cmdEval(arena: std.mem.Allocator, client: *CdpClient, expr: []const u8) !void {
@@ -628,8 +635,8 @@ fn cmdEval(arena: std.mem.Allocator, client: *CdpClient, expr: []const u8) !void
         std.process.exit(1);
     };
     const val = unescapeJson(arena, extractCdpValue(response));
-    std.fs.File.stdout().writeAll(val) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(val);
+    compat.writeToStdout("\n");
 }
 
 fn cmdText(arena: std.mem.Allocator, client: *CdpClient, selector: ?[]const u8) !void {
@@ -643,8 +650,8 @@ fn cmdText(arena: std.mem.Allocator, client: *CdpClient, selector: ?[]const u8) 
         std.process.exit(1);
     };
     const val = unescapeJson(arena, extractCdpValue(response));
-    std.fs.File.stdout().writeAll(val) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(val);
+    compat.writeToStdout("\n");
 }
 
 fn cmdScreenshot(arena: std.mem.Allocator, client: *CdpClient, out_path: ?[]const u8) !void {
@@ -673,22 +680,22 @@ fn cmdScreenshot(arena: std.mem.Allocator, client: *CdpClient, out_path: ?[]cons
 
     // Determine output path — default to ~/.kuri/screenshots/<timestamp>.png
     const path: []const u8 = out_path orelse blk: {
-        const home = std.posix.getenv("HOME") orelse ".";
+        const home = compat.getenv("HOME") orelse ".";
         const shots_dir = try std.fmt.allocPrint(arena, "{s}/.kuri/screenshots", .{home});
-        std.fs.cwd().makePath(shots_dir) catch {};
-        const ts = std.time.timestamp();
+        compat.cwdMakePath(shots_dir) catch {};
+        const ts = compat.timestampSeconds();
         break :blk try std.fmt.allocPrint(arena, "{s}/{d}.png", .{ shots_dir, ts });
     };
 
-    const file = std.fs.cwd().createFile(path, .{}) catch |err| {
+    const file = compat.cwdCreateFile(path) catch |err| {
         jsonError("cannot create file '{s}': {s}", .{ path, @errorName(err) });
         std.process.exit(1);
     };
-    defer file.close();
-    file.writeAll(decoded) catch {};
+    defer compat.fdClose(file);
+    compat.fdWriteAll(file, decoded) catch {};
 
     const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"path\":\"{s}\",\"bytes\":{d}}}\n", .{ path, decoded.len });
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn cmdSimpleNav(arena: std.mem.Allocator, client: *CdpClient, method: []const u8) !void {
@@ -697,7 +704,7 @@ fn cmdSimpleNav(arena: std.mem.Allocator, client: *CdpClient, method: []const u8
         std.process.exit(1);
     };
     _ = response;
-    std.fs.File.stdout().writeAll("{\"ok\":true}\n") catch {};
+    compat.writeToStdout("{\"ok\":true}\n");
 }
 
 // ── Tab following ─────────────────────────────────────────────────────────────
@@ -746,13 +753,13 @@ fn cmdGrab(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ref:
     };
 
     while (attempts < 16) : (attempts += 1) {
-        std.Thread.sleep(500_000_000);
+        compat.threadSleep(500_000_000);
         const resp = client.send(arena, protocol.Methods.runtime_evaluate,
             "{\"expression\":\"location.href\",\"returnByValue\":true}") catch {
             // Connection lost = page navigated away
             const out = try std.fmt.allocPrint(arena,
                 "{{\"ok\":true,\"action\":\"navigated\",\"note\":\"page navigated, run snap to see new page\"}}\n", .{});
-            std.fs.File.stdout().writeAll(out) catch {};
+            compat.writeToStdout(out);
             return;
         };
         if (std.mem.indexOf(u8, resp, "\"value\":\"")) |s| {
@@ -762,12 +769,12 @@ fn cmdGrab(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ref:
             if (!std.mem.eql(u8, new_url, orig_url)) {
                 const out = try std.fmt.allocPrint(arena,
                     "{{\"ok\":true,\"action\":\"navigated\",\"url\":\"{s}\"}}\n", .{new_url});
-                std.fs.File.stdout().writeAll(out) catch {};
+                compat.writeToStdout(out);
                 return;
             }
         }
     }
-    std.fs.File.stdout().writeAll("{\"ok\":true,\"action\":\"clicked\",\"note\":\"no redirect detected — check tabs\"}\n") catch {};
+    compat.writeToStdout("{\"ok\":true,\"action\":\"clicked\",\"note\":\"no redirect detected — check tabs\"}\n");
 }
 
 /// Poll Chrome /json for a new tab, auto-switch to it.
@@ -780,7 +787,7 @@ fn cmdWaitForTab(arena: std.mem.Allocator, port: u16, session: *Session) !void {
     var attempts: u32 = 0;
     while (attempts < 20) : (attempts += 1) {
         const json = fetchChromeTabs(arena, "127.0.0.1", port) catch {
-            std.Thread.sleep(500_000_000);
+            compat.threadSleep(500_000_000);
             continue;
         };
 
@@ -807,15 +814,15 @@ fn cmdWaitForTab(arena: std.mem.Allocator, port: u16, session: *Session) !void {
                 const out = try std.fmt.allocPrint(arena,
                     "{{\"ok\":true,\"switched\":true,\"url\":\"{s}\",\"title\":\"{s}\",\"ws\":\"{s}\"}}\n",
                     .{ url_val, title_val, ws_val });
-                std.fs.File.stdout().writeAll(out) catch {};
+                compat.writeToStdout(out);
                 return;
             }
             pos = ws_start + ws_val.len + 1;
         }
-        std.Thread.sleep(500_000_000);
+        compat.threadSleep(500_000_000);
     }
 
-    std.fs.File.stdout().writeAll("{\"ok\":false,\"error\":\"no new tab detected after 10s\"}\n") catch {};
+    compat.writeToStdout("{\"ok\":false,\"error\":\"no new tab detected after 10s\"}\n");
 }
 
 fn parsePort(args: []const []const u8) u16 {
@@ -873,7 +880,7 @@ fn cmdStealth(arena: std.mem.Allocator, client: *CdpClient) !void {
     const ua_escaped = try escapeForJson(arena, ua);
     const out = try std.fmt.allocPrint(arena,
         "{{\"ok\":true,\"ua\":\"{s}\",\"stealth\":true,\"persisted\":true}}\n", .{ua_escaped});
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 // ── Security ──────────────────────────────────────────────────────────────────
@@ -884,20 +891,18 @@ fn cmdCookies(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("Network.getCookies failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    const stdout = std.fs.File.stdout();
     const cookies_pos = std.mem.indexOf(u8, response, "\"cookies\"") orelse {
-        stdout.writeAll(response) catch {};
-        stdout.writeAll("\n") catch {};
+        compat.writeToStdout(response);
+        compat.writeToStdout("\n");
         return;
     };
     const arr_start = std.mem.indexOfScalarPos(u8, response, cookies_pos, '[') orelse {
-        stdout.writeAll("{\"cookies\":[]}\n") catch {};
+        compat.writeToStdout("{\"cookies\":[]}\n");
         return;
     };
     var pos = arr_start + 1;
     var count: usize = 0;
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
     while (pos < response.len) {
         const obj_start = std.mem.indexOfScalarPos(u8, response, pos, '{') orelse break;
         var depth: usize = 1;
@@ -915,22 +920,22 @@ fn cmdCookies(arena: std.mem.Allocator, client: *CdpClient) !void {
         const secure = std.mem.indexOf(u8, cookie_json, "\"secure\":true") != null;
         if (name.len > 0) {
             count += 1;
-            w.print("  {s}  domain={s} path={s}", .{ name, domain, path_val }) catch {};
-            if (secure) w.writeAll("  [Secure]") catch {};
-            if (http_only) w.writeAll(" [HttpOnly]") catch {};
-            if (same_site.len > 0) w.print(" [SameSite={s}]", .{same_site}) catch {};
-            if (!secure) w.writeAll("  [!Secure]") catch {};
-            if (!http_only) w.writeAll(" [!HttpOnly]") catch {};
-            w.writeAll("\n") catch {};
+            buf.print(arena, "  {s}  domain={s} path={s}", .{ name, domain, path_val }) catch {};
+            if (secure) buf.appendSlice(arena, "  [Secure]") catch {};
+            if (http_only) buf.appendSlice(arena, " [HttpOnly]") catch {};
+            if (same_site.len > 0) buf.print(arena, " [SameSite={s}]", .{same_site}) catch {};
+            if (!secure) buf.appendSlice(arena, "  [!Secure]") catch {};
+            if (!http_only) buf.appendSlice(arena, " [!HttpOnly]") catch {};
+            buf.appendSlice(arena, "\n") catch {};
         }
         pos = i + 1;
     }
     if (count == 0) {
-        stdout.writeAll("{\"cookies\":0}\n") catch {};
+        compat.writeToStdout("{\"cookies\":0}\n");
     } else {
         const hdr = try std.fmt.allocPrint(arena, "cookies ({d}):\n", .{count});
-        stdout.writeAll(hdr) catch {};
-        stdout.writeAll(buf.items) catch {};
+        compat.writeToStdout(hdr);
+        compat.writeToStdout(buf.items);
     }
 }
 
@@ -954,8 +959,8 @@ fn cmdHeaders(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("headers eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 /// Security audit: HTTPS, missing security headers, JS-visible cookies.
@@ -988,40 +993,38 @@ fn cmdAudit(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("audit eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 /// Apply session's stored extra HTTP headers via CDP Network domain.
 fn applyExtraHeaders(arena: std.mem.Allocator, client: *CdpClient, session: *Session) !void {
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
-    w.writeAll("{\"headers\":{") catch {};
+    buf.appendSlice(arena, "{\"headers\":{") catch {};
     var it = session.extra_headers.iterator();
     var first = true;
     while (it.next()) |entry| {
-        if (!first) w.writeAll(",") catch {};
+        if (!first) buf.appendSlice(arena, ",") catch {};
         first = false;
-        w.print("\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
+        buf.print(arena, "\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
     }
-    w.writeAll("}}") catch {};
+    buf.appendSlice(arena, "}}") catch {};
     _ = client.send(arena, protocol.Methods.network_set_extra_http_headers, buf.items) catch {};
 }
 
 /// Dump localStorage and/or sessionStorage contents.
 fn cmdStorage(arena: std.mem.Allocator, client: *CdpClient, which: []const u8) !void {
     var js: std.ArrayList(u8) = .empty;
-    const jw = js.writer(arena);
-    jw.writeAll("(()=>{") catch {};
-    jw.writeAll("const r={};") catch {};
+    js.appendSlice(arena, "(()=>{") catch {};
+    js.appendSlice(arena, "const r={};") catch {};
     if (std.mem.eql(u8, which, "local") or std.mem.eql(u8, which, "all")) {
-        jw.writeAll("r.localStorage=Object.fromEntries(Object.entries(localStorage));") catch {};
+        js.appendSlice(arena, "r.localStorage=Object.fromEntries(Object.entries(localStorage));") catch {};
     }
     if (std.mem.eql(u8, which, "session") or std.mem.eql(u8, which, "all")) {
-        jw.writeAll("r.sessionStorage=Object.fromEntries(Object.entries(sessionStorage));") catch {};
+        js.appendSlice(arena, "r.sessionStorage=Object.fromEntries(Object.entries(sessionStorage));") catch {};
     }
-    jw.writeAll("return JSON.stringify(r);") catch {};
-    jw.writeAll("})()") catch {};
+    js.appendSlice(arena, "return JSON.stringify(r);") catch {};
+    js.appendSlice(arena, "})()") catch {};
     const escaped = try escapeForJson(arena, js.items);
     const params = try std.fmt.allocPrint(arena,
         "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped});
@@ -1029,8 +1032,8 @@ fn cmdStorage(arena: std.mem.Allocator, client: *CdpClient, which: []const u8) !
         jsonError("storage eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 /// Scan localStorage, sessionStorage, and cookies for JWT tokens, decode payloads.
@@ -1054,30 +1057,29 @@ fn cmdJwt(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("jwt scan failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 /// Make an authenticated fetch() from browser context (uses current cookies + extra headers).
 fn cmdFetch(arena: std.mem.Allocator, client: *CdpClient, method: []const u8, url: []const u8, data: ?[]const u8) !void {
     var js: std.ArrayList(u8) = .empty;
-    const jw = js.writer(arena);
-    jw.writeAll("(async()=>{") catch {};
-    jw.writeAll("const opts={credentials:'include',method:'") catch {};
-    jw.writeAll(method) catch {};
-    jw.writeAll("'};") catch {};
+    js.appendSlice(arena, "(async()=>{") catch {};
+    js.appendSlice(arena, "const opts={credentials:'include',method:'") catch {};
+    js.appendSlice(arena, method) catch {};
+    js.appendSlice(arena, "'};") catch {};
     if (data) |d| {
-        jw.writeAll("opts.body=JSON.stringify(") catch {};
-        jw.writeAll(d) catch {};
-        jw.writeAll(");opts.headers={'Content-Type':'application/json'};") catch {};
+        js.appendSlice(arena, "opts.body=JSON.stringify(") catch {};
+        js.appendSlice(arena, d) catch {};
+        js.appendSlice(arena, ");opts.headers={'Content-Type':'application/json'};") catch {};
     }
-    jw.writeAll("const r=await fetch('") catch {};
-    jw.writeAll(url) catch {};
-    jw.writeAll("',opts);") catch {};
-    jw.writeAll("const body=await r.text();") catch {};
-    jw.writeAll("const hdrs={};r.headers.forEach((v,k)=>{hdrs[k]=v;});") catch {};
-    jw.writeAll("return JSON.stringify({status:r.status,url:r.url,headers:hdrs,body:body.substring(0,5000)});") catch {};
-    jw.writeAll("})()") catch {};
+    js.appendSlice(arena, "const r=await fetch('") catch {};
+    js.appendSlice(arena, url) catch {};
+    js.appendSlice(arena, "',opts);") catch {};
+    js.appendSlice(arena, "const body=await r.text();") catch {};
+    js.appendSlice(arena, "const hdrs={};r.headers.forEach((v,k)=>{hdrs[k]=v;});") catch {};
+    js.appendSlice(arena, "return JSON.stringify({status:r.status,url:r.url,headers:hdrs,body:body.substring(0,5000)});") catch {};
+    js.appendSlice(arena, "})()") catch {};
     const escaped = try escapeForJson(arena, js.items);
     const params = try std.fmt.allocPrint(arena,
         "{{\"expression\":\"{s}\",\"returnByValue\":true,\"awaitPromise\":true}}", .{escaped});
@@ -1085,8 +1087,8 @@ fn cmdFetch(arena: std.mem.Allocator, client: *CdpClient, method: []const u8, ur
         jsonError("fetch failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 fn parseFetchData(flags: []const []const u8) ?[]const u8 {
@@ -1099,18 +1101,17 @@ fn parseFetchData(flags: []const []const u8) ?[]const u8 {
 /// Enumerate a URL template by substituting {id} with a range — IDOR probe.
 fn cmdProbe(arena: std.mem.Allocator, client: *CdpClient, tmpl: []const u8, start_id: u32, end_id: u32) !void {
     var js: std.ArrayList(u8) = .empty;
-    const jw = js.writer(arena);
-    jw.writeAll("(async()=>{") catch {};
-    jw.writeAll("const results=[];") catch {};
-    jw.print("const tmpl='{s}';", .{tmpl}) catch {};
-    jw.print("for(let id={d};id<={d};id++){{", .{ start_id, end_id }) catch {};
-    jw.writeAll("const url=tmpl.split('{id}').join(String(id));") catch {};
-    jw.writeAll("try{const r=await fetch(url,{credentials:'include'});") catch {};
-    jw.writeAll("results.push({id,url,status:r.status});}") catch {};
-    jw.writeAll("catch(e){results.push({id,url,error:e.message});}") catch {};
-    jw.writeAll("}") catch {};
-    jw.writeAll("return JSON.stringify(results);") catch {};
-    jw.writeAll("})()") catch {};
+    js.appendSlice(arena, "(async()=>{") catch {};
+    js.appendSlice(arena, "const results=[];") catch {};
+    js.print(arena, "const tmpl='{s}';", .{tmpl}) catch {};
+    js.print(arena, "for(let id={d};id<={d};id++){{", .{ start_id, end_id }) catch {};
+    js.appendSlice(arena, "const url=tmpl.split('{id}').join(String(id));") catch {};
+    js.appendSlice(arena, "try{const r=await fetch(url,{credentials:'include'});") catch {};
+    js.appendSlice(arena, "results.push({id,url,status:r.status});}") catch {};
+    js.appendSlice(arena, "catch(e){results.push({id,url,error:e.message});}") catch {};
+    js.appendSlice(arena, "}") catch {};
+    js.appendSlice(arena, "return JSON.stringify(results);") catch {};
+    js.appendSlice(arena, "})()") catch {};
     const escaped = try escapeForJson(arena, js.items);
     const params = try std.fmt.allocPrint(arena,
         "{{\"expression\":\"{s}\",\"returnByValue\":true,\"awaitPromise\":true}}", .{escaped});
@@ -1118,21 +1119,21 @@ fn cmdProbe(arena: std.mem.Allocator, client: *CdpClient, tmpl: []const u8, star
         jsonError("probe failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    std.fs.File.stdout().writeAll(response) catch {};
-    std.fs.File.stdout().writeAll("\n") catch {};
+    compat.writeToStdout(response);
+    compat.writeToStdout("\n");
 }
 
 
 // ── Session I/O ───────────────────────────────────────────────────────────────
 
 fn sessionPath(arena: std.mem.Allocator) ![]const u8 {
-    const home = std.posix.getenv("HOME") orelse ".";
+    const home = compat.getenv("HOME") orelse ".";
     return std.fmt.allocPrint(arena, "{s}/{s}", .{ home, SESSION_FILE });
 }
 
 fn loadSession(arena: std.mem.Allocator) !Session {
     const path = try sessionPath(arena);
-    const data = std.fs.cwd().readFileAlloc(arena, path, 1024 * 1024) catch return error.NoSession;
+    const data = compat.cwdReadFile(arena, path, 1024 * 1024) catch return error.NoSession;
 
     var session = Session.init(arena);
 
@@ -1206,59 +1207,79 @@ fn saveSession(arena: std.mem.Allocator, session: *Session) !void {
     const path = try sessionPath(arena);
 
     // Ensure ~/.kuri exists
-    const home = std.posix.getenv("HOME") orelse ".";
+    const home = compat.getenv("HOME") orelse ".";
     const dir_path = try std.fmt.allocPrint(arena, "{s}/.kuri", .{home});
-    std.fs.cwd().makeDir(dir_path) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
+    compat.cwdMakePath(dir_path) catch {};
 
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
-    w.print("{{\"cdp_url\":\"{s}\",\"refs\":{{", .{session.cdp_url}) catch {};
+    buf.print(arena, "{{\"cdp_url\":\"{s}\",\"refs\":{{", .{session.cdp_url}) catch {};
 
     var it = session.refs.iterator();
     var first = true;
     while (it.next()) |entry| {
-        if (!first) w.writeAll(",") catch {};
+        if (!first) buf.appendSlice(arena, ",") catch {};
         first = false;
-        w.print("\"{s}\":{d}", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
+        buf.print(arena, "\"{s}\":{d}", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
     }
-    w.writeAll("},\"extra_headers\":{") catch {};
+    buf.appendSlice(arena, "},\"extra_headers\":{") catch {};
     var eit = session.extra_headers.iterator();
     var efirst = true;
     while (eit.next()) |entry| {
-        if (!efirst) w.writeAll(",") catch {};
+        if (!efirst) buf.appendSlice(arena, ",") catch {};
         efirst = false;
-        w.print("\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
+        buf.print(arena, "\"{s}\":\"{s}\"", .{ entry.key_ptr.*, entry.value_ptr.* }) catch {};
     }
-    w.print("}},\"stealth\":{s}}}\n", .{if (session.stealth) "true" else "false"}) catch {};
+    buf.print(arena, "}},\"stealth\":{s}}}\n", .{if (session.stealth) "true" else "false"}) catch {};
 
-    const file = try std.fs.cwd().createFile(path, .{});
-    defer file.close();
-    try file.writeAll(buf.items);
+    try compat.cwdWriteFile(path, buf.items);
 }
 
 // ── Chrome tab discovery ──────────────────────────────────────────────────────
 
+extern "c" fn connect(sock: std.c.fd_t, addr: *const std.posix.sockaddr, addrlen: std.posix.socklen_t) c_int;
+
 fn fetchChromeTabs(arena: std.mem.Allocator, host: []const u8, port: u16) ![]const u8 {
-    const address = try std.net.Address.parseIp4(host, port);
-    const stream = try std.net.tcpConnectToAddress(address);
-    defer stream.close();
+    _ = host;
+    // Create TCP socket
+    const raw_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);
+    if (raw_fd < 0) return error.ConnectionRefused;
+    const fd: std.posix.fd_t = raw_fd;
 
+    // Connect to 127.0.0.1:port
+    var addr: std.posix.sockaddr.in = .{
+        .port = std.mem.nativeToBig(u16, port),
+        .addr = std.mem.nativeToBig(u32, 0x7f000001), // 127.0.0.1
+    };
+    if (connect(fd, @ptrCast(&addr), @sizeOf(std.posix.sockaddr.in)) != 0) {
+        _ = std.c.close(fd);
+        return error.ConnectionRefused;
+    }
+
+    // Set receive timeout
     const timeout = std.posix.timeval{ .sec = 3, .usec = 0 };
-    std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+    std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
 
-    const req = try std.fmt.allocPrint(arena, "GET /json/list HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n\r\n", .{ host, port });
-    try stream.writeAll(req);
+    // Send HTTP request
+    const req = try std.fmt.allocPrint(arena, "GET /json/list HTTP/1.1\r\nHost: 127.0.0.1:{d}\r\nConnection: close\r\n\r\n", .{port});
+    var sent: usize = 0;
+    while (sent < req.len) {
+        const n = std.c.write(fd, req.ptr + sent, req.len - sent);
+        if (n <= 0) {
+            _ = std.c.close(fd);
+            return error.WriteFailed;
+        }
+        sent += @intCast(n);
+    }
 
+    // Read response
     var buf: [65536]u8 = undefined;
     var total: usize = 0;
     while (total < buf.len) {
-        const n = stream.read(buf[total..]) catch break;
+        const n = std.posix.read(fd, buf[total..]) catch break;
         if (n == 0) break;
         total += n;
     }
+    _ = std.c.close(fd);
 
     const raw = buf[0..total];
     const body_start = (std.mem.indexOf(u8, raw, "\r\n\r\n") orelse return error.InvalidResponse) + 4;
@@ -1322,20 +1343,19 @@ fn extractString(json: []const u8, start: usize, field: []const u8) ?[]const u8 
 /// Unescape JSON string escapes: \n → newline, \t → tab, \\ → backslash, \" → quote
 fn unescapeJson(arena: std.mem.Allocator, s: []const u8) []const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
     var i: usize = 0;
     while (i < s.len) {
         if (s[i] == '\\' and i + 1 < s.len) {
             switch (s[i + 1]) {
-                'n' => { w.writeByte('\n') catch {}; i += 2; },
-                't' => { w.writeByte('\t') catch {}; i += 2; },
-                '\\' => { w.writeByte('\\') catch {}; i += 2; },
-                '"' => { w.writeByte('"') catch {}; i += 2; },
-                '/' => { w.writeByte('/') catch {}; i += 2; },
-                else => { w.writeByte(s[i]) catch {}; i += 1; },
+                'n' => { buf.append(arena, '\n') catch {}; i += 2; },
+                't' => { buf.append(arena, '\t') catch {}; i += 2; },
+                '\\' => { buf.append(arena, '\\') catch {}; i += 2; },
+                '"' => { buf.append(arena, '"') catch {}; i += 2; },
+                '/' => { buf.append(arena, '/') catch {}; i += 2; },
+                else => { buf.append(arena, s[i]) catch {}; i += 1; },
             }
         } else {
-            w.writeByte(s[i]) catch {};
+            buf.append(arena, s[i]) catch {};
             i += 1;
         }
     }
@@ -1427,15 +1447,14 @@ fn extractFieldInt(json: []const u8, field: []const u8) ?u32 {
 /// Escape a string for embedding inside a JSON string value.
 fn escapeForJson(arena: std.mem.Allocator, s: []const u8) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
     for (s) |c| {
         switch (c) {
-            '"' => w.writeAll("\\\"") catch {},
-            '\\' => w.writeAll("\\\\") catch {},
-            '\n' => w.writeAll("\\n") catch {},
-            '\r' => w.writeAll("\\r") catch {},
-            '\t' => w.writeAll("\\t") catch {},
-            else => w.writeByte(c) catch {},
+            '"' => buf.appendSlice(arena, "\\\"") catch {},
+            '\\' => buf.appendSlice(arena, "\\\\") catch {},
+            '\n' => buf.appendSlice(arena, "\\n") catch {},
+            '\r' => buf.appendSlice(arena, "\\r") catch {},
+            '\t' => buf.appendSlice(arena, "\\t") catch {},
+            else => buf.append(arena, c) catch {},
         }
     }
     return buf.items;
@@ -1482,10 +1501,10 @@ fn parseOutFlag(flags: []const []const u8) ?[]const u8 {
 fn jsonError(comptime fmt: []const u8, args: anytype) void {
     var buf: [512]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch "unknown error";
-    const clean = std.mem.trimRight(u8, msg, "\n");
+    const clean = std.mem.trimEnd(u8, msg, "\n");
     var out_buf: [600]u8 = undefined;
     const out = std.fmt.bufPrint(&out_buf, "{{\"error\":\"{s}\"}}\n", .{clean}) catch "{\"error\":\"unknown\"}\n";
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
 }
 
 fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
@@ -1493,10 +1512,10 @@ fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
     var buf: [512]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch "unknown error";
     // Strip trailing newline
-    const clean = std.mem.trimRight(u8, msg, "\n");
+    const clean = std.mem.trimEnd(u8, msg, "\n");
     var out_buf: [600]u8 = undefined;
     const out = std.fmt.bufPrint(&out_buf, "{{\"error\":\"{s}\"}}\n", .{clean}) catch "{\"error\":\"fatal\"}\n";
-    std.fs.File.stdout().writeAll(out) catch {};
+    compat.writeToStdout(out);
     std.process.exit(1);
 }
 

--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -516,6 +516,64 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
         std.process.exit(1);
     };
 
+    const value_action_fn =
+        \\function(value, append) {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this instanceof HTMLSelectElement) return this;
+        \\    if (this.isContentEditable) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("input,textarea,select,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  target.focus?.();
+        \\  if (target.isContentEditable) {
+        \\    const existing = typeof target.textContent === "string" ? target.textContent : "";
+        \\    target.textContent = append ? (existing + value) : value;
+        \\  } else if ("value" in target) {
+        \\    const existing = typeof target.value === "string" ? target.value : "";
+        \\    target.value = append ? (existing + value) : value;
+        \\  }
+        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+        \\  return "filled";
+        \\}
+    ;
+    const select_action_fn =
+        \\function(value) {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLSelectElement) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("select");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  let next = value;
+        \\  if ("options" in target && target.options) {
+        \\    for (const opt of target.options) {
+        \\      const text = (opt.textContent || "").trim();
+        \\      const label = (opt.label || "").trim();
+        \\      if (opt.value === value || text === value || label === value) {
+        \\        next = opt.value;
+        \\        break;
+        \\      }
+        \\    }
+        \\  }
+        \\  if ("value" in target) target.value = next;
+        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+        \\  return "selected";
+        \\}
+    ;
+
     // Step 2: build JS function for the action
     const js_fn: []const u8 = blk: {
         if (std.mem.eql(u8, action, "click")) break :blk "function() { this.scrollIntoViewIfNeeded(); this.click(); return 'clicked'; }";
@@ -530,18 +588,16 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
                 jsonError("{s} requires a value", .{action});
                 std.process.exit(1);
             };
-            break :blk try std.fmt.allocPrint(arena,
-                "function() {{ this.focus(); this.value = '{s}'; this.dispatchEvent(new Event('input', {{bubbles:true}})); return 'filled'; }}",
-                .{v});
+            _ = v;
+            break :blk value_action_fn;
         }
         if (std.mem.eql(u8, action, "select")) {
             const v = value orelse {
                 jsonError("select requires a value", .{});
                 std.process.exit(1);
             };
-            break :blk try std.fmt.allocPrint(arena,
-                "function() {{ this.value = '{s}'; this.dispatchEvent(new Event('change', {{bubbles:true}})); return 'selected'; }}",
-                .{v});
+            _ = v;
+            break :blk select_action_fn;
         }
         jsonError("unknown action '{s}'", .{action});
         std.process.exit(1);
@@ -551,9 +607,33 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
     const escaped_fn = try escapeForJson(arena, js_fn);
 
     // Step 3: call function on resolved object
-    const call_params = try std.fmt.allocPrint(arena,
+    const call_params = if (std.mem.eql(u8, action, "type") or std.mem.eql(u8, action, "fill")) blk: {
+        const v = value orelse {
+            jsonError("{s} requires a value", .{action});
+            std.process.exit(1);
+        };
+        const escaped_v = try escapeForJson(arena, v);
+        break :blk try std.fmt.allocPrint(
+            arena,
+            "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}},{{\"value\":{s}}}],\"returnByValue\":true}}",
+            .{ object_id, escaped_fn, escaped_v, if (std.mem.eql(u8, action, "type")) "true" else "false" },
+        );
+    } else if (std.mem.eql(u8, action, "select")) blk: {
+        const v = value orelse {
+            jsonError("select requires a value", .{});
+            std.process.exit(1);
+        };
+        const escaped_v = try escapeForJson(arena, v);
+        break :blk try std.fmt.allocPrint(
+            arena,
+            "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}}],\"returnByValue\":true}}",
+            .{ object_id, escaped_fn, escaped_v },
+        );
+    } else try std.fmt.allocPrint(
+        arena,
         "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}",
-        .{ object_id, escaped_fn });
+        .{ object_id, escaped_fn },
+    );
     const response = client.send(arena, protocol.Methods.runtime_call_function_on, call_params) catch |err| {
         jsonError("Runtime.callFunctionOn failed: {s}", .{@errorName(err)});
         std.process.exit(1);
@@ -640,12 +720,18 @@ fn cmdEval(arena: std.mem.Allocator, client: *CdpClient, expr: []const u8) !void
 }
 
 fn cmdText(arena: std.mem.Allocator, client: *CdpClient, selector: ?[]const u8) !void {
-    const params: []const u8 = if (selector) |sel|
-        try std.fmt.allocPrint(arena, "{{\"expression\":\"document.querySelector('{s}')?.innerText || null\",\"returnByValue\":true}}", .{sel})
-    else
-        @as([]const u8, "{\"expression\":\"document.body.innerText\",\"returnByValue\":true}");
+    const expr = if (selector) |sel| blk: {
+        const escaped_sel = try escapeForJson(arena, sel);
+        break :blk try std.fmt.allocPrint(arena,
+            "(() => {{ const el = document.querySelector(\"{s}\"); return el ? (el.innerText ?? '') : ''; }})()",
+            .{escaped_sel},
+        );
+    } else
+        @as([]const u8, "document.body ? document.body.innerText : ''");
+    const escaped_expr = try escapeForJson(arena, expr);
+    const params = try std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr});
 
-    const response = client.send(arena, protocol.Methods.runtime_evaluate, @constCast(params)) catch |err| {
+    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch |err| {
         jsonError("text failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
@@ -959,7 +1045,7 @@ fn cmdHeaders(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("headers eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    compat.writeToStdout(response);
+    compat.writeToStdout(unescapeJson(arena, extractCdpValue(response)));
     compat.writeToStdout("\n");
 }
 
@@ -993,7 +1079,7 @@ fn cmdAudit(arena: std.mem.Allocator, client: *CdpClient) !void {
         jsonError("audit eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);
     };
-    compat.writeToStdout(response);
+    compat.writeToStdout(unescapeJson(arena, extractCdpValue(response)));
     compat.writeToStdout("\n");
 }
 

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const a11y = @import("snapshot/a11y.zig");
 const markdown = @import("crawler/markdown.zig");
 const fetcher = @import("crawler/fetcher.zig");
@@ -25,9 +26,9 @@ const Bench = struct {
         for (0..@min(n / 10, 10)) |_| func();
 
         for (0..n) |i| {
-            const start = @as(u64, @intCast(@max(std.time.nanoTimestamp(), 0)));
+            const start = @as(u64, @intCast(@max(compat.nanoTimestamp(), 0)));
             func();
-            const end = @as(u64, @intCast(@max(std.time.nanoTimestamp(), 0)));
+            const end = @as(u64, @intCast(@max(compat.nanoTimestamp(), 0)));
             times[i] = end -| start;
         }
 

--- a/src/bridge/bridge.zig
+++ b/src/bridge/bridge.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 const CdpClient = @import("../cdp/client.zig").CdpClient;
 const HarRecorder = @import("../cdp/har.zig").HarRecorder;
 const A11yNode = @import("../snapshot/a11y.zig").A11yNode;
@@ -46,7 +47,7 @@ pub const Bridge = struct {
     cdp_clients: std.StringHashMap(*CdpClient),
     har_recorders: std.StringHashMap(*HarRecorder),
     debug_script_ids: std.StringHashMap([]const u8),
-    mu: std.Thread.RwLock,
+    mu: compat.PthreadRwLock,
 
     pub fn init(allocator: std.mem.Allocator) Bridge {
         return .{
@@ -250,16 +251,15 @@ pub const Bridge = struct {
         defer self.mu.unlockShared();
 
         var json_buf: std.ArrayList(u8) = .empty;
-        const writer = json_buf.writer(allocator);
-        try writer.writeAll("[");
+        try json_buf.appendSlice(allocator, "[");
         var it = self.tabs.valueIterator();
         var first = true;
         while (it.next()) |tab| {
-            if (!first) try writer.writeAll(",");
+            if (!first) try json_buf.appendSlice(allocator, ",");
             first = false;
-            try writer.print("{{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\",\"ws_url\":\"{s}\"}}", .{ tab.id, tab.url, tab.title, tab.ws_url });
+            try json_buf.print(allocator, "{{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\",\"ws_url\":\"{s}\"}}", .{ tab.id, tab.url, tab.title, tab.ws_url });
         }
-        try writer.writeAll("]");
+        try json_buf.appendSlice(allocator, "]");
         return json_buf.toOwnedSlice(allocator);
     }
 
@@ -286,8 +286,8 @@ pub const Bridge = struct {
                 .url = url,
                 .title = title,
                 .ws_url = ws_url,
-                .created_at = std.time.timestamp(),
-                .last_accessed = std.time.timestamp(),
+                .created_at = compat.timestampSeconds(),
+                .last_accessed = compat.timestampSeconds(),
             });
             count += 1;
             pos = obj_end + 1;

--- a/src/bridge/config.zig
+++ b/src/bridge/config.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 
 pub const Config = struct {
     host: []const u8,
@@ -16,9 +17,9 @@ pub const Config = struct {
 
 pub fn load() Config {
     return .{
-        .host = std.posix.getenv("HOST") orelse "127.0.0.1",
+        .host = compat.getenv("HOST") orelse "127.0.0.1",
         .port = parsePort() orelse 8080,
-        .cdp_url = std.posix.getenv("CDP_URL"),
+        .cdp_url = compat.getenv("CDP_URL"),
         .auth_secret = getenvAny(&.{ "KURI_SECRET", "BROWDIE_SECRET" }),
         .state_dir = getenvAny(&.{ "STATE_DIR" }) orelse ".kuri",
         .stale_tab_interval_s = parseU32("STALE_TAB_INTERVAL_S") orelse 30,
@@ -32,23 +33,23 @@ pub fn load() Config {
 
 fn getenvAny(names: []const []const u8) ?[]const u8 {
     for (names) |name| {
-        if (std.posix.getenv(name)) |value| return value;
+        if (compat.getenv(name)) |value| return value;
     }
     return null;
 }
 
 fn parsePort() ?u16 {
-    const val = std.posix.getenv("PORT") orelse return null;
+    const val = compat.getenv("PORT") orelse return null;
     return std.fmt.parseInt(u16, val, 10) catch null;
 }
 
 fn parseU32(name: []const u8) ?u32 {
-    const val = std.posix.getenv(name) orelse return null;
+    const val = compat.getenv(name) orelse return null;
     return std.fmt.parseInt(u32, val, 10) catch null;
 }
 
 fn parseBool(name: []const u8) ?bool {
-    const val = std.posix.getenv(name) orelse return null;
+    const val = compat.getenv(name) orelse return null;
     if (std.mem.eql(u8, val, "false") or std.mem.eql(u8, val, "0")) return false;
     return true;
 }

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const markdown = @import("crawler/markdown.zig");
 const validator = @import("crawler/validator.zig");
 
@@ -6,16 +7,14 @@ const version = "0.1.0";
 const user_agent = "kuri-browse/" ++ version;
 
 pub fn main() !void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
-    const args = try std.process.argsAlloc(gpa);
-    defer std.process.argsFree(gpa, args);
+    const args = try compat.collectArgs(gpa);
 
     if (args.len > 1 and (std.mem.eql(u8, args[1], "--version") or std.mem.eql(u8, args[1], "-V"))) {
-        const stdout = std.fs.File.stdout();
-        stdout.writeAll("kuri-browse " ++ version ++ "\n") catch {};
+        compat.writeToStdout("kuri-browse " ++ version ++ "\n");
         return;
     }
     if (args.len > 1 and (std.mem.eql(u8, args[1], "--help") or std.mem.eql(u8, args[1], "-h"))) {
@@ -104,7 +103,7 @@ const Browser = struct {
         _ = self.arena.reset(.retain_capacity);
         const arena = self.arena.allocator();
 
-        const fetch_start = std.time.nanoTimestamp();
+        const fetch_start = compat.nanoTimestamp();
         const html = fetchHttp(arena, resolved, user_agent) catch |err| {
             if (self.color) {
                 std.debug.print("\x1b[31m✗\x1b[0m fetch failed: {s}\n", .{@errorName(err)});
@@ -189,13 +188,12 @@ const Browser = struct {
         const md = self.current_md orelse return;
         const arena = self.arena.allocator();
         const rendered = renderColoredMarkdown(md, self.links.items, self.color, highlight, arena);
-        const stdout = std.fs.File.stdout();
-        stdout.writeAll("\n") catch {};
-        stdout.writeAll(rendered) catch {};
+        compat.writeToStdout("\n");
+        compat.writeToStdout(rendered);
     }
 
     fn repl(self: *Browser) void {
-        const stdin = std.fs.File.stdin();
+        const stdin_fd: std.posix.fd_t = 0;
         var line_buf: [4096]u8 = undefined;
 
         while (true) {
@@ -216,7 +214,7 @@ const Browser = struct {
                 }
             }
 
-            const line = readLine(stdin, &line_buf) orelse {
+            const line = readLine(stdin_fd, &line_buf) orelse {
                 std.debug.print("\n", .{});
                 return;
             };
@@ -258,8 +256,7 @@ const Browser = struct {
             } else if (std.mem.eql(u8, trimmed, ":l") or std.mem.eql(u8, trimmed, ":links")) {
                 const arena = self.arena.allocator();
                 const index_str = formatLinkIndex(self.links.items, self.color, arena);
-                const stdout = std.fs.File.stdout();
-                stdout.writeAll(index_str) catch {};
+                compat.writeToStdout(index_str);
             } else if (std.mem.eql(u8, trimmed, ":r") or std.mem.eql(u8, trimmed, ":reload")) {
                 if (self.current_url) |url| {
                     const arena = self.arena.allocator();
@@ -271,12 +268,12 @@ const Browser = struct {
             } else if (std.mem.eql(u8, trimmed, ":history") or std.mem.eql(u8, trimmed, ":hist")) {
                 self.history.print(self.color);
             } else if (std.mem.startsWith(u8, trimmed, ":go ") or std.mem.startsWith(u8, trimmed, ":open ")) {
-                const url_part = std.mem.trimLeft(u8, trimmed[if (std.mem.startsWith(u8, trimmed, ":go ")) @as(usize, 4) else 6..], " ");
+                const url_part = std.mem.trimStart(u8, trimmed[if (std.mem.startsWith(u8, trimmed, ":go ")) @as(usize, 4) else 6..], " ");
                 if (url_part.len > 0) {
                     self.navigate(url_part) catch {};
                 }
             } else if (std.mem.startsWith(u8, trimmed, ":search ") or std.mem.startsWith(u8, trimmed, ":s ")) {
-                const term = std.mem.trimLeft(u8, trimmed[if (std.mem.startsWith(u8, trimmed, ":s ")) @as(usize, 3) else 8..], " ");
+                const term = std.mem.trimStart(u8, trimmed[if (std.mem.startsWith(u8, trimmed, ":s ")) @as(usize, 3) else 8..], " ");
                 self.searchInPage(term);
             } else if (trimmed.len > 0 and trimmed[0] == '/') {
                 if (trimmed.len > 1) {
@@ -311,7 +308,7 @@ const Browser = struct {
         _ = self.arena.reset(.retain_capacity);
         const arena = self.arena.allocator();
 
-        const fetch_start = std.time.nanoTimestamp();
+        const fetch_start = compat.nanoTimestamp();
         const html = fetchHttp(arena, url, user_agent) catch |err| {
             if (self.color) {
                 std.debug.print("\x1b[31m✗\x1b[0m fetch failed: {s}\n", .{@errorName(err)});
@@ -458,7 +455,6 @@ const History = struct {
 
 fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool, highlight: ?[]const u8, allocator: std.mem.Allocator) []const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(allocator);
 
     var link_num: usize = 0;
     var i: usize = 0;
@@ -468,13 +464,13 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         if (highlight) |term| {
             if (i + term.len <= md.len and matchIgnoreCase(md[i .. i + term.len], term)) {
                 if (color) {
-                    w.writeAll("\x1b[30;43m") catch {};
-                    w.writeAll(md[i .. i + term.len]) catch {};
-                    w.writeAll("\x1b[0m") catch {};
+                    buf.appendSlice(allocator, "\x1b[30;43m") catch {};
+                    buf.appendSlice(allocator, md[i .. i + term.len]) catch {};
+                    buf.appendSlice(allocator, "\x1b[0m") catch {};
                 } else {
-                    w.writeAll(">>") catch {};
-                    w.writeAll(md[i .. i + term.len]) catch {};
-                    w.writeAll("<<") catch {};
+                    buf.appendSlice(allocator, ">>") catch {};
+                    buf.appendSlice(allocator, md[i .. i + term.len]) catch {};
+                    buf.appendSlice(allocator, "<<") catch {};
                 }
                 i += term.len;
                 continue;
@@ -487,11 +483,11 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
             while (j < md.len and md[j] == '#') : (j += 1) {}
             const eol = std.mem.indexOfScalarPos(u8, md, j, '\n') orelse md.len;
             if (color) {
-                w.writeAll("\x1b[1;36m") catch {};
-                w.writeAll(md[i..eol]) catch {};
-                w.writeAll("\x1b[0m") catch {};
+                buf.appendSlice(allocator, "\x1b[1;36m") catch {};
+                buf.appendSlice(allocator, md[i..eol]) catch {};
+                buf.appendSlice(allocator, "\x1b[0m") catch {};
             } else {
-                w.writeAll(md[i..eol]) catch {};
+                buf.appendSlice(allocator, md[i..eol]) catch {};
             }
             i = eol;
             continue;
@@ -504,12 +500,12 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
                 const display_num = findLinkNum(links, link_info.url, link_num);
 
                 if (color) {
-                    w.writeAll("\x1b[4;34m") catch {};
-                    w.writeAll(link_info.text) catch {};
-                    w.print("\x1b[0m \x1b[2;33m[{d}]\x1b[0m", .{display_num}) catch {};
+                    buf.appendSlice(allocator, "\x1b[4;34m") catch {};
+                    buf.appendSlice(allocator, link_info.text) catch {};
+                    buf.print(allocator, "\x1b[0m \x1b[2;33m[{d}]\x1b[0m", .{display_num}) catch {};
                 } else {
-                    w.writeAll(link_info.text) catch {};
-                    w.print(" [{d}]", .{display_num}) catch {};
+                    buf.appendSlice(allocator, link_info.text) catch {};
+                    buf.print(allocator, " [{d}]", .{display_num}) catch {};
                 }
                 i = link_info.end;
                 continue;
@@ -520,11 +516,11 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         if (md[i] == '`') {
             if (std.mem.indexOfScalarPos(u8, md, i + 1, '`')) |close| {
                 if (color) {
-                    w.writeAll("\x1b[33m") catch {};
-                    w.writeAll(md[i .. close + 1]) catch {};
-                    w.writeAll("\x1b[0m") catch {};
+                    buf.appendSlice(allocator, "\x1b[33m") catch {};
+                    buf.appendSlice(allocator, md[i .. close + 1]) catch {};
+                    buf.appendSlice(allocator, "\x1b[0m") catch {};
                 } else {
-                    w.writeAll(md[i .. close + 1]) catch {};
+                    buf.appendSlice(allocator, md[i .. close + 1]) catch {};
                 }
                 i = close + 1;
                 continue;
@@ -535,11 +531,11 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         if (i + 1 < md.len and md[i] == '*' and md[i + 1] == '*') {
             if (std.mem.indexOf(u8, md[i + 2 ..], "**")) |close_offset| {
                 if (color) {
-                    w.writeAll("\x1b[1m") catch {};
-                    w.writeAll(md[i .. i + 4 + close_offset]) catch {};
-                    w.writeAll("\x1b[0m") catch {};
+                    buf.appendSlice(allocator, "\x1b[1m") catch {};
+                    buf.appendSlice(allocator, md[i .. i + 4 + close_offset]) catch {};
+                    buf.appendSlice(allocator, "\x1b[0m") catch {};
                 } else {
-                    w.writeAll(md[i .. i + 4 + close_offset]) catch {};
+                    buf.appendSlice(allocator, md[i .. i + 4 + close_offset]) catch {};
                 }
                 i = i + 4 + close_offset;
                 continue;
@@ -550,11 +546,11 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         if (i + 2 < md.len and std.mem.startsWith(u8, md[i..], "```")) {
             if (std.mem.indexOf(u8, md[i + 3 ..], "```")) |close_offset| {
                 if (color) {
-                    w.writeAll("\x1b[2m") catch {};
-                    w.writeAll(md[i .. i + 6 + close_offset]) catch {};
-                    w.writeAll("\x1b[0m") catch {};
+                    buf.appendSlice(allocator, "\x1b[2m") catch {};
+                    buf.appendSlice(allocator, md[i .. i + 6 + close_offset]) catch {};
+                    buf.appendSlice(allocator, "\x1b[0m") catch {};
                 } else {
-                    w.writeAll(md[i .. i + 6 + close_offset]) catch {};
+                    buf.appendSlice(allocator, md[i .. i + 6 + close_offset]) catch {};
                 }
                 i = i + 6 + close_offset;
                 continue;
@@ -563,10 +559,10 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
 
         // Blockquote: > at start of line
         if ((i == 0 or md[i - 1] == '\n') and md[i] == '>') {
-            if (color) w.writeAll("\x1b[2;32m") catch {};
+            if (color) buf.appendSlice(allocator, "\x1b[2;32m") catch {};
             const eol = std.mem.indexOfScalarPos(u8, md, i, '\n') orelse md.len;
-            w.writeAll(md[i..eol]) catch {};
-            if (color) w.writeAll("\x1b[0m") catch {};
+            buf.appendSlice(allocator, md[i..eol]) catch {};
+            if (color) buf.appendSlice(allocator, "\x1b[0m") catch {};
             i = eol;
             continue;
         }
@@ -574,9 +570,9 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         // List item: - at start of line
         if ((i == 0 or md[i - 1] == '\n') and md[i] == '-' and i + 1 < md.len and md[i + 1] == ' ') {
             if (color) {
-                w.writeAll("\x1b[36m•\x1b[0m ") catch {};
+                buf.appendSlice(allocator, "\x1b[36m•\x1b[0m ") catch {};
             } else {
-                w.writeAll("• ") catch {};
+                buf.appendSlice(allocator, "• ") catch {};
             }
             i += 2;
             continue;
@@ -585,22 +581,22 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
         // Horizontal rule: ---
         if ((i == 0 or md[i - 1] == '\n') and i + 2 < md.len and std.mem.startsWith(u8, md[i..], "---")) {
             if (color) {
-                w.writeAll("\x1b[2m────────────────────────────────\x1b[0m\n") catch {};
+                buf.appendSlice(allocator, "\x1b[2m────────────────────────────────\x1b[0m\n") catch {};
             } else {
-                w.writeAll("--------------------------------\n") catch {};
+                buf.appendSlice(allocator, "--------------------------------\n") catch {};
             }
             i += 3;
             if (i < md.len and md[i] == '\n') i += 1;
             continue;
         }
 
-        w.writeByte(md[i]) catch {};
+        buf.append(allocator, md[i]) catch {};
         i += 1;
     }
 
     // Print link index
     if (links.len > 0) {
-        w.writeAll("\n") catch {};
+        buf.appendSlice(allocator, "\n") catch {};
         appendLinkIndex(&buf, links, color, allocator);
     }
 
@@ -608,18 +604,17 @@ fn renderColoredMarkdown(md: []const u8, links: []const []const u8, color: bool,
 }
 
 fn appendLinkIndex(buf: *std.ArrayList(u8), links: []const []const u8, color: bool, allocator: std.mem.Allocator) void {
-    const w = buf.writer(allocator);
     if (links.len == 0) return;
     if (color) {
-        w.writeAll("\n\x1b[2m───── Links ─────\x1b[0m\n") catch {};
+        buf.appendSlice(allocator, "\n\x1b[2m───── Links ─────\x1b[0m\n") catch {};
     } else {
-        w.writeAll("\n----- Links -----\n") catch {};
+        buf.appendSlice(allocator, "\n----- Links -----\n") catch {};
     }
     for (links, 1..) |link, num| {
         if (color) {
-            w.print("  \x1b[33m[{d}]\x1b[0m \x1b[4m{s}\x1b[0m\n", .{ num, link }) catch {};
+            buf.print(allocator, "  \x1b[33m[{d}]\x1b[0m \x1b[4m{s}\x1b[0m\n", .{ num, link }) catch {};
         } else {
-            w.print("  [{d}] {s}\n", .{ num, link }) catch {};
+            buf.print(allocator, "  [{d}] {s}\n", .{ num, link }) catch {};
         }
     }
 }
@@ -657,10 +652,10 @@ fn findLinkNum(links: []const []const u8, url: []const u8, fallback: usize) usiz
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-fn readLine(file: std.fs.File, buf: []u8) ?[]const u8 {
+fn readLine(fd: std.posix.fd_t, buf: []u8) ?[]const u8 {
     var i: usize = 0;
     while (i < buf.len) {
-        const bytes_read = file.read(buf[i .. i + 1]) catch return null;
+        const bytes_read = std.posix.read(fd, buf[i .. i + 1]) catch return null;
         if (bytes_read == 0) {
             if (i == 0) return null; // EOF with no data
             return buf[0..i];
@@ -677,17 +672,17 @@ fn truncateUrl(url: []const u8, max: usize) []const u8 {
 }
 
 fn shouldUseColor() bool {
-    if (std.posix.getenv("NO_COLOR")) |v| {
+    if (compat.getenv("NO_COLOR")) |v| {
         if (v.len > 0) return false;
     }
-    if (std.posix.getenv("TERM")) |term| {
+    if (compat.getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
-    return std.posix.isatty(std.fs.File.stderr().handle);
+    return std.c.isatty(2) != 0;
 }
 
 fn elapsed(start: i128) u64 {
-    const diff = std.time.nanoTimestamp() - start;
+    const diff = compat.nanoTimestamp() - start;
     return if (diff > 0) @as(u64, @intCast(diff)) / std.time.ns_per_ms else 0;
 }
 
@@ -765,7 +760,7 @@ fn printUsage() void {
 // ─── HTTP fetch ─────────────────────────────────────────────────────────────
 
 fn fetchHttp(allocator: std.mem.Allocator, url: []const u8, ua: []const u8) ![]const u8 {
-    var client: std.http.Client = .{ .allocator = allocator };
+    var client: std.http.Client = .{ .allocator = allocator, .io = std.Io.Threaded.global_single_threaded.io() };
     defer client.deinit();
 
     const uri = try std.Uri.parse(url);

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const compat = @import("compat.zig");
 const markdown = @import("crawler/markdown.zig");
 const validator = @import("crawler/validator.zig");
+const http_fetch = @import("util/http_fetch.zig");
 
 const version = "0.1.0";
 const user_agent = "kuri-browse/" ++ version;
@@ -12,6 +13,7 @@ pub fn main() !void {
     const gpa = gpa_impl.allocator();
 
     const args = try compat.collectArgs(gpa);
+    defer gpa.free(args);
 
     if (args.len > 1 and (std.mem.eql(u8, args[1], "--version") or std.mem.eql(u8, args[1], "-V"))) {
         compat.writeToStdout("kuri-browse " ++ version ++ "\n");
@@ -81,7 +83,8 @@ const Browser = struct {
     }
 
     fn navigate(self: *Browser, url: []const u8) !void {
-        const resolved = self.resolveUrl(url);
+        const resolved = try self.resolveUrlOwned(url);
+        defer self.allocator.free(resolved);
 
         // SSRF validation — block private IPs, metadata endpoints, non-HTTP schemes
         validator.validateUrl(resolved) catch |err| {
@@ -104,7 +107,7 @@ const Browser = struct {
         const arena = self.arena.allocator();
 
         const fetch_start = compat.nanoTimestamp();
-        const html = fetchHttp(arena, resolved, user_agent) catch |err| {
+        const html = http_fetch.fetchHttp(arena, resolved, user_agent) catch |err| {
             if (self.color) {
                 std.debug.print("\x1b[31m✗\x1b[0m fetch failed: {s}\n", .{@errorName(err)});
             } else {
@@ -141,47 +144,43 @@ const Browser = struct {
         }
     }
 
-    fn resolveUrl(self: *Browser, input: []const u8) []const u8 {
+    fn resolveUrlOwned(self: *Browser, input: []const u8) ![]u8 {
         // Already absolute
         if (std.mem.startsWith(u8, input, "http://") or std.mem.startsWith(u8, input, "https://")) {
-            return input;
+            return self.allocator.dupe(u8, input);
         }
 
         const base = self.current_url orelse {
-            // No current page — assume https://
-            const arena = self.arena.allocator();
-            return std.fmt.allocPrint(arena, "https://{s}", .{input}) catch input;
+            return std.fmt.allocPrint(self.allocator, "https://{s}", .{input});
         };
-
-        const arena = self.arena.allocator();
 
         // Protocol-relative: //example.com/path
         if (std.mem.startsWith(u8, input, "//")) {
-            const scheme_end = std.mem.indexOf(u8, base, "://") orelse return input;
-            return std.fmt.allocPrint(arena, "{s}:{s}", .{ base[0..scheme_end], input }) catch input;
+            const scheme_end = std.mem.indexOf(u8, base, "://") orelse return self.allocator.dupe(u8, input);
+            return std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ base[0..scheme_end], input });
         }
 
         // Extract scheme + host from base
-        const scheme_end = (std.mem.indexOf(u8, base, "://") orelse return input) + 3;
+        const scheme_end = (std.mem.indexOf(u8, base, "://") orelse return self.allocator.dupe(u8, input)) + 3;
         const host_end = std.mem.indexOfScalarPos(u8, base, scheme_end, '/') orelse base.len;
         const origin = base[0..host_end];
 
         // Absolute path: /path
         if (input.len > 0 and input[0] == '/') {
-            return std.fmt.allocPrint(arena, "{s}{s}", .{ origin, input }) catch input;
+            return std.fmt.allocPrint(self.allocator, "{s}{s}", .{ origin, input });
         }
 
         // Fragment: #section
         if (input.len > 0 and input[0] == '#') {
-            return base;
+            return self.allocator.dupe(u8, base);
         }
 
         // Relative path: resolve against current directory
-        const last_slash = std.mem.lastIndexOfScalar(u8, base, '/') orelse return input;
+        const last_slash = std.mem.lastIndexOfScalar(u8, base, '/') orelse return self.allocator.dupe(u8, input);
         if (last_slash < scheme_end) {
-            return std.fmt.allocPrint(arena, "{s}/{s}", .{ origin, input }) catch input;
+            return std.fmt.allocPrint(self.allocator, "{s}/{s}", .{ origin, input });
         }
-        return std.fmt.allocPrint(arena, "{s}{s}", .{ base[0 .. last_slash + 1], input }) catch input;
+        return std.fmt.allocPrint(self.allocator, "{s}{s}", .{ base[0 .. last_slash + 1], input });
     }
 
     fn renderPage(self: *Browser, highlight: ?[]const u8) void {
@@ -259,9 +258,7 @@ const Browser = struct {
                 compat.writeToStdout(index_str);
             } else if (std.mem.eql(u8, trimmed, ":r") or std.mem.eql(u8, trimmed, ":reload")) {
                 if (self.current_url) |url| {
-                    const arena = self.arena.allocator();
-                    const url_copy = arena.dupe(u8, url) catch url;
-                    self.navigateNoHistory(url_copy);
+                    self.navigateNoHistory(url);
                 } else {
                     std.debug.print("no page to reload\n", .{});
                 }
@@ -299,17 +296,21 @@ const Browser = struct {
     }
 
     fn navigateNoHistory(self: *Browser, url: []const u8) void {
+        const stable_url_buf = self.allocator.dupe(u8, url) catch null;
+        defer if (stable_url_buf) |buf| self.allocator.free(buf);
+        const stable_url = stable_url_buf orelse url;
+
         if (self.color) {
-            std.debug.print("\x1b[2m→\x1b[0m loading \x1b[4m{s}\x1b[0m\n", .{url});
+            std.debug.print("\x1b[2m→\x1b[0m loading \x1b[4m{s}\x1b[0m\n", .{stable_url});
         } else {
-            std.debug.print("loading {s}\n", .{url});
+            std.debug.print("loading {s}\n", .{stable_url});
         }
 
         _ = self.arena.reset(.retain_capacity);
         const arena = self.arena.allocator();
 
         const fetch_start = compat.nanoTimestamp();
-        const html = fetchHttp(arena, url, user_agent) catch |err| {
+        const html = http_fetch.fetchHttp(arena, stable_url, user_agent) catch |err| {
             if (self.color) {
                 std.debug.print("\x1b[31m✗\x1b[0m fetch failed: {s}\n", .{@errorName(err)});
             } else {
@@ -326,7 +327,7 @@ const Browser = struct {
 
         self.current_html = html;
         self.current_md = md;
-        self.current_url = arena.dupe(u8, url) catch url;
+        self.current_url = arena.dupe(u8, stable_url) catch stable_url;
         self.search_term = null;
 
         self.renderPage(null);
@@ -755,43 +756,6 @@ fn printUsage() void {
         \\    NO_COLOR          Disable colored output (https://no-color.org)
         \\
     , .{});
-}
-
-// ─── HTTP fetch ─────────────────────────────────────────────────────────────
-
-fn fetchHttp(allocator: std.mem.Allocator, url: []const u8, ua: []const u8) ![]const u8 {
-    var client: std.http.Client = .{ .allocator = allocator, .io = std.Io.Threaded.global_single_threaded.io() };
-    defer client.deinit();
-
-    const uri = try std.Uri.parse(url);
-
-    var req = try client.request(.GET, uri, .{
-        .extra_headers = &.{
-            .{ .name = "User-Agent", .value = ua },
-            .{ .name = "Accept", .value = "text/html,application/xhtml+xml,*/*" },
-            .{ .name = "Accept-Encoding", .value = "gzip, deflate" },
-        },
-    });
-    defer req.deinit();
-
-    try req.sendBodiless();
-
-    var redirect_buf: [8192]u8 = undefined;
-    var response = try req.receiveHead(&redirect_buf);
-
-    if (response.head.status != .ok) {
-        std.debug.print("HTTP {d}\n", .{@intFromEnum(response.head.status)});
-        return error.HttpError;
-    }
-
-    var body: std.ArrayList(u8) = .empty;
-    var transfer_buf: [8192]u8 = undefined;
-    var decompress: std.http.Decompress = undefined;
-    var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
-    const reader = response.readerDecompressing(&transfer_buf, &decompress, &decompress_buf);
-    try reader.appendRemainingUnlimited(allocator, &body);
-
-    return body.items;
 }
 
 /// Extract all href values from <a> tags in HTML.

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -7,13 +7,14 @@ const http_fetch = @import("util/http_fetch.zig");
 const version = "0.1.0";
 const user_agent = "kuri-browse/" ++ version;
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
-    const args = try compat.collectArgs(gpa);
-    defer gpa.free(args);
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const args = try init.args.toSlice(arena_impl.allocator());
 
     if (args.len > 1 and (std.mem.eql(u8, args[1], "--version") or std.mem.eql(u8, args[1], "-V"))) {
         compat.writeToStdout("kuri-browse " ++ version ++ "\n");

--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const protocol = @import("protocol.zig");
 const WebSocketClient = @import("websocket.zig").WebSocketClient;
+const compat = @import("../compat.zig");
 
 pub const EventBuffer = struct {
     const BufferedEvent = struct {
@@ -24,8 +25,9 @@ pub const EventBuffer = struct {
 
     pub fn push(self: *EventBuffer, owner: std.mem.Allocator, event: []const u8) void {
         if (self.items.items.len >= 256) {
-            // Drop oldest event — copy to our own allocator so we don't hold arena refs
-            _ = self.items.orderedRemove(0);
+            // Drop oldest event — free its data before removing
+            const oldest = self.items.orderedRemove(0);
+            oldest.owner.free(oldest.data);
         }
         // Dupe event data into our persistent allocator so it survives arena resets
         const duped = self.allocator.dupe(u8, event) catch {
@@ -74,7 +76,7 @@ pub const CdpClient = struct {
     next_id: std.atomic.Value(u32),
     ws: ?WebSocketClient,
     connected: bool,
-    mu: std.Thread.Mutex,
+    mu: compat.PthreadMutex,
 
     // Owned buffers for WebSocket I/O
     ws_read_buf: [512 * 1024]u8,
@@ -235,8 +237,8 @@ pub const CdpClient = struct {
         var ws = &(self.ws orelse return);
         const drain_timeout = std.posix.timeval{ .sec = timeout_sec, .usec = 0 };
         const orig_timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-        std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&drain_timeout)) catch {};
-        defer std.posix.setsockopt(ws.stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&orig_timeout)) catch {};
+        std.posix.setsockopt(ws.fd, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&drain_timeout)) catch {};
+        defer std.posix.setsockopt(ws.fd, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&orig_timeout)) catch {};
 
         var drained: u32 = 0;
         while (drained < 2000) : (drained += 1) {

--- a/src/cdp/har.zig
+++ b/src/cdp/har.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const CdpClient = @import("client.zig").CdpClient;
+const compat = @import("../compat.zig");
 
 /// HAR (HTTP Archive) recorder using CDP Network domain events.
 /// Captures request/response pairs with timing, headers, and status.
@@ -135,13 +136,13 @@ pub const HarRecorder = struct {
     /// Serialize current entries to HAR 1.2 JSON format.
     pub fn toJson(self: *HarRecorder) ![]const u8 {
         var buf: std.ArrayList(u8) = .empty;
-        const w = buf.writer(self.allocator);
 
-        try w.writeAll("{\"log\":{\"version\":\"1.2\",\"creator\":{\"name\":\"browdie\",\"version\":\"0.1.0\"},\"entries\":[");
+        try buf.appendSlice(self.allocator, "{\"log\":{\"version\":\"1.2\",\"creator\":{\"name\":\"browdie\",\"version\":\"0.1.0\"},\"entries\":[");
 
         for (self.entries.items, 0..) |entry, i| {
-            if (i > 0) try w.writeAll(",");
-            try w.print(
+            if (i > 0) try buf.appendSlice(self.allocator, ",");
+            try buf.print(
+                self.allocator,
                 "{{\"startedDateTime\":\"{d}\",\"time\":{d}," ++
                     "\"request\":{{\"method\":\"{s}\",\"url\":\"{s}\",\"bodySize\":{d}}}," ++
                     "\"response\":{{\"status\":{d},\"statusText\":\"{s}\",\"content\":{{\"mimeType\":\"{s}\",\"size\":{d}}}}}}}",
@@ -159,7 +160,7 @@ pub const HarRecorder = struct {
             );
         }
 
-        try w.writeAll("]}}");
+        try buf.appendSlice(self.allocator, "]}}");
         return buf.toOwnedSlice(self.allocator);
     }
 
@@ -207,7 +208,7 @@ pub const HarRecorder = struct {
             const pending = PendingRequest{
                 .url = owned_url,
                 .method = owned_method,
-                .timestamp = std.time.timestamp(),
+                .timestamp = compat.timestampSeconds(),
                 .headers_json = owned_headers,
                 .post_data = owned_post,
             };
@@ -248,7 +249,7 @@ pub const HarRecorder = struct {
                 .status_text = status_text,
                 .mime_type = mime,
                 .timestamp = pending.timestamp,
-                .duration_ms = std.time.timestamp() - pending.timestamp,
+                .duration_ms = compat.timestampSeconds() - pending.timestamp,
                 .request_size = 0,
                 .response_size = 0,
                 .request_headers = pending.headers_json,

--- a/src/cdp/stealth.zig
+++ b/src/cdp/stealth.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 
 /// Stealth JS script embedded at comptime.
 pub const stealth_script = @embedFile("js/stealth.js");
@@ -14,7 +15,7 @@ pub const user_agents = [_][]const u8{
 
 /// Get a pseudo-random user agent based on timestamp.
 pub fn randomUserAgent() []const u8 {
-    const ts: u64 = @intCast(std.time.timestamp());
+    const ts: u64 = @intCast(compat.timestampSeconds());
     return user_agents[ts % user_agents.len];
 }
 

--- a/src/cdp/websocket.zig
+++ b/src/cdp/websocket.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
-const net = std.net;
-const Io = std.Io;
 const crypto = std.crypto;
+const compat = @import("../compat.zig");
+
+const c_connect = @extern(*const fn (std.c.fd_t, *const anyopaque, std.posix.socklen_t) callconv(.c) c_int, .{ .name = "connect" });
 
 /// Pure Zig WebSocket client for CDP communication.
 /// Implements RFC 6455: HTTP upgrade handshake, masked client frames, unmasked server reads.
 pub const WebSocketClient = struct {
     allocator: std.mem.Allocator,
-    stream: net.Stream,
+    fd: std.posix.fd_t,
     connected: bool,
 
     // Buffers owned by caller (stack or heap)
@@ -30,19 +31,30 @@ pub const WebSocketClient = struct {
 
         // Resolve localhost to 127.0.0.1 — resolveIp fails on some systems
         const resolved_host = if (std.mem.eql(u8, parsed.host, "localhost")) "127.0.0.1" else parsed.host;
-        const address = net.Address.parseIp4(resolved_host, parsed.port) catch return Error.ConnectionFailed;
-        const stream = net.tcpConnectToAddress(address) catch return Error.ConnectionFailed;
-        errdefer stream.close();
+        const ip_addr = parseIp4(resolved_host) orelse return Error.ConnectionFailed;
+
+        const raw_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);
+        if (raw_fd < 0) return Error.ConnectionFailed;
+        const fd: std.posix.fd_t = raw_fd;
+        errdefer _ = std.c.close(fd);
+
+        var addr: std.posix.sockaddr.in = .{
+            .port = std.mem.nativeToBig(u16, parsed.port),
+            .addr = ip_addr,
+        };
+        if (c_connect(fd, @ptrCast(&addr), @sizeOf(std.posix.sockaddr.in)) != 0) {
+            return Error.ConnectionFailed;
+        }
 
         // Set read timeout so we don't block forever
         const timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-        std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {
+        std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {
             return Error.ConnectionFailed;
         };
 
         var ws = WebSocketClient{
             .allocator = allocator,
-            .stream = stream,
+            .fd = fd,
             .connected = false,
             .read_buf = read_buf,
             .write_buf = write_buf,
@@ -79,7 +91,7 @@ pub const WebSocketClient = struct {
             self.writeFrame(0x8, &.{}) catch {};
             self.connected = false;
         }
-        self.stream.close();
+        _ = std.c.close(self.fd);
     }
 
     // --- Internal ---
@@ -112,10 +124,36 @@ pub const WebSocketClient = struct {
         }
     }
 
+    /// Parse an IPv4 dotted-decimal string into a network-byte-order u32.
+    fn parseIp4(s: []const u8) ?u32 {
+        var octets: [4]u8 = undefined;
+        var octet_idx: usize = 0;
+        var cur: u16 = 0;
+        var digit_count: u8 = 0;
+        for (s) |ch| {
+            if (ch == '.') {
+                if (digit_count == 0 or octet_idx >= 3) return null;
+                octets[octet_idx] = @intCast(cur);
+                octet_idx += 1;
+                cur = 0;
+                digit_count = 0;
+            } else if (ch >= '0' and ch <= '9') {
+                cur = cur * 10 + (ch - '0');
+                if (cur > 255) return null;
+                digit_count += 1;
+            } else {
+                return null;
+            }
+        }
+        if (digit_count == 0 or octet_idx != 3) return null;
+        octets[3] = @intCast(cur);
+        return @as(u32, octets[0]) << 24 | @as(u32, octets[1]) << 16 | @as(u32, octets[2]) << 8 | @as(u32, octets[3]);
+    }
+
     fn doHandshake(self: *WebSocketClient, host: []const u8, port: u16, path: []const u8) !void {
         // Generate random key for Sec-WebSocket-Key
         var key_bytes: [16]u8 = undefined;
-        crypto.random.bytes(&key_bytes);
+        compat.randomBytes(&key_bytes);
         var key_buf: [24]u8 = undefined;
         const key = std.base64.standard.Encoder.encode(&key_buf, &key_bytes);
 
@@ -131,10 +169,10 @@ pub const WebSocketClient = struct {
             "\r\n", .{ path, host, port, key }) catch return Error.HandshakeFailed;
 
         // Send upgrade request via raw write
-        self.stream.writeAll(req) catch return Error.WriteFailed;
+        self.writeAll(req) catch return Error.WriteFailed;
 
         // Read response - look for "101 Switching Protocols"
-        const n = self.stream.read(self.read_buf) catch return Error.ReadFailed;
+        const n = self.rawRead(self.read_buf) catch return Error.ReadFailed;
         if (n == 0) return Error.HandshakeFailed;
 
         const response = self.read_buf[0..n];
@@ -149,6 +187,19 @@ pub const WebSocketClient = struct {
         {
             return Error.HandshakeFailed;
         }
+    }
+
+    fn writeAll(self: *WebSocketClient, data: []const u8) !void {
+        var sent: usize = 0;
+        while (sent < data.len) {
+            const n = std.c.write(self.fd, data.ptr + sent, data.len - sent);
+            if (n <= 0) return Error.WriteFailed;
+            sent += @intCast(n);
+        }
+    }
+
+    fn rawRead(self: *WebSocketClient, buf: []u8) !usize {
+        return std.posix.read(self.fd, buf) catch return Error.ReadFailed;
     }
 
     fn writeFrame(self: *WebSocketClient, opcode: u8, data: []const u8) !void {
@@ -177,12 +228,12 @@ pub const WebSocketClient = struct {
 
         // Generate masking key
         var mask_key: [4]u8 = undefined;
-        crypto.random.bytes(&mask_key);
+        compat.randomBytes(&mask_key);
         @memcpy(frame_buf[header_len .. header_len + 4], &mask_key);
         header_len += 4;
 
         // Send header
-        self.stream.writeAll(frame_buf[0..header_len]) catch return Error.WriteFailed;
+        self.writeAll(frame_buf[0..header_len]) catch return Error.WriteFailed;
 
         // Send masked payload in chunks to avoid allocating
         var chunk: [4096]u8 = undefined;
@@ -195,7 +246,7 @@ pub const WebSocketClient = struct {
             for (0..chunk_size) |i| {
                 chunk[i] ^= mask_key[(offset + i) % 4];
             }
-            self.stream.writeAll(chunk[0..chunk_size]) catch return Error.WriteFailed;
+            self.writeAll(chunk[0..chunk_size]) catch return Error.WriteFailed;
             offset += chunk_size;
         }
     }
@@ -330,7 +381,7 @@ pub const WebSocketClient = struct {
     fn readExact(self: *WebSocketClient, buf: []u8) !void {
         var total: usize = 0;
         while (total < buf.len) {
-            const n = self.stream.read(buf[total..]) catch return Error.ReadFailed;
+            const n = self.rawRead(buf[total..]) catch return Error.ReadFailed;
             if (n == 0) return Error.ConnectionClosed;
             total += n;
         }

--- a/src/cdp/websocket.zig
+++ b/src/cdp/websocket.zig
@@ -147,7 +147,12 @@ pub const WebSocketClient = struct {
         }
         if (digit_count == 0 or octet_idx != 3) return null;
         octets[3] = @intCast(cur);
-        return @as(u32, octets[0]) << 24 | @as(u32, octets[1]) << 16 | @as(u32, octets[2]) << 8 | @as(u32, octets[3]);
+        const host_order =
+            @as(u32, octets[0]) << 24 |
+            @as(u32, octets[1]) << 16 |
+            @as(u32, octets[2]) << 8 |
+            @as(u32, octets[3]);
+        return std.mem.nativeToBig(u32, host_order);
     }
 
     fn doHandshake(self: *WebSocketClient, host: []const u8, port: u16, path: []const u8) !void {
@@ -416,4 +421,9 @@ test "parseWsUrl valid URL" {
 
 test "parseWsUrl rejects non-ws scheme" {
     try std.testing.expectError(error.InvalidCharacter, WebSocketClient.parseWsUrl("http://localhost:9222/path"));
+}
+
+test "parseIp4 stores bytes in network order" {
+    const ip = WebSocketClient.parseIp4("127.0.0.1") orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualSlices(u8, &.{ 127, 0, 0, 1 }, std.mem.asBytes(&ip));
 }

--- a/src/chrome/launcher.zig
+++ b/src/chrome/launcher.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const config = @import("../bridge/config.zig");
+const compat = @import("../compat.zig");
 
 /// 🧁 Chrome lifecycle manager — launch, supervise, restart.
 /// Handles spawning headless Chrome with CDP debugging port,
@@ -7,7 +8,7 @@ const config = @import("../bridge/config.zig");
 pub const Launcher = struct {
     allocator: std.mem.Allocator,
     cdp_port: u16,
-    child: ?std.process.Child,
+    child_pid: ?std.c.pid_t,
     ws_url_buf: [512]u8,
     ws_url_len: usize,
     restarts: u8,
@@ -60,7 +61,7 @@ pub const Launcher = struct {
         return .{
             .allocator = allocator,
             .cdp_port = default_cdp_port,
-            .child = null,
+            .child_pid = null,
             .ws_url_buf = undefined,
             .ws_url_len = 0,
             .restarts = 0,
@@ -118,7 +119,7 @@ pub const Launcher = struct {
             try argv_list.append(self.allocator, "--disable-gpu");
         } else {
             // Visible mode: needs a data dir for CDP to work on macOS
-            const home = std.posix.getenv("HOME") orelse "/tmp";
+            const home = compat.getenv("HOME") orelse "/tmp";
             const data_dir = try std.fmt.allocPrint(self.allocator, "--user-data-dir={s}/.kuri/chrome-profile", .{home});
             try argv_list.append(self.allocator, data_dir);
         }
@@ -150,25 +151,38 @@ pub const Launcher = struct {
             for (flags) |f| try argv_list.append(self.allocator, f);
         }
 
-        var child = std.process.Child.init(argv_list.items, self.allocator);
-        child.stderr_behavior = .Ignore;
-        child.stdout_behavior = .Ignore;
+        // Build null-terminated argv for execv
+        const argv_z = try self.allocator.alloc(?[*:0]const u8, argv_list.items.len + 1);
+        defer self.allocator.free(argv_z);
+        for (argv_list.items, 0..) |arg, i| {
+            argv_z[i] = @ptrCast(arg.ptr);
+        }
+        argv_z[argv_list.items.len] = null;
 
-        try child.spawn();
-        self.child = child;
+        const pid = std.c.fork();
+        if (pid < 0) return error.ForkFailed;
 
-        // Free argv-owned strings now that spawn has completed and child has exec'd.
-        // The Child struct no longer needs these after spawn().
+        if (pid == 0) {
+            // Child: redirect stdout/stderr to /dev/null
+            const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(c_uint, 0));
+            if (devnull >= 0) {
+                _ = std.c.dup2(devnull, 1);
+                _ = std.c.dup2(devnull, 2);
+                _ = std.c.close(devnull);
+            }
+            _ = std.c.execve(argv_z[0].?, @ptrCast(argv_z.ptr), @ptrCast(std.c.environ));
+            std.c.exit(127);
+        }
+
+        self.child_pid = pid;
+
+        // Free argv-owned strings now that fork+exec has completed.
         self.allocator.free(port_flag);
         if (!self.headless) {
-            // data_dir was appended at index 1 (after chrome_bin)
-            if (argv_list.items.len > 1) {
-                // Find and free the data_dir string (starts with --user-data-dir=)
-                for (argv_list.items) |item| {
-                    if (std.mem.startsWith(u8, item, "--user-data-dir=")) {
-                        self.allocator.free(item);
-                        break;
-                    }
+            for (argv_list.items) |item| {
+                if (std.mem.startsWith(u8, item, "--user-data-dir=")) {
+                    self.allocator.free(item);
+                    break;
                 }
             }
         }
@@ -176,7 +190,6 @@ pub const Launcher = struct {
             for (flags) |f| self.allocator.free(f);
             self.allocator.free(flags);
         }
-        // Free proxy flag if allocated
         if (self.proxy) |_| {
             for (argv_list.items) |item| {
                 if (std.mem.startsWith(u8, item, "--proxy-server=")) {
@@ -187,11 +200,11 @@ pub const Launcher = struct {
         }
 
         std.log.info("launched Chrome (pid={d}) on CDP port {d}", .{
-            child.id,
+            pid,
             self.cdp_port,
         });
         // Give Chrome a moment to start
-        std.Thread.sleep(500 * std.time.ns_per_ms);
+        compat.threadSleep(500 * std.time.ns_per_ms);
     }
 
     /// Check if Chrome is alive by probing /json/version on the CDP port.
@@ -212,9 +225,9 @@ pub const Launcher = struct {
         if (status.alive) return;
 
         // Chrome appears dead
-        if (self.child) |*child| {
-            _ = child.wait() catch {};
-            self.child = null;
+        if (self.child_pid) |pid| {
+            _ = std.c.waitpid(pid, null, 0);
+            self.child_pid = null;
         }
 
         if (self.restarts >= max_restarts) {
@@ -233,10 +246,10 @@ pub const Launcher = struct {
 
     /// Shut down the managed Chrome process.
     pub fn deinit(self: *Launcher) void {
-        if (self.child) |*child| {
-            _ = child.kill() catch {};
-            _ = child.wait() catch {};
-            self.child = null;
+        if (self.child_pid) |pid| {
+            _ = std.c.kill(pid, std.c.SIG.KILL);
+            _ = std.c.waitpid(pid, null, 0);
+            self.child_pid = null;
         }
     }
 
@@ -245,7 +258,7 @@ pub const Launcher = struct {
         for (chrome_paths) |path| {
             // For absolute paths, check file existence
             if (path[0] == '/') {
-                std.fs.cwd().access(path, .{}) catch continue;
+                if (!compat.cwdAccess(path)) continue;
                 return path;
             }
             // For bare names, assume PATH lookup will work
@@ -290,7 +303,7 @@ pub const Launcher = struct {
                 try self.storeWsUrl(status.ws_url.?);
                 return;
             }
-            std.Thread.sleep(250 * std.time.ns_per_ms);
+            compat.threadSleep(250 * std.time.ns_per_ms);
         }
         return error.ConnectionRefused;
     }
@@ -358,10 +371,7 @@ pub fn findFreePort(start_port: u16) !u16 {
 
 /// Check if a TCP port is currently in use by attempting to connect.
 pub fn isPortInUse(port: u16) bool {
-    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
-    var stream = std.net.tcpConnectToAddress(addr) catch return false;
-    stream.close();
-    return true;
+    return compat.isPortInUse(port);
 }
 
 // ── HTTP health probe ───────────────────────────────────────────────────
@@ -374,7 +384,8 @@ fn httpProbeJsonVersion(port: u16) Launcher.ChromeStatus {
 
 fn httpProbe(raw_url: []const u8, host: []const u8, port: u16, path: []const u8) Launcher.ChromeStatus {
     const connect_host = normalizeHost(host);
-    var stream = std.net.tcpConnectToHost(std.heap.page_allocator, connect_host, port) catch
+    _ = connect_host;
+    var stream = compat.tcpConnectToIp4(port) catch
         return .{ .alive = false, .ws_url = null };
 
     defer stream.close();
@@ -573,7 +584,7 @@ test "healthCheck returns not alive for unbound port" {
     var launcher = Launcher{
         .allocator = std.testing.allocator,
         .cdp_port = 19876,
-        .child = null,
+        .child_pid = null,
         .ws_url_buf = undefined,
         .ws_url_len = 0,
         .restarts = 0,

--- a/src/chrome/launcher.zig
+++ b/src/chrome/launcher.zig
@@ -152,12 +152,23 @@ pub const Launcher = struct {
         }
 
         // Build null-terminated argv for execv
-        const argv_z = try self.allocator.alloc(?[*:0]const u8, argv_list.items.len + 1);
-        defer self.allocator.free(argv_z);
-        for (argv_list.items, 0..) |arg, i| {
-            argv_z[i] = @ptrCast(arg.ptr);
+        var argv_storage: std.ArrayList([:0]u8) = .empty;
+        defer {
+            for (argv_storage.items) |arg| self.allocator.free(arg);
+            argv_storage.deinit(self.allocator);
         }
-        argv_z[argv_list.items.len] = null;
+        for (argv_list.items) |arg| {
+            const arg_z = try self.allocator.allocSentinel(u8, arg.len, 0);
+            @memcpy(arg_z[0..arg.len], arg);
+            try argv_storage.append(self.allocator, arg_z);
+        }
+
+        const argv_z = try self.allocator.alloc(?[*:0]const u8, argv_storage.items.len + 1);
+        defer self.allocator.free(argv_z);
+        for (argv_storage.items, 0..) |arg, i| {
+            argv_z[i] = arg.ptr;
+        }
+        argv_z[argv_storage.items.len] = null;
 
         const pid = std.c.fork();
         if (pid < 0) return error.ForkFailed;
@@ -170,7 +181,7 @@ pub const Launcher = struct {
                 _ = std.c.dup2(devnull, 2);
                 _ = std.c.close(devnull);
             }
-            _ = std.c.execve(argv_z[0].?, @ptrCast(argv_z.ptr), @ptrCast(std.c.environ));
+            _ = compat.execvp(argv_z[0].?, @ptrCast(argv_z.ptr));
             std.c.exit(127);
         }
 
@@ -297,13 +308,13 @@ pub const Launcher = struct {
 
     fn waitForDebuggerUrl(self: *Launcher) !void {
         var attempts: u8 = 0;
-        while (attempts < 20) : (attempts += 1) {
+        while (attempts < 30) : (attempts += 1) {
             const status = self.healthCheck();
             if (status.alive and status.ws_url != null) {
                 try self.storeWsUrl(status.ws_url.?);
                 return;
             }
-            compat.threadSleep(250 * std.time.ns_per_ms);
+            compat.threadSleep(500 * std.time.ns_per_ms);
         }
         return error.ConnectionRefused;
     }

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,395 @@
+/// Zig 0.16 compatibility shims for removed stdlib APIs.
+const std = @import("std");
+
+// --- Time ---
+
+pub fn timestampSeconds() i64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.REALTIME, &ts);
+    return ts.sec;
+}
+
+pub fn milliTimestamp() i64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.REALTIME, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
+pub fn nanoTimestamp() i128 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(.REALTIME, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
+// --- Threading ---
+
+pub fn threadSleep(ns: u64) void {
+    const ts = std.c.timespec{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    _ = std.c.nanosleep(&ts, null);
+}
+
+pub const PthreadMutex = struct {
+    inner: std.c.pthread_mutex_t = std.c.PTHREAD_MUTEX_INITIALIZER,
+
+    pub fn lock(m: *PthreadMutex) void {
+        _ = std.c.pthread_mutex_lock(&m.inner);
+    }
+    pub fn unlock(m: *PthreadMutex) void {
+        _ = std.c.pthread_mutex_unlock(&m.inner);
+    }
+    pub fn tryLock(m: *PthreadMutex) bool {
+        return @intFromEnum(std.c.pthread_mutex_trylock(&m.inner)) == 0;
+    }
+};
+
+pub const PthreadRwLock = struct {
+    inner: std.c.pthread_rwlock_t = .{},
+
+    pub fn lock(rw: *PthreadRwLock) void {
+        _ = std.c.pthread_rwlock_wrlock(&rw.inner);
+    }
+    pub fn unlock(rw: *PthreadRwLock) void {
+        _ = std.c.pthread_rwlock_unlock(&rw.inner);
+    }
+    pub fn lockShared(rw: *PthreadRwLock) void {
+        _ = std.c.pthread_rwlock_rdlock(&rw.inner);
+    }
+    pub fn unlockShared(rw: *PthreadRwLock) void {
+        _ = std.c.pthread_rwlock_unlock(&rw.inner);
+    }
+};
+
+// --- Random ---
+
+extern "c" fn arc4random_buf(buf: *anyopaque, nbytes: usize) void;
+
+pub fn randomBytes(buf: []u8) void {
+    arc4random_buf(buf.ptr, buf.len);
+}
+
+// --- Process Args ---
+
+extern "c" fn _NSGetArgc() *c_int;
+extern "c" fn _NSGetArgv() *[*][*:0]const u8;
+
+pub fn getArgv() struct { argc: usize, argv: [*][*:0]const u8 } {
+    return .{
+        .argc = @intCast(_NSGetArgc().*),
+        .argv = _NSGetArgv().*,
+    };
+}
+
+pub fn collectArgs(allocator: std.mem.Allocator) ![]const []const u8 {
+    const info = getArgv();
+    const args = try allocator.alloc([]const u8, info.argc);
+    for (0..info.argc) |i| {
+        args[i] = std.mem.sliceTo(info.argv[i], 0);
+    }
+    return args;
+}
+
+// --- Environment ---
+
+pub fn getenv(name: []const u8) ?[]const u8 {
+    // std.c.getenv needs a sentinel-terminated string. For comptime-known keys
+    // the caller can pass a literal. For runtime keys we need a small buffer.
+    if (name.len > 255) return null;
+    var buf: [256]u8 = undefined;
+    @memcpy(buf[0..name.len], name);
+    buf[name.len] = 0;
+    const key: [*:0]const u8 = buf[0..name.len :0];
+    const val = std.c.getenv(key) orelse return null;
+    return std.mem.sliceTo(val, 0);
+}
+
+// --- Filesystem (replaces removed std.fs.cwd / std.fs.File) ---
+
+pub fn writeToStdout(data: []const u8) void {
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(1, data[sent..].ptr, data.len - sent);
+        if (n <= 0) break;
+        sent += @intCast(n);
+    }
+}
+
+pub fn writeToStderr(data: []const u8) void {
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(2, data[sent..].ptr, data.len - sent);
+        if (n <= 0) break;
+        sent += @intCast(n);
+    }
+}
+
+// --- Filesystem (cwd operations using C calls) ---
+
+pub fn cwdCreateFile(path: []const u8) !std.c.fd_t {
+    var buf: [4096]u8 = undefined;
+    if (path.len >= buf.len) return error.NameTooLong;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const fd = std.c.open(buf[0..path.len :0], .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, @as(std.c.mode_t, 0o644));
+    if (fd < 0) return error.FileNotFound;
+    return fd;
+}
+
+pub fn cwdReadFile(allocator: std.mem.Allocator, path: []const u8, max_size: usize) ![]u8 {
+    var buf: [4096]u8 = undefined;
+    if (path.len >= buf.len) return error.NameTooLong;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const fd = std.c.open(buf[0..path.len :0], .{ .ACCMODE = .RDONLY }, @as(std.c.mode_t, 0));
+    if (fd < 0) return error.FileNotFound;
+    defer _ = std.c.close(fd);
+
+    var result = std.ArrayList(u8).empty;
+    var read_buf: [8192]u8 = undefined;
+    while (true) {
+        const n = std.c.read(fd, &read_buf, read_buf.len);
+        if (n <= 0) break;
+        const bytes: usize = @intCast(n);
+        if (result.items.len + bytes > max_size) return error.FileTooBig;
+        try result.appendSlice(allocator, read_buf[0..bytes]);
+    }
+    return result.toOwnedSlice(allocator);
+}
+
+pub fn cwdWriteFile(path: []const u8, data: []const u8) !void {
+    const fd = try cwdCreateFile(path);
+    defer _ = std.c.close(fd);
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
+        if (n <= 0) return error.WriteError;
+        sent += @intCast(n);
+    }
+}
+
+pub fn cwdMakePath(path: []const u8) !void {
+    // Iteratively create each component
+    var i: usize = 0;
+    while (i < path.len) {
+        i += 1;
+        while (i < path.len and path[i] != '/') : (i += 1) {}
+        var buf: [4096]u8 = undefined;
+        if (i > buf.len - 1) return error.NameTooLong;
+        @memcpy(buf[0..i], path[0..i]);
+        buf[i] = 0;
+        _ = std.c.mkdir(buf[0..i :0], 0o755);
+    }
+}
+
+pub fn cwdDeleteFile(path: []const u8) !void {
+    var buf: [4096]u8 = undefined;
+    if (path.len >= buf.len) return error.NameTooLong;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    if (std.c.unlink(buf[0..path.len :0]) != 0) return error.FileNotFound;
+}
+
+pub fn cwdAccess(path: []const u8) bool {
+    var buf: [4096]u8 = undefined;
+    if (path.len >= buf.len) return false;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    return std.c.access(buf[0..path.len :0], std.c.F_OK) == 0;
+}
+
+pub fn fdWriteAll(fd: std.c.fd_t, data: []const u8) !void {
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
+        if (n <= 0) return error.WriteError;
+        sent += @intCast(n);
+    }
+}
+
+pub fn fdClose(fd: std.c.fd_t) void {
+    _ = std.c.close(fd);
+}
+
+// --- Process (replaces removed std.process.Child.init/run) ---
+
+extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+
+pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_output: usize) !struct { stdout: []u8, term: i32 } {
+    var pipe_fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&pipe_fds) != 0) return error.PipeCreateFailed;
+
+    const pid = std.c.fork();
+    if (pid < 0) return error.ForkFailed;
+
+    if (pid == 0) {
+        // Child: redirect stdout to pipe write end
+        _ = std.c.close(pipe_fds[0]);
+        _ = std.c.dup2(pipe_fds[1], 1);
+        _ = std.c.dup2(pipe_fds[1], 2); // also capture stderr
+        _ = std.c.close(pipe_fds[1]);
+
+        var c_argv_buf: [64]?[*:0]const u8 = undefined;
+        for (argv, 0..) |arg, i| {
+            if (i >= c_argv_buf.len - 1) break;
+            c_argv_buf[i] = @ptrCast(arg.ptr);
+        }
+        c_argv_buf[argv.len] = null;
+        _ = execvp(@ptrCast(argv[0].ptr), @ptrCast(&c_argv_buf));
+        std.c._exit(127);
+    }
+
+    // Parent: read from pipe
+    _ = std.c.close(pipe_fds[1]);
+    defer _ = std.c.close(pipe_fds[0]);
+
+    var result = std.ArrayList(u8).empty;
+    var read_buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.c.read(pipe_fds[0], &read_buf, read_buf.len);
+        if (n <= 0) break;
+        const bytes: usize = @intCast(n);
+        if (result.items.len + bytes > max_output) break;
+        try result.appendSlice(allocator, read_buf[0..bytes]);
+    }
+
+    var status: c_int = 0;
+    _ = std.c.waitpid(pid, &status, 0);
+
+    return .{
+        .stdout = try result.toOwnedSlice(allocator),
+        .term = @intCast(status),
+    };
+}
+
+// --- Networking (replaces removed std.net) ---
+
+const c = std.c;
+const fd_t = std.c.fd_t;
+const native_endian = @import("builtin").cpu.arch.endian();
+
+fn htons(val: u16) u16 {
+    return if (native_endian == .little) @byteSwap(val) else val;
+}
+
+fn ntohs(val: u16) u16 {
+    return htons(val);
+}
+
+/// Try to connect to 127.0.0.1:port. Returns true if connection succeeded.
+pub fn isPortInUse(port: u16) bool {
+    const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
+    if (fd < 0) return false;
+    defer _ = c.close(fd);
+
+    var addr = c.sockaddr.in{
+        .port = htons(port),
+        .addr = 0x0100007F, // 127.0.0.1 in network byte order
+    };
+
+    const rc = c.connect(fd, @ptrCast(&addr), @sizeOf(c.sockaddr.in));
+    return rc == 0;
+}
+
+/// A minimal TCP stream wrapping a C socket fd.
+pub const TcpStream = struct {
+    fd: fd_t,
+
+    pub fn close(self: TcpStream) void {
+        _ = c.close(self.fd);
+    }
+
+    pub fn writeAll(self: TcpStream, data: []const u8) !void {
+        var sent: usize = 0;
+        while (sent < data.len) {
+            const n = c.write(self.fd, data[sent..].ptr, data.len - sent);
+            if (n <= 0) return error.BrokenPipe;
+            sent += @intCast(n);
+        }
+    }
+
+    pub fn read(self: TcpStream, buf: []u8) !usize {
+        const n = c.read(self.fd, buf.ptr, buf.len);
+        if (n < 0) return error.ConnectionResetByPeer;
+        return @intCast(n);
+    }
+
+    pub fn write(self: TcpStream, data: []const u8) !usize {
+        const n = c.write(self.fd, data.ptr, data.len);
+        if (n <= 0) return error.BrokenPipe;
+        return @intCast(n);
+    }
+
+    pub fn setSockOpt(self: TcpStream, level: i32, optname: u32, optval: []const u8) void {
+        _ = c.setsockopt(self.fd, level, optname, optval.ptr, @intCast(optval.len));
+    }
+};
+
+/// Connect to 127.0.0.1:port via TCP. Returns a TcpStream.
+pub fn tcpConnectToIp4(port: u16) !TcpStream {
+    const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
+    if (fd < 0) return error.SocketCreateFailed;
+
+    var addr = c.sockaddr.in{
+        .port = htons(port),
+        .addr = 0x0100007F, // 127.0.0.1
+    };
+
+    const rc = c.connect(fd, @ptrCast(&addr), @sizeOf(c.sockaddr.in));
+    if (rc != 0) {
+        _ = c.close(fd);
+        return error.ConnectionRefused;
+    }
+    return .{ .fd = fd };
+}
+
+/// Connect to host:port via TCP. For now supports "127.0.0.1" only
+/// (which covers all our use cases). Falls back to loopback for "localhost".
+pub fn tcpConnectToHost(host: []const u8, port: u16) !TcpStream {
+    _ = host; // all callers use 127.0.0.1 or localhost
+    return tcpConnectToIp4(port);
+}
+
+/// A minimal TCP server that binds and listens.
+pub const TcpServer = struct {
+    fd: fd_t,
+
+    pub const Connection = struct {
+        stream: TcpStream,
+    };
+
+    pub fn accept(self: TcpServer) !Connection {
+        const client_fd = c.accept(self.fd, null, null);
+        if (client_fd < 0) return error.AcceptFailed;
+        return .{ .stream = .{ .fd = client_fd } };
+    }
+
+    pub fn deinit(self: *TcpServer) void {
+        _ = c.close(self.fd);
+    }
+};
+
+/// Bind and listen on 127.0.0.1:port.
+pub fn tcpListen(port: u16) !TcpServer {
+    const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
+    if (fd < 0) return error.SocketCreateFailed;
+    errdefer _ = c.close(fd);
+
+    // SO_REUSEADDR
+    const one: c_int = 1;
+    _ = c.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&one), @sizeOf(c_int));
+
+    var addr = c.sockaddr.in{
+        .port = htons(port),
+        .addr = 0x0100007F, // 127.0.0.1
+    };
+
+    if (c.bind(fd, @ptrCast(&addr), @sizeOf(c.sockaddr.in)) != 0) {
+        return error.AddressInUse;
+    }
+    if (c.listen(fd, 1) != 0) {
+        return error.ListenFailed;
+    }
+    return .{ .fd = fd };
+}

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -70,27 +70,6 @@ pub fn randomBytes(buf: []u8) void {
     arc4random_buf(buf.ptr, buf.len);
 }
 
-// --- Process Args ---
-
-extern "c" fn _NSGetArgc() *c_int;
-extern "c" fn _NSGetArgv() *[*][*:0]const u8;
-
-pub fn getArgv() struct { argc: usize, argv: [*][*:0]const u8 } {
-    return .{
-        .argc = @intCast(_NSGetArgc().*),
-        .argv = _NSGetArgv().*,
-    };
-}
-
-pub fn collectArgs(allocator: std.mem.Allocator) ![]const []const u8 {
-    const info = getArgv();
-    const args = try allocator.alloc([]const u8, info.argc);
-    for (0..info.argc) |i| {
-        args[i] = std.mem.sliceTo(info.argv[i], 0);
-    }
-    return args;
-}
-
 // --- Environment ---
 
 pub fn getenv(name: []const u8) ?[]const u8 {

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -64,10 +64,31 @@ pub const PthreadRwLock = struct {
 
 // --- Random ---
 
-extern "c" fn arc4random_buf(buf: *anyopaque, nbytes: usize) void;
-
 pub fn randomBytes(buf: []u8) void {
-    arc4random_buf(buf.ptr, buf.len);
+    if (buf.len == 0) return;
+
+    if (@import("builtin").os.tag == .linux and @TypeOf(std.c.getrandom) != void) {
+        var filled: usize = 0;
+        while (filled < buf.len) {
+            const rc = std.c.getrandom(buf[filled..].ptr, buf.len - filled, 0);
+            switch (std.c.errno(rc)) {
+                .SUCCESS => {
+                    const n: usize = @intCast(rc);
+                    if (n == 0) break;
+                    filled += n;
+                },
+                .INTR => continue,
+                else => break,
+            }
+        }
+        if (filled == buf.len) return;
+    } else if (@TypeOf(std.c.arc4random_buf) != void) {
+        std.c.arc4random_buf(buf.ptr, buf.len);
+        return;
+    }
+
+    var prng = std.Random.DefaultPrng.init(@as(u64, @truncate(@as(u128, @intCast(nanoTimestamp())))));
+    prng.random().bytes(buf);
 }
 
 // --- Environment ---
@@ -193,7 +214,7 @@ pub fn fdClose(fd: std.c.fd_t) void {
 
 // --- Process (replaces removed std.process.Child.init/run) ---
 
-extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+pub extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
 
 pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_output: usize) !struct { stdout: []u8, term: i32 } {
     var arg_storage: std.ArrayList([:0]u8) = .empty;

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -217,6 +217,24 @@ pub fn fdClose(fd: std.c.fd_t) void {
 extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
 
 pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_output: usize) !struct { stdout: []u8, term: i32 } {
+    var arg_storage: std.ArrayList([:0]u8) = .empty;
+    defer {
+        for (arg_storage.items) |arg| allocator.free(arg);
+        arg_storage.deinit(allocator);
+    }
+    for (argv) |arg| {
+        const duped = try allocator.allocSentinel(u8, arg.len, 0);
+        @memcpy(duped[0..arg.len], arg);
+        try arg_storage.append(allocator, duped);
+    }
+
+    const c_argv = try allocator.alloc(?[*:0]const u8, arg_storage.items.len + 1);
+    defer allocator.free(c_argv);
+    for (arg_storage.items, 0..) |arg, i| {
+        c_argv[i] = arg.ptr;
+    }
+    c_argv[arg_storage.items.len] = null;
+
     var pipe_fds: [2]std.c.fd_t = undefined;
     if (std.c.pipe(&pipe_fds) != 0) return error.PipeCreateFailed;
 
@@ -230,13 +248,7 @@ pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_ou
         _ = std.c.dup2(pipe_fds[1], 2); // also capture stderr
         _ = std.c.close(pipe_fds[1]);
 
-        var c_argv_buf: [64]?[*:0]const u8 = undefined;
-        for (argv, 0..) |arg, i| {
-            if (i >= c_argv_buf.len - 1) break;
-            c_argv_buf[i] = @ptrCast(arg.ptr);
-        }
-        c_argv_buf[argv.len] = null;
-        _ = execvp(@ptrCast(argv[0].ptr), @ptrCast(&c_argv_buf));
+        _ = execvp(c_argv[0].?, @ptrCast(c_argv.ptr));
         std.c._exit(127);
     }
 

--- a/src/crawler/fetcher.zig
+++ b/src/crawler/fetcher.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const validator = @import("validator.zig");
 const CdpClient = @import("../cdp/client.zig").CdpClient;
+const compat = @import("../compat.zig");
 
 pub const FetchError = error{
     ValidationFailed,
@@ -53,7 +54,7 @@ pub fn fetchPage(
         // Exponential backoff for retries (no delay on first attempt)
         if (attempt > 0) {
             const delay_ms = retryDelayMs(attempt - 1);
-            std.Thread.sleep(delay_ms * std.time.ns_per_ms);
+            compat.threadSleep(delay_ms * std.time.ns_per_ms);
         }
 
         // Navigate to URL via CDP Page.navigate
@@ -164,7 +165,7 @@ pub fn fetchPageGeneric(client: anytype, url: []const u8, _: FetchOpts, rate_lim
     _ = client.send(arena, "Page.navigate", nav_params) catch return FetchError.FetchFailed;
 
     // Brief wait for page load (50ms baseline — CDP navigate is async)
-    std.Thread.sleep(50 * std.time.ns_per_ms);
+    compat.threadSleep(50 * std.time.ns_per_ms);
 
     // Extract HTML via Runtime.evaluate
     const eval_params = "{\"expression\":\"document.documentElement.outerHTML\",\"returnByValue\":true}";
@@ -187,7 +188,7 @@ pub fn fetchPageWithRetry(client: anytype, url: []const u8, opts: FetchOpts, rat
             return res;
         } else |err| {
             if (err != FetchError.FetchFailed) return err;
-            std.Thread.sleep(retryDelayNs(attempt));
+            compat.threadSleep(retryDelayNs(attempt));
         }
     }
     return FetchError.FetchFailed;
@@ -204,7 +205,7 @@ pub const RateLimiter = struct {
         return .{
             .tokens = std.atomic.Value(u32).init(max_tokens),
             .max_tokens = max_tokens,
-            .last_refill = std.atomic.Value(i64).init(@intCast(std.time.nanoTimestamp())),
+            .last_refill = std.atomic.Value(i64).init(@intCast(compat.nanoTimestamp())),
             .refill_interval_ns = @as(i64, refill_interval_ms) * std.time.ns_per_ms,
         };
     }
@@ -224,7 +225,7 @@ pub const RateLimiter = struct {
     }
 
     fn maybeRefill(self: *RateLimiter) void {
-        const now: i64 = @intCast(std.time.nanoTimestamp());
+        const now: i64 = @intCast(compat.nanoTimestamp());
         const last = self.last_refill.load(.acquire);
         if (now - last >= self.refill_interval_ns) {
             if (self.last_refill.cmpxchgWeak(last, now, .release, .monotonic) == null) {

--- a/src/crawler/markdown.zig
+++ b/src/crawler/markdown.zig
@@ -4,7 +4,6 @@ const std = @import("std");
 /// Handles common HTML elements: headings, paragraphs, links, lists, code blocks, emphasis.
 pub fn htmlToMarkdown(html: []const u8, allocator: std.mem.Allocator) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const writer = buf.writer(allocator);
 
     var i: usize = 0;
     while (i < html.len) {
@@ -18,44 +17,44 @@ pub fn htmlToMarkdown(html: []const u8, allocator: std.mem.Allocator) ![]const u
             const tag_name = extractTagName(if (is_close) tag_content[1..] else tag_content);
 
             if (std.mem.eql(u8, tag_name, "h1")) {
-                if (!is_close) try writer.writeAll("# ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "# ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "h2")) {
-                if (!is_close) try writer.writeAll("## ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "## ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "h3")) {
-                if (!is_close) try writer.writeAll("### ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "### ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "h4")) {
-                if (!is_close) try writer.writeAll("#### ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "#### ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "h5")) {
-                if (!is_close) try writer.writeAll("##### ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "##### ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "h6")) {
-                if (!is_close) try writer.writeAll("###### ") else try writer.writeAll("\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "###### ") else try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "p")) {
-                if (is_close) try writer.writeAll("\n\n");
+                if (is_close) try buf.appendSlice(allocator, "\n\n");
             } else if (std.mem.eql(u8, tag_name, "br")) {
-                try writer.writeAll("\n");
+                try buf.appendSlice(allocator, "\n");
             } else if (std.mem.eql(u8, tag_name, "strong") or std.mem.eql(u8, tag_name, "b")) {
-                try writer.writeAll("**");
+                try buf.appendSlice(allocator, "**");
             } else if (std.mem.eql(u8, tag_name, "em") or std.mem.eql(u8, tag_name, "i")) {
-                try writer.writeAll("*");
+                try buf.appendSlice(allocator, "*");
             } else if (std.mem.eql(u8, tag_name, "code")) {
-                try writer.writeAll("`");
+                try buf.appendSlice(allocator, "`");
             } else if (std.mem.eql(u8, tag_name, "pre")) {
-                if (!is_close) try writer.writeAll("\n```\n") else try writer.writeAll("\n```\n\n");
+                if (!is_close) try buf.appendSlice(allocator, "\n```\n") else try buf.appendSlice(allocator, "\n```\n\n");
             } else if (std.mem.eql(u8, tag_name, "li")) {
-                if (!is_close) try writer.writeAll("- ");
-                if (is_close) try writer.writeAll("\n");
+                if (!is_close) try buf.appendSlice(allocator, "- ");
+                if (is_close) try buf.appendSlice(allocator, "\n");
             } else if (std.mem.eql(u8, tag_name, "blockquote")) {
-                if (!is_close) try writer.writeAll("> ");
+                if (!is_close) try buf.appendSlice(allocator, "> ");
             } else if (std.mem.eql(u8, tag_name, "hr")) {
-                try writer.writeAll("\n---\n\n");
+                try buf.appendSlice(allocator, "\n---\n\n");
             } else if (std.mem.eql(u8, tag_name, "a")) {
                 if (!is_close) {
                     if (extractAttr(tag_content, "href")) |href| {
-                        try writer.writeAll("[");
+                        try buf.appendSlice(allocator, "[");
                         if (std.mem.indexOf(u8, html[tag_end + 1 ..], "</a>")) |close_idx| {
                             const text = html[tag_end + 1 .. tag_end + 1 + close_idx];
-                            try writer.writeAll(text);
-                            try writer.print("]({s})", .{href});
+                            try buf.appendSlice(allocator, text);
+                            try buf.print(allocator, "]({s})", .{href});
                             i = tag_end + 1 + close_idx + 4;
                             continue;
                         }
@@ -75,68 +74,68 @@ pub fn htmlToMarkdown(html: []const u8, allocator: std.mem.Allocator) ![]const u
         } else {
             if (html[i] == '&') {
                 if (std.mem.startsWith(u8, html[i..], "&amp;")) {
-                    try writer.writeByte('&');
+                    try buf.append(allocator, '&');
                     i += 5;
                 } else if (std.mem.startsWith(u8, html[i..], "&lt;")) {
-                    try writer.writeByte('<');
+                    try buf.append(allocator, '<');
                     i += 4;
                 } else if (std.mem.startsWith(u8, html[i..], "&gt;")) {
-                    try writer.writeByte('>');
+                    try buf.append(allocator, '>');
                     i += 4;
                 } else if (std.mem.startsWith(u8, html[i..], "&quot;")) {
-                    try writer.writeByte('"');
+                    try buf.append(allocator, '"');
                     i += 6;
                 } else if (std.mem.startsWith(u8, html[i..], "&nbsp;")) {
-                    try writer.writeByte(' ');
+                    try buf.append(allocator, ' ');
                     i += 6;
                 } else if (std.mem.startsWith(u8, html[i..], "&apos;")) {
-                    try writer.writeByte('\'');
+                    try buf.append(allocator, '\'');
                     i += 6;
                 } else if (std.mem.startsWith(u8, html[i..], "&rsquo;") or std.mem.startsWith(u8, html[i..], "&lsquo;")) {
-                    try writer.writeByte('\'');
+                    try buf.append(allocator, '\'');
                     i += 7;
                 } else if (std.mem.startsWith(u8, html[i..], "&rdquo;") or std.mem.startsWith(u8, html[i..], "&ldquo;")) {
-                    try writer.writeByte('"');
+                    try buf.append(allocator, '"');
                     i += 7;
                 } else if (std.mem.startsWith(u8, html[i..], "&mdash;")) {
-                    try writer.writeAll("—");
+                    try buf.appendSlice(allocator, "—");
                     i += 7;
                 } else if (std.mem.startsWith(u8, html[i..], "&ndash;")) {
-                    try writer.writeAll("–");
+                    try buf.appendSlice(allocator, "–");
                     i += 7;
                 } else if (std.mem.startsWith(u8, html[i..], "&hellip;")) {
-                    try writer.writeAll("…");
+                    try buf.appendSlice(allocator, "…");
                     i += 8;
                 } else if (std.mem.startsWith(u8, html[i..], "&copy;")) {
-                    try writer.writeAll("©");
+                    try buf.appendSlice(allocator, "©");
                     i += 6;
                 } else if (std.mem.startsWith(u8, html[i..], "&reg;")) {
-                    try writer.writeAll("®");
+                    try buf.appendSlice(allocator, "®");
                     i += 5;
                 } else if (std.mem.startsWith(u8, html[i..], "&trade;")) {
-                    try writer.writeAll("™");
+                    try buf.appendSlice(allocator, "™");
                     i += 7;
                 } else if (decodeNumericEntity(html[i..])) |decoded| {
                     // Numeric entities: &#123; (decimal) or &#x7b; (hex)
                     if (decoded.codepoint < 128) {
-                        try writer.writeByte(@intCast(decoded.codepoint));
+                        try buf.append(allocator, @intCast(decoded.codepoint));
                     } else {
                         // Encode as UTF-8
                         var utf8_buf: [4]u8 = undefined;
                         const utf8_len = std.unicode.utf8Encode(@intCast(decoded.codepoint), &utf8_buf) catch {
-                            try writer.writeByte('?');
+                            try buf.append(allocator, '?');
                             i += decoded.len;
                             continue;
                         };
-                        try writer.writeAll(utf8_buf[0..utf8_len]);
+                        try buf.appendSlice(allocator, utf8_buf[0..utf8_len]);
                     }
                     i += decoded.len;
                 } else {
-                    try writer.writeByte(html[i]);
+                    try buf.append(allocator, html[i]);
                     i += 1;
                 }
             } else {
-                try writer.writeByte(html[i]);
+                try buf.append(allocator, html[i]);
                 i += 1;
             }
         }

--- a/src/crawler/pipeline.zig
+++ b/src/crawler/pipeline.zig
@@ -21,7 +21,7 @@ pub const WorkItem = struct {
 pub const ThreadPool = struct {
     threads: []std.Thread,
     queue: std.ArrayList(WorkItem),
-    mutex: std.Thread.Mutex,
+    mutex: @import("../compat.zig").PthreadMutex,
     allocator: std.mem.Allocator,
     active: std.atomic.Value(u32),
     shutdown: std.atomic.Value(bool),

--- a/src/crawler/validator.zig
+++ b/src/crawler/validator.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
+
+extern "c" fn lstat(noalias path: [*:0]const u8, noalias buf: *std.c.Stat) c_int;
 
 pub const ValidationError = error{
     InvalidScheme,
@@ -55,12 +58,16 @@ pub fn validateOutputPath(path: []const u8) ValidationError!void {
     // For existing files, check symlink via lstat (race-free for existing paths).
     // Note: TOCTOU gap remains for files created between check and use.
     // Callers should open with O_NOFOLLOW where the OS supports it.
-    const stat = std.fs.cwd().statFile(path) catch |err| switch (err) {
-        error.FileNotFound => return,
-        else => return ValidationError.InvalidPath,
-    };
+    var path_buf: [4096]u8 = undefined;
+    if (path.len >= path_buf.len) return ValidationError.InvalidPath;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const path_z: [*:0]const u8 = path_buf[0..path.len :0];
 
-    if (stat.kind == .sym_link) {
+    var stat_buf: std.c.Stat = undefined;
+    if (lstat(path_z, &stat_buf) != 0) return; // file doesn't exist yet, OK
+
+    if (std.c.S.ISLNK(@intCast(stat_buf.mode))) {
         return ValidationError.SymlinkNotAllowed;
     }
 }

--- a/src/crawler/validator.zig
+++ b/src/crawler/validator.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const compat = @import("../compat.zig");
-
-extern "c" fn lstat(noalias path: [*:0]const u8, noalias buf: *std.c.Stat) c_int;
 
 pub const ValidationError = error{
     InvalidScheme,
@@ -64,12 +63,36 @@ pub fn validateOutputPath(path: []const u8) ValidationError!void {
     path_buf[path.len] = 0;
     const path_z: [*:0]const u8 = path_buf[0..path.len :0];
 
-    var stat_buf: std.c.Stat = undefined;
-    if (lstat(path_z, &stat_buf) != 0) return; // file doesn't exist yet, OK
-
-    if (std.c.S.ISLNK(@intCast(stat_buf.mode))) {
+    if (pathIsSymlink(path_z)) {
         return ValidationError.SymlinkNotAllowed;
     }
+}
+
+fn pathIsSymlink(path_z: [*:0]const u8) bool {
+    return switch (builtin.os.tag) {
+        .linux => linuxPathIsSymlink(path_z),
+        else => posixPathIsSymlink(path_z),
+    };
+}
+
+fn linuxPathIsSymlink(path_z: [*:0]const u8) bool {
+    const linux = std.os.linux;
+    var statx = std.mem.zeroes(linux.Statx);
+    const flags = linux.AT.NO_AUTOMOUNT | linux.AT.SYMLINK_NOFOLLOW;
+
+    switch (linux.errno(linux.statx(linux.AT.FDCWD, path_z, flags, .{ .TYPE = true }, &statx))) {
+        .SUCCESS => return linux.S.ISLNK(statx.mode),
+        else => return false,
+    }
+}
+
+fn posixPathIsSymlink(path_z: [*:0]const u8) bool {
+    var stat_buf: std.c.Stat = undefined;
+    if (std.c.fstatat(std.c.AT.FDCWD, path_z, &stat_buf, std.c.AT.SYMLINK_NOFOLLOW) != 0) {
+        return false;
+    }
+
+    return std.c.S.ISLNK(@intCast(stat_buf.mode));
 }
 
 fn extractHost(url: []const u8) ?[]const u8 {

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("compat.zig");
 const validator = @import("crawler/validator.zig");
 const markdown = @import("crawler/markdown.zig");
 const js_engine = @import("js_engine.zig");
@@ -6,12 +7,11 @@ const js_engine = @import("js_engine.zig");
 const version = "0.2.0";
 
 pub fn main() !void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
-    const args = try std.process.argsAlloc(gpa);
-    defer std.process.argsFree(gpa, args);
+    const args = try compat.collectArgs(gpa);
 
     var opts = Options{};
 
@@ -38,8 +38,7 @@ pub fn main() !void {
             if (i >= args.len) fatal("--user-agent requires a value");
             opts.user_agent = args[i];
         } else if (std.mem.eql(u8, args[i], "--version") or std.mem.eql(u8, args[i], "-V")) {
-            const stdout = std.fs.File.stdout();
-            stdout.writeAll("kuri-fetch " ++ version ++ "\n") catch {};
+            compat.writeToStdout("kuri-fetch " ++ version ++ "\n");
             return;
         } else if (std.mem.eql(u8, args[i], "--help") or std.mem.eql(u8, args[i], "-h")) {
             printUsage();
@@ -87,7 +86,7 @@ pub fn main() !void {
         }
     }
 
-    const fetch_start = std.time.nanoTimestamp();
+    const fetch_start = compat.nanoTimestamp();
 
     var html = fetchHttp(arena, target_url, opts.user_agent) catch |err| {
         if (color) {
@@ -126,10 +125,9 @@ pub fn main() !void {
         .links => blk: {
             const links = try extractLinks(html, arena);
             var buf: std.ArrayList(u8) = .empty;
-            const w = buf.writer(arena);
             for (links) |link| {
-                w.writeAll(link) catch break :blk "";
-                w.writeByte('\n') catch break :blk "";
+                buf.appendSlice(arena, link) catch break :blk "";
+                buf.append(arena, '\n') catch break :blk "";
             }
             break :blk buf.toOwnedSlice(arena) catch "";
         },
@@ -138,13 +136,12 @@ pub fn main() !void {
             const md_content = try markdown.htmlToMarkdown(html, arena);
             const links = try extractLinks(html, arena);
             var link_buf: std.ArrayList(u8) = .empty;
-            const lw = link_buf.writer(arena);
-            lw.writeByte('[') catch break :blk "";
+            link_buf.append(arena, '[') catch break :blk "";
             for (links, 0..) |link, li| {
-                if (li > 0) lw.writeByte(',') catch {};
-                lw.print("\"{s}\"", .{link}) catch {};
+                if (li > 0) link_buf.append(arena, ',') catch {};
+                link_buf.print(arena, "\"{s}\"", .{link}) catch {};
             }
-            lw.writeByte(']') catch {};
+            link_buf.append(arena, ']') catch {};
             const link_json = link_buf.toOwnedSlice(arena) catch "[]";
             const escaped_url = js_engine.escapeForJs(target_url, arena) orelse target_url;
             const escaped_md = js_engine.escapeForJs(md_content, arena) orelse "";
@@ -158,7 +155,7 @@ pub fn main() !void {
 
     // Write output to file or stdout
     if (opts.output_file) |path| {
-        const file = std.fs.cwd().createFile(path, .{}) catch |err| {
+        const file = compat.cwdCreateFile(path) catch |err| {
             if (color) {
                 std.debug.print("\x1b[31m✗\x1b[0m cannot write to '{s}': {s}\n", .{ path, @errorName(err) });
             } else {
@@ -166,8 +163,8 @@ pub fn main() !void {
             }
             std.process.exit(1);
         };
-        defer file.close();
-        file.writeAll(output_content) catch |err| {
+        defer compat.fdClose(file);
+        compat.fdWriteAll(file, output_content) catch |err| {
             std.debug.print("error: write failed: {s}\n", .{@errorName(err)});
             std.process.exit(1);
         };
@@ -179,8 +176,7 @@ pub fn main() !void {
             }
         }
     } else {
-        const stdout = std.fs.File.stdout();
-        stdout.writeAll(output_content) catch {};
+        compat.writeToStdout(output_content);
         // Summary to stderr (not polluting stdout pipe)
         if (!opts.quiet) {
             if (color) {
@@ -193,19 +189,19 @@ pub fn main() !void {
 }
 
 fn elapsed(start: i128) u64 {
-    const diff = std.time.nanoTimestamp() - start;
+    const diff = compat.nanoTimestamp() - start;
     return if (diff > 0) @as(u64, @intCast(diff)) / std.time.ns_per_ms else 0;
 }
 
 fn shouldUseColor(force_no_color: bool) bool {
     if (force_no_color) return false;
-    if (std.posix.getenv("NO_COLOR")) |v| {
+    if (compat.getenv("NO_COLOR")) |v| {
         if (v.len > 0) return false;
     }
-    if (std.posix.getenv("TERM")) |term| {
+    if (compat.getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
-    return std.posix.isatty(std.fs.File.stderr().handle);
+    return std.c.isatty(2) != 0;
 }
 
 const Options = struct {
@@ -276,7 +272,7 @@ fn printUsage() void {
 
 /// Fetch a URL using std.http.Client and return the response body.
 pub fn fetchHttp(allocator: std.mem.Allocator, url: []const u8, user_agent: []const u8) ![]const u8 {
-    var client: std.http.Client = .{ .allocator = allocator };
+    var client: std.http.Client = .{ .allocator = allocator, .io = std.Io.Threaded.global_single_threaded.io() };
     defer client.deinit();
 
     const uri = try std.Uri.parse(url);
@@ -371,7 +367,6 @@ fn findAttrValue(tag: []const u8, attr: []const u8) ?[]const u8 {
 /// Extract plain text from HTML — strips all tags and decodes entities.
 pub fn extractText(html: []const u8, allocator: std.mem.Allocator) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const writer = buf.writer(allocator);
 
     var i: usize = 0;
     var in_script = false;
@@ -398,7 +393,7 @@ pub fn extractText(html: []const u8, allocator: std.mem.Allocator) ![]const u8 {
             }
 
             if (is_close and isBlockElement(tag_name)) {
-                try writer.writeByte('\n');
+                try buf.append(allocator, '\n');
             }
 
             i = tag_end + 1;
@@ -406,29 +401,29 @@ pub fn extractText(html: []const u8, allocator: std.mem.Allocator) ![]const u8 {
             i += 1;
         } else if (html[i] == '&') {
             if (std.mem.startsWith(u8, html[i..], "&amp;")) {
-                try writer.writeByte('&');
+                try buf.append(allocator, '&');
                 i += 5;
             } else if (std.mem.startsWith(u8, html[i..], "&lt;")) {
-                try writer.writeByte('<');
+                try buf.append(allocator, '<');
                 i += 4;
             } else if (std.mem.startsWith(u8, html[i..], "&gt;")) {
-                try writer.writeByte('>');
+                try buf.append(allocator, '>');
                 i += 4;
             } else if (std.mem.startsWith(u8, html[i..], "&quot;")) {
-                try writer.writeByte('"');
+                try buf.append(allocator, '"');
                 i += 6;
             } else if (std.mem.startsWith(u8, html[i..], "&nbsp;")) {
-                try writer.writeByte(' ');
+                try buf.append(allocator, ' ');
                 i += 6;
             } else if (std.mem.startsWith(u8, html[i..], "&#39;") or std.mem.startsWith(u8, html[i..], "&#x27;")) {
-                try writer.writeByte('\'');
+                try buf.append(allocator, '\'');
                 i += if (std.mem.startsWith(u8, html[i..], "&#39;")) @as(usize, 5) else 6;
             } else {
-                try writer.writeByte(html[i]);
+                try buf.append(allocator, html[i]);
                 i += 1;
             }
         } else {
-            try writer.writeByte(html[i]);
+            try buf.append(allocator, html[i]);
             i += 1;
         }
     }

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -7,13 +7,16 @@ const http_fetch = @import("util/http_fetch.zig");
 
 const version = "0.2.0";
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
-    const args = try compat.collectArgs(gpa);
-    defer gpa.free(args);
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const args = try init.args.toSlice(arena);
 
     var opts = Options{};
 
@@ -74,10 +77,6 @@ pub fn main() !void {
             std.debug.print("  hint: private/localhost URLs are blocked for SSRF protection\n", .{});
         std.process.exit(1);
     };
-
-    var arena_impl = std.heap.ArenaAllocator.init(gpa);
-    defer arena_impl.deinit();
-    const arena = arena_impl.allocator();
 
     // Status: fetching
     if (!opts.quiet) {

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -3,6 +3,7 @@ const compat = @import("compat.zig");
 const validator = @import("crawler/validator.zig");
 const markdown = @import("crawler/markdown.zig");
 const js_engine = @import("js_engine.zig");
+const http_fetch = @import("util/http_fetch.zig");
 
 const version = "0.2.0";
 
@@ -12,6 +13,7 @@ pub fn main() !void {
     const gpa = gpa_impl.allocator();
 
     const args = try compat.collectArgs(gpa);
+    defer gpa.free(args);
 
     var opts = Options{};
 
@@ -88,7 +90,7 @@ pub fn main() !void {
 
     const fetch_start = compat.nanoTimestamp();
 
-    var html = fetchHttp(arena, target_url, opts.user_agent) catch |err| {
+    var html = http_fetch.fetchHttp(arena, target_url, opts.user_agent) catch |err| {
         if (color) {
             std.debug.print("\x1b[31m✗\x1b[0m fetch failed: {s}\n", .{@errorName(err)});
         } else {
@@ -268,42 +270,6 @@ fn printUsage() void {
         \\    NO_COLOR   Disable colors (https://no-color.org)
         \\
     , .{});
-}
-
-/// Fetch a URL using std.http.Client and return the response body.
-pub fn fetchHttp(allocator: std.mem.Allocator, url: []const u8, user_agent: []const u8) ![]const u8 {
-    var client: std.http.Client = .{ .allocator = allocator, .io = std.Io.Threaded.global_single_threaded.io() };
-    defer client.deinit();
-
-    const uri = try std.Uri.parse(url);
-
-    var req = try client.request(.GET, uri, .{
-        .extra_headers = &.{
-            .{ .name = "User-Agent", .value = user_agent },
-            .{ .name = "Accept", .value = "text/html,application/xhtml+xml,*/*" },
-            .{ .name = "Accept-Encoding", .value = "gzip, deflate" },
-        },
-    });
-    defer req.deinit();
-
-    try req.sendBodiless();
-
-    var redirect_buf: [8192]u8 = undefined;
-    var response = try req.receiveHead(&redirect_buf);
-
-    if (response.head.status != .ok) {
-        std.debug.print("HTTP {d}\n", .{@intFromEnum(response.head.status)});
-        return error.HttpError;
-    }
-
-    var body: std.ArrayList(u8) = .empty;
-    var transfer_buf: [8192]u8 = undefined;
-    var decompress: std.http.Decompress = undefined;
-    var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
-    const reader = response.readerDecompressing(&transfer_buf, &decompress, &decompress_buf);
-    try reader.appendRemainingUnlimited(allocator, &body);
-
-    return body.items;
 }
 
 /// Extract all href values from <a> tags in HTML.

--- a/src/js_engine.zig
+++ b/src/js_engine.zig
@@ -159,15 +159,14 @@ fn injectDomStubs(engine: *JsEngine, html: []const u8, url: ?[]const u8, allocat
 /// Escape a string for embedding inside a double-quoted string literal (JS/JSON).
 pub fn escapeForJs(input: []const u8, allocator: std.mem.Allocator) ?[]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const writer = buf.writer(allocator);
     for (input) |c| {
         switch (c) {
-            '\\' => writer.writeAll("\\\\") catch return null,
-            '"' => writer.writeAll("\\\"") catch return null,
-            '\n' => writer.writeAll("\\n") catch return null,
-            '\r' => writer.writeAll("\\r") catch return null,
-            '\t' => writer.writeAll("\\t") catch return null,
-            else => writer.writeByte(c) catch return null,
+            '\\' => buf.appendSlice(allocator, "\\\\") catch return null,
+            '"' => buf.appendSlice(allocator, "\\\"") catch return null,
+            '\n' => buf.appendSlice(allocator, "\\n") catch return null,
+            '\r' => buf.appendSlice(allocator, "\\r") catch return null,
+            '\t' => buf.appendSlice(allocator, "\\t") catch return null,
+            else => buf.append(allocator, c) catch return null,
         }
     }
     return buf.toOwnedSlice(allocator) catch null;

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,7 +5,7 @@ const Bridge = @import("bridge/bridge.zig").Bridge;
 const launcher = @import("chrome/launcher.zig");
 
 pub fn main() !void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 

--- a/src/server/middleware.zig
+++ b/src/server/middleware.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Config = @import("../bridge/config.zig").Config;
+const compat = @import("../compat.zig");
 
 /// Check auth header against configured secret.
 /// Returns true if no secret is configured or if the header matches.
@@ -35,7 +36,7 @@ test "constantTimeEql" {
 /// Generate a request ID as a 16-char hex string from 8 random bytes.
 /// Caller owns the returned slice.
 pub fn generateRequestId(allocator: std.mem.Allocator) ![]u8 {
-    var rng = std.Random.DefaultPrng.init(@as(u64, @intCast(@abs(std.time.nanoTimestamp()))));
+    var rng = std.Random.DefaultPrng.init(@as(u64, @intCast(@abs(compat.nanoTimestamp()))));
     var bytes: [8]u8 = undefined;
     rng.random().bytes(&bytes);
     const hex = std.fmt.bytesToHex(bytes, .lower);
@@ -47,11 +48,11 @@ pub const RequestTimer = struct {
     start_ns: i128,
 
     pub fn start() RequestTimer {
-        return .{ .start_ns = std.time.nanoTimestamp() };
+        return .{ .start_ns = compat.nanoTimestamp() };
     }
 
     pub fn elapsed(self: RequestTimer) u64 {
-        const diff = std.time.nanoTimestamp() - self.start_ns;
+        const diff = compat.nanoTimestamp() - self.start_ns;
         return if (diff > 0) @as(u64, @intCast(diff)) else 0;
     }
 };

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
+const compat = @import("../compat.zig");
 const bridge_mod = @import("../bridge/bridge.zig");
 const Bridge = bridge_mod.Bridge;
 const TabEntry = bridge_mod.TabEntry;
@@ -15,42 +16,44 @@ const auth_profiles = @import("../storage/auth_profiles.zig");
 const url_validator = @import("../crawler/validator.zig");
 
 pub fn run(gpa: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16) !void {
-    const address = try net.Address.parseIp4(cfg.host, cfg.port);
-    var tcp_server = try address.listen(.{
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const address = try net.IpAddress.parseIp4(cfg.host, cfg.port);
+    var tcp_server = try net.IpAddress.listen(&address, io, .{
         .reuse_address = true,
     });
-    defer tcp_server.deinit();
+    defer tcp_server.deinit(io);
 
     std.log.info("server ready on {s}:{d}", .{ cfg.host, cfg.port });
 
     while (true) {
-        const conn = tcp_server.accept() catch |err| {
+        const stream = tcp_server.accept(io) catch |err| {
             std.log.err("accept error: {s}", .{@errorName(err)});
             continue;
         };
 
-        const thread = std.Thread.spawn(.{}, handleConnection, .{ gpa, bridge, cfg, cdp_port, conn }) catch |err| {
+        const thread = std.Thread.spawn(.{}, handleConnection, .{ gpa, bridge, cfg, cdp_port, stream }) catch |err| {
             std.log.err("thread spawn error: {s}", .{@errorName(err)});
-            conn.stream.close();
+            stream.close(io);
             continue;
         };
         thread.detach();
     }
 }
 
-fn handleConnection(gpa: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16, conn: net.Server.Connection) void {
-    defer conn.stream.close();
+fn handleConnection(gpa: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16, stream: net.Stream) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    defer stream.close(io);
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
     var read_buf: [8192]u8 = undefined;
-    var net_reader = net.Stream.Reader.init(conn.stream, &read_buf);
+    var net_reader = net.Stream.Reader.init(stream, io, &read_buf);
     var write_buf: [8192]u8 = undefined;
-    var net_writer = net.Stream.Writer.init(conn.stream, &write_buf);
+    var net_writer = net.Stream.Writer.init(stream, io, &write_buf);
 
-    var http_server = std.http.Server.init(net_reader.interface(), &net_writer.interface);
+    var http_server = std.http.Server.init(&net_reader.interface, &net_writer.interface);
 
     while (true) {
         var request = http_server.receiveHead() catch |err| {
@@ -351,20 +354,19 @@ fn handleTabs(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         return;
     };
     var json_buf: std.ArrayList(u8) = .empty;
-    const writer = json_buf.writer(arena);
 
-    writer.writeAll("[") catch return;
+    json_buf.appendSlice(arena, "[") catch return;
     for (tabs, 0..) |tab, i| {
-        if (i > 0) writer.writeAll(",") catch return;
-        writer.writeAll("{") catch return;
-        writeJsonField(writer, arena, "id", tab.id) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "url", tab.url) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "title", tab.title) catch return;
-        writer.writeAll("}") catch return;
+        if (i > 0) json_buf.appendSlice(arena, ",") catch return;
+        json_buf.appendSlice(arena, "{") catch return;
+        writeJsonField(&json_buf, arena, "id", tab.id) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "url", tab.url) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "title", tab.title) catch return;
+        json_buf.appendSlice(arena, "}") catch return;
     }
-    writer.writeAll("]") catch return;
+    json_buf.appendSlice(arena, "]") catch return;
 
     resp.sendJson(request, json_buf.items);
 }
@@ -418,7 +420,7 @@ fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         if (bridge.getHarRecorder(tid)) |rec| {
             if (rec.isRecording()) {
                 // Wait briefly for network events to start arriving
-                std.Thread.sleep(1500 * std.time.ns_per_ms);
+                compat.threadSleep(1500 * std.time.ns_per_ms);
                 client.drainWsEvents(arena, 2);
                 flushEventsToHar(arena, client, rec);
             }
@@ -428,7 +430,7 @@ fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         const bot_detect = if (getQueryParam(target, "bot_detect")) |v| !std.mem.eql(u8, v, "false") else true;
         if (bot_detect) {
             // Wait for page to settle before checking
-            std.Thread.sleep(3000 * std.time.ns_per_ms);
+            compat.threadSleep(3000 * std.time.ns_per_ms);
             // Detection uses BLOCKER= prefix markers so we can find them in the CDP string response
             const detect_js = "(() => { var t = document.title || ''; var b = document.body ? document.body.innerText.substring(0, 2000) : ''; var h = document.documentElement.innerHTML.substring(0, 8000); var blocker = ''; var code = ''; if (b.indexOf('Reference error code:') !== -1 || h.indexOf('WAF_Custom_Deny') !== -1 || h.indexOf('akamai') !== -1 || (t.indexOf('Maintenance') !== -1 && b.indexOf('error code') !== -1)) { blocker = 'akamai'; var idx = b.indexOf('Reference error code:'); if (idx !== -1) { var rest = b.substring(idx + 22, idx + 80); var nl = rest.indexOf(String.fromCharCode(10)); code = nl !== -1 ? rest.substring(0, nl).trim() : rest.trim(); } } else if (t === 'Just a moment...' || h.indexOf('challenge-platform') !== -1 || h.indexOf('cf-browser-verification') !== -1 || h.indexOf('cf-chl-') !== -1) { blocker = 'cloudflare'; } else if (h.indexOf('perimeterx') !== -1 || h.indexOf('_pxCaptcha') !== -1 || h.indexOf('human-challenge') !== -1) { blocker = 'perimeterx'; } else if (h.indexOf('datadome') !== -1 || h.indexOf('DataDome') !== -1) { blocker = 'datadome'; } else if (h.indexOf('captcha') !== -1 && (t.indexOf('Access Denied') !== -1 || t.indexOf('Blocked') !== -1 || t === '')) { blocker = 'captcha'; } else if (t.indexOf('Access Denied') !== -1 || t.indexOf('403 Forbidden') !== -1 || (t === '' && b.length < 50 && h.indexOf('block') !== -1)) { blocker = 'unknown'; } if (!blocker) return 'NOBLOCK'; return 'BLOCKED|' + blocker + '|' + code + '|' + window.location.href; })()";
             const detect_escaped = jsonEscapeAlloc(arena, detect_js) orelse {
@@ -486,7 +488,7 @@ fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
             const max_polls = cf_timeout_ms / 1500;
             var polls: u64 = 0;
             // Initial wait for page to load
-            std.Thread.sleep(2000 * std.time.ns_per_ms);
+            compat.threadSleep(2000 * std.time.ns_per_ms);
             while (polls < max_polls) : (polls += 1) {
                 const check_params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{cf_check_js}) catch break;
                 const check_response = client.send(arena, protocol.Methods.runtime_evaluate, check_params) catch break;
@@ -505,7 +507,7 @@ fn handleNavigate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
                     resp.sendJson(request, response);
                     return;
                 }
-                std.Thread.sleep(1500 * std.time.ns_per_ms);
+                compat.threadSleep(1500 * std.time.ns_per_ms);
             }
             // Timed out waiting for CF challenge
             const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"cf_challenge\":true,\"cf_cleared\":false,\"wait_ms\":{d}}}", .{cf_timeout_ms}) catch {
@@ -631,23 +633,22 @@ fn sendSnapshotResponse(request: *std.http.Server.Request, arena: std.mem.Alloca
 
     // JSON format
     var json_buf: std.ArrayList(u8) = .empty;
-    const writer = json_buf.writer(arena);
-    writer.writeAll("[") catch return;
+    json_buf.appendSlice(arena, "[") catch return;
     for (snapshot, 0..) |node, i| {
-        if (i > 0) writer.writeAll(",") catch return;
-        writer.writeAll("{") catch return;
-        writeJsonField(writer, arena, "ref", node.ref) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "role", node.role) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "name", node.name) catch return;
+        if (i > 0) json_buf.appendSlice(arena, ",") catch return;
+        json_buf.appendSlice(arena, "{") catch return;
+        writeJsonField(&json_buf, arena, "ref", node.ref) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "role", node.role) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "name", node.name) catch return;
         if (node.value.len > 0) {
-            writer.writeAll(",") catch return;
-            writeJsonField(writer, arena, "value", node.value) catch return;
+            json_buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&json_buf, arena, "value", node.value) catch return;
         }
-        writer.writeAll("}") catch return;
+        json_buf.appendSlice(arena, "}") catch return;
     }
-    writer.writeAll("]") catch return;
+    json_buf.appendSlice(arena, "]") catch return;
     resp.sendJson(request, json_buf.items);
 }
 
@@ -942,23 +943,30 @@ pub fn discoverTabs(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_
     const host = cdp_addr.host;
     const port = cdp_addr.port;
 
-    const address = net.Address.parseIp4(host, port) catch return error.CannotResolveChromeAddress;
-    const stream = net.tcpConnectToAddress(address) catch return error.CannotConnectToChrome;
-    defer stream.close();
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const address = net.IpAddress.parseIp4(host, port) catch return error.CannotResolveChromeAddress;
+    const stream = net.IpAddress.connect(&address, io, .{ .mode = .stream }) catch return error.CannotConnectToChrome;
+    defer stream.close(io);
 
     // Set read timeout (2 seconds) to avoid blocking forever
     const timeout = std.posix.timeval{ .sec = 2, .usec = 0 };
-    std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+    std.posix.setsockopt(stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
 
     // HTTP/1.1 required — Chrome ignores HTTP/1.0
     const http_req = try std.fmt.allocPrint(arena, "GET /json/list HTTP/1.1\r\nHost: {s}:{d}\r\nConnection: close\r\n\r\n", .{ host, port });
-    try stream.writeAll(http_req);
+    // Write request using raw syscall
+    var written: usize = 0;
+    while (written < http_req.len) {
+        const rc = std.c.write(stream.socket.handle, http_req.ptr + written, http_req.len - written);
+        if (rc <= 0) return error.CannotConnectToChrome;
+        written += @intCast(rc);
+    }
 
     // Read response with Content-Length awareness
     var response_buf: [65536]u8 = undefined;
     var total: usize = 0;
     while (total < response_buf.len) {
-        const n = stream.read(response_buf[total..]) catch break;
+        const n = std.posix.read(stream.socket.handle, response_buf[total..]) catch break;
         if (n == 0) break;
         total += n;
         // Once we have headers, check Content-Length to know when body is complete
@@ -998,8 +1006,8 @@ pub fn discoverTabs(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_
                 .url = url_val,
                 .title = title_val,
                 .ws_url = ws_val,
-                .created_at = @intCast(std.time.timestamp()),
-                .last_accessed = @intCast(std.time.timestamp()),
+                .created_at = @intCast(compat.timestampSeconds()),
+                .last_accessed = @intCast(compat.timestampSeconds()),
             };
             try bridge.putTab(entry);
             registered += 1;
@@ -1357,14 +1365,13 @@ fn handleHarReplay(request: *std.http.Server.Request, arena: std.mem.Allocator, 
     }
 
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(arena);
 
-    w.writeAll("{\"entries\":") catch {
+    buf.appendSlice(arena, "{\"entries\":") catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    w.print("{d}", .{rec.entryCount()}) catch return;
-    w.writeAll(",\"api_calls\":[") catch return;
+    buf.print(arena, "{d}", .{rec.entryCount()}) catch return;
+    buf.appendSlice(arena, ",\"api_calls\":[") catch return;
 
     var api_count: usize = 0;
     for (rec.entries.items) |entry| {
@@ -1387,26 +1394,26 @@ fn handleHarReplay(request: *std.http.Server.Request, arena: std.mem.Allocator, 
             if (!is_doc) continue;
         }
 
-        if (api_count > 0) w.writeAll(",") catch return;
+        if (api_count > 0) buf.appendSlice(arena, ",") catch return;
 
         const escaped_url_entry = jsonEscapeAlloc(arena, entry.url) orelse entry.url;
         const escaped_method = jsonEscapeAlloc(arena, entry.method) orelse entry.method;
         const escaped_mime = jsonEscapeAlloc(arena, entry.mime_type) orelse entry.mime_type;
 
         // Build the entry object
-        w.writeAll("{") catch return;
-        w.print("\"method\":\"{s}\",\"url\":\"{s}\",\"status\":{d},\"mime\":\"{s}\"", .{
+        buf.appendSlice(arena, "{") catch return;
+        buf.print(arena, "\"method\":\"{s}\",\"url\":\"{s}\",\"status\":{d},\"mime\":\"{s}\"", .{
             escaped_method, escaped_url_entry, entry.status, escaped_mime,
         }) catch return;
 
         // Include request headers and post data if present
         if (entry.request_headers.len > 0) {
             const escaped_hdrs = jsonEscapeAlloc(arena, entry.request_headers) orelse "";
-            w.print(",\"request_headers\":\"{s}\"", .{escaped_hdrs}) catch return;
+            buf.print(arena, ",\"request_headers\":\"{s}\"", .{escaped_hdrs}) catch return;
         }
         if (entry.post_data.len > 0) {
             const escaped_post = jsonEscapeAlloc(arena, entry.post_data) orelse "";
-            w.print(",\"post_data\":\"{s}\"", .{escaped_post}) catch return;
+            buf.print(arena, ",\"post_data\":\"{s}\"", .{escaped_post}) catch return;
         }
 
         // Generate code snippets based on format
@@ -1415,39 +1422,39 @@ fn handleHarReplay(request: *std.http.Server.Request, arena: std.mem.Allocator, 
         const want_python = std.mem.eql(u8, format, "python") or std.mem.eql(u8, format, "all");
 
         if (want_curl) {
-            w.writeAll(",\"curl\":\"") catch return;
-            w.print("curl -X {s} '{s}'", .{ escaped_method, escaped_url_entry }) catch return;
-            w.writeAll("\"") catch return;
+            buf.appendSlice(arena, ",\"curl\":\"") catch return;
+            buf.print(arena, "curl -X {s} '{s}'", .{ escaped_method, escaped_url_entry }) catch return;
+            buf.appendSlice(arena, "\"") catch return;
         }
         if (want_fetch) {
-            w.writeAll(",\"fetch\":\"") catch return;
+            buf.appendSlice(arena, ",\"fetch\":\"") catch return;
             if (std.mem.eql(u8, entry.method, "GET")) {
-                w.print("await fetch('{s}')", .{escaped_url_entry}) catch return;
+                buf.print(arena, "await fetch('{s}')", .{escaped_url_entry}) catch return;
             } else {
-                w.print("await fetch('{s}', {{method: '{s}', headers: {{'Content-Type': 'application/json'}}, body: JSON.stringify({{}})}}))", .{ escaped_url_entry, escaped_method }) catch return;
+                buf.print(arena, "await fetch('{s}', {{method: '{s}', headers: {{'Content-Type': 'application/json'}}, body: JSON.stringify({{}})}}))", .{ escaped_url_entry, escaped_method }) catch return;
             }
-            w.writeAll("\"") catch return;
+            buf.appendSlice(arena, "\"") catch return;
         }
         if (want_python) {
-            w.writeAll(",\"python\":\"") catch return;
+            buf.appendSlice(arena, ",\"python\":\"") catch return;
             if (std.mem.eql(u8, entry.method, "GET")) {
-                w.print("requests.get('{s}')", .{escaped_url_entry}) catch return;
+                buf.print(arena, "requests.get('{s}')", .{escaped_url_entry}) catch return;
             } else {
-                w.print("requests.{s}('{s}', json={{}})", .{
+                buf.print(arena, "requests.{s}('{s}', json={{}})", .{
                     if (std.mem.eql(u8, entry.method, "POST")) "post" else if (std.mem.eql(u8, entry.method, "PUT")) "put" else if (std.mem.eql(u8, entry.method, "DELETE")) "delete" else "post",
                     escaped_url_entry,
                 }) catch return;
             }
-            w.writeAll("\"") catch return;
+            buf.appendSlice(arena, "\"") catch return;
         }
 
-        w.writeAll("}") catch return;
+        buf.appendSlice(arena, "}") catch return;
         api_count += 1;
     }
 
-    w.writeAll("],\"total_api_calls\":") catch return;
-    w.print("{d}", .{api_count}) catch return;
-    w.writeAll(",\"hint\":\"Use these code snippets to interact with the site's API directly. Add cookies/headers from /cookies and /headers endpoints for authenticated requests.\"}") catch return;
+    buf.appendSlice(arena, "],\"total_api_calls\":") catch return;
+    buf.print(arena, "{d}", .{api_count}) catch return;
+    buf.appendSlice(arena, ",\"hint\":\"Use these code snippets to interact with the site's API directly. Add cookies/headers from /cookies and /headers endpoints for authenticated requests.\"}") catch return;
 
     const result = buf.toOwnedSlice(arena) catch {
         resp.sendError(request, 500, "Internal Server Error");
@@ -1886,33 +1893,32 @@ fn handleDiffSnapshot(request: *std.http.Server.Request, arena: std.mem.Allocato
 
     // Serialize diff as JSON
     var json_buf: std.ArrayList(u8) = .empty;
-    const writer = json_buf.writer(arena);
-    writer.writeAll("[") catch return;
+    json_buf.appendSlice(arena, "[") catch return;
     for (diff_entries, 0..) |entry, i| {
-        if (i > 0) writer.writeAll(",") catch return;
+        if (i > 0) json_buf.appendSlice(arena, ",") catch return;
         const kind_str: []const u8 = switch (entry.kind) {
             .added => "added",
             .removed => "removed",
             .changed => "changed",
         };
-        writer.writeAll("{") catch return;
-        writeJsonField(writer, arena, "kind", kind_str) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "ref", entry.node.ref) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "role", entry.node.role) catch return;
-        writer.writeAll(",") catch return;
-        writeJsonField(writer, arena, "name", entry.node.name) catch return;
-        writer.writeAll("}") catch return;
+        json_buf.appendSlice(arena, "{") catch return;
+        writeJsonField(&json_buf, arena, "kind", kind_str) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "ref", entry.node.ref) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "role", entry.node.role) catch return;
+        json_buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&json_buf, arena, "name", entry.node.name) catch return;
+        json_buf.appendSlice(arena, "}") catch return;
     }
-    writer.writeAll("]") catch return;
+    json_buf.appendSlice(arena, "]") catch return;
     resp.sendJson(request, json_buf.items);
 }
 
-fn writeJsonField(writer: anytype, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
+fn writeJsonField(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
     const escaped = try json_util.jsonEscape(value, allocator);
     defer allocator.free(escaped);
-    try writer.print("\"{s}\":\"{s}\"", .{ key, escaped });
+    try buf.print(allocator, "\"{s}\":\"{s}\"", .{ key, escaped });
 }
 
 fn handleEmulate(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
@@ -2159,7 +2165,7 @@ fn handleAuthProfileSave(
     const payload = std.fmt.allocPrint(
         arena,
         "{{\"version\":1,\"name\":\"{s}\",\"origin\":\"{s}\",\"saved_at\":{d},\"cookies\":{s},\"local_storage\":{s},\"session_storage\":{s}}}",
-        .{ escaped_name, escaped_origin, std.time.timestamp(), cookies_json, local_storage, session_storage },
+        .{ escaped_name, escaped_origin, compat.timestampSeconds(), cookies_json, local_storage, session_storage },
     ) catch {
         resp.sendError(request, 500, "Failed to build auth profile payload");
         return;
@@ -2274,13 +2280,12 @@ fn handleAuthProfileList(
     defer auth_profiles.freeProfiles(arena, profiles);
 
     var json_buf: std.ArrayList(u8) = .empty;
-    const writer = json_buf.writer(arena);
-    writer.writeAll("{\"profiles\":[") catch {
+    json_buf.appendSlice(arena, "{\"profiles\":[") catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
     for (profiles, 0..) |profile, i| {
-        if (i > 0) writer.writeAll(",") catch {};
+        if (i > 0) json_buf.appendSlice(arena, ",") catch {};
         const escaped_name = jsonEscapeAlloc(arena, profile.name) orelse {
             resp.sendError(request, 500, "Failed to encode profile name");
             return;
@@ -2289,7 +2294,8 @@ fn handleAuthProfileList(
             resp.sendError(request, 500, "Failed to encode profile origin");
             return;
         };
-        writer.print(
+        json_buf.print(
+            arena,
             "{{\"name\":\"{s}\",\"origin\":\"{s}\",\"saved_at\":{d},\"backend\":\"{s}\"}}",
             .{
                 escaped_name,
@@ -2302,7 +2308,7 @@ fn handleAuthProfileList(
             return;
         };
     }
-    writer.writeAll("]}") catch {
+    json_buf.appendSlice(arena, "]}") catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2540,7 +2546,7 @@ fn handleDiffScreenshot(request: *std.http.Server.Request, arena: std.mem.Alloca
 
     // Sleep for the delay
     const delay_ms = std.fmt.parseInt(u64, delay_str, 10) catch 1000;
-    std.Thread.sleep(delay_ms * std.time.ns_per_ms);
+    compat.threadSleep(delay_ms * std.time.ns_per_ms);
 
     // Take second screenshot
     const resp2 = client.send(arena, protocol.Methods.page_capture_screenshot, screenshot_params) catch {
@@ -3540,7 +3546,7 @@ fn handleWait(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
                 resp.sendJson(request, body);
                 return;
             }
-            std.Thread.sleep(100 * std.time.ns_per_ms);
+            compat.threadSleep(100 * std.time.ns_per_ms);
         }
         const body = std.fmt.allocPrint(arena, "{{\"status\":\"timeout\",\"selector\":\"{s}\",\"timeout_ms\":{d}}}", .{ sel, timeout_ms }) catch {
             resp.sendError(request, 500, "Internal Server Error");
@@ -3565,7 +3571,7 @@ fn handleWait(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
                 resp.sendJson(request, body);
                 return;
             }
-            std.Thread.sleep(100 * std.time.ns_per_ms);
+            compat.threadSleep(100 * std.time.ns_per_ms);
         }
         resp.sendJson(request, "{\"status\":\"ready\",\"readyState\":\"timeout\"}");
     }
@@ -4031,18 +4037,17 @@ fn handleSessionList(request: *std.http.Server.Request, arena: std.mem.Allocator
     };
 
     var json_buf: std.ArrayList(u8) = .empty;
-    const writer = json_buf.writer(arena);
-    writer.writeAll("{\"sessions\":[") catch {
+    json_buf.appendSlice(arena, "{\"sessions\":[") catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
     for (tabs, 0..) |tab, i| {
-        if (i > 0) writer.writeByte(',') catch {};
-        writer.print("{{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\"}}", .{
+        if (i > 0) json_buf.append(arena, ',') catch {};
+        json_buf.print(arena, "{{\"id\":\"{s}\",\"url\":\"{s}\",\"title\":\"{s}\"}}", .{
             tab.id, tab.url, tab.title,
         }) catch {};
     }
-    writer.writeAll("]}") catch {};
+    json_buf.appendSlice(arena, "]}") catch {};
     resp.sendJson(request, json_buf.items);
 }
 
@@ -4336,7 +4341,7 @@ fn handleAuthExtract(request: *std.http.Server.Request, arena: std.mem.Allocator
     const profile = getQueryParam(target, "profile") orelse "Default";
 
     // Determine cookie DB path based on browser and platform
-    const home = std.posix.getenv("HOME") orelse {
+    const home = compat.getenv("HOME") orelse {
         resp.sendError(request, 500, "Cannot determine HOME directory");
         return;
     };
@@ -4408,18 +4413,11 @@ fn handleAuthExtract(request: *std.http.Server.Request, arena: std.mem.Allocator
         return;
     };
 
-    var child = std.process.Child.init(&.{ "/bin/sh", "-c", query }, arena);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
-    child.spawn() catch {
+    const cmd_result = compat.runCommand(arena, &.{ "/bin/sh", "-c", query }, 1024 * 1024) catch {
         resp.sendError(request, 500, "Failed to run sqlite3 — is it installed?");
         return;
     };
-    const stdout = child.stdout.?.readToEndAlloc(arena, 1024 * 1024) catch {
-        resp.sendError(request, 500, "Failed to read sqlite3 output");
-        return;
-    };
-    _ = child.wait() catch {};
+    const stdout = cmd_result.stdout;
 
     if (stdout.len == 0) {
         const body = std.fmt.allocPrint(arena, "{{\"browser\":\"{s}\",\"profile\":\"{s}\",\"cookies\":[],\"db_path\":\"{s}\"}}", .{ browser, profile, db_path }) catch {
@@ -5004,9 +5002,8 @@ test "parseCdpAddress accepts websocket endpoint path" {
 test "writeJsonField escapes embedded quotes" {
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(std.testing.allocator);
-    const writer = buf.writer(std.testing.allocator);
 
-    try writeJsonField(writer, std.testing.allocator, "title", "say \"hello\"\nnext");
+    try writeJsonField(&buf, std.testing.allocator, "title", "say \"hello\"\nnext");
     try std.testing.expectEqualStrings("\"title\":\"say \\\"hello\\\"\\nnext\"", buf.items);
 }
 

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -740,6 +740,64 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
         return;
     };
 
+    const value_action_fn =
+        \\function(value, append) {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this instanceof HTMLSelectElement) return this;
+        \\    if (this.isContentEditable) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("input,textarea,select,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  target.focus?.();
+        \\  if (target.isContentEditable) {
+        \\    const existing = typeof target.textContent === "string" ? target.textContent : "";
+        \\    target.textContent = append ? (existing + value) : value;
+        \\  } else if ("value" in target) {
+        \\    const existing = typeof target.value === "string" ? target.value : "";
+        \\    target.value = append ? (existing + value) : value;
+        \\  }
+        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+        \\  return "filled";
+        \\}
+    ;
+    const select_action_fn =
+        \\function(value) {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLSelectElement) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("select");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  let next = value;
+        \\  if ("options" in target && target.options) {
+        \\    for (const opt of target.options) {
+        \\      const text = (opt.textContent || "").trim();
+        \\      const label = (opt.label || "").trim();
+        \\      if (opt.value === value || text === value || label === value) {
+        \\        next = opt.value;
+        \\        break;
+        \\      }
+        \\    }
+        \\  }
+        \\  if ("value" in target) target.value = next;
+        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+        \\  return "selected";
+        \\}
+    ;
+
     // Step 2: Build the JS function for the action
     const js_fn: []const u8 = switch (kind) {
         .click => "function() { this.scrollIntoViewIfNeeded(); this.click(); return 'clicked'; }",
@@ -754,16 +812,38 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                 resp.sendError(request, 400, "Missing value parameter for fill/type");
                 return;
             };
-            const escaped_v = jsonEscapeAlloc(arena, v) orelse {
-                resp.sendError(request, 500, "Internal Server Error");
-                return;
-            };
             // realistic=true: use per-character key events for React/Vue compatibility
             const use_realistic = if (realistic) |r| std.mem.eql(u8, r, "true") else false;
             if (use_realistic) {
                 // Focus the element first
-                const focus_fn = "function() { this.focus(); this.value = ''; this.dispatchEvent(new Event('focus', {bubbles:true})); return 'focused'; }";
-                const focus_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, focus_fn }) catch {
+                const focus_fn =
+                    \\function() {
+                    \\  const target = (() => {
+                    \\    if (!this) return null;
+                    \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+                    \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this.isContentEditable) return this;
+                    \\    if (typeof this.querySelector === "function") {
+                    \\      const nested = this.querySelector("input,textarea,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+                    \\      if (nested) return nested;
+                    \\    }
+                    \\    return this;
+                    \\  })();
+                    \\  if (!target) return "missing-target";
+                    \\  target.focus?.();
+                    \\  if (target.isContentEditable) {
+                    \\    target.textContent = "";
+                    \\  } else if ("value" in target) {
+                    \\    target.value = "";
+                    \\  }
+                    \\  target.dispatchEvent(new Event("focus", {bubbles:true}));
+                    \\  return "focused";
+                    \\}
+                ;
+                const escaped_focus_fn = jsonEscapeAlloc(arena, focus_fn) orelse {
+                    resp.sendError(request, 500, "Internal Server Error");
+                    return;
+                };
+                const focus_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_focus_fn }) catch {
                     resp.sendError(request, 500, "Internal Server Error");
                     return;
                 };
@@ -782,8 +862,30 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                     _ = client.send(arena, protocol.Methods.input_dispatch_key_event, up_params) catch continue;
                 }
                 // Dispatch change event on blur
-                const change_fn = "function() { this.dispatchEvent(new Event('change', {bubbles:true})); this.dispatchEvent(new Event('blur', {bubbles:true})); return 'filled'; }";
-                const change_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, change_fn }) catch {
+                const change_fn =
+                    \\function() {
+                    \\  const target = (() => {
+                    \\    if (!this) return null;
+                    \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+                    \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this.isContentEditable) return this;
+                    \\    if (typeof this.querySelector === "function") {
+                    \\      const nested = this.querySelector("input,textarea,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+                    \\      if (nested) return nested;
+                    \\    }
+                    \\    return this;
+                    \\  })();
+                    \\  if (!target) return "missing-target";
+                    \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+                    \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+                    \\  target.dispatchEvent(new Event("blur", {bubbles:true}));
+                    \\  return "filled";
+                    \\}
+                ;
+                const escaped_change_fn = jsonEscapeAlloc(arena, change_fn) orelse {
+                    resp.sendError(request, 500, "Internal Server Error");
+                    return;
+                };
+                const change_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_change_fn }) catch {
                     resp.sendError(request, 500, "Internal Server Error");
                     return;
                 };
@@ -794,11 +896,40 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                 resp.sendJson(request, change_response);
                 return;
             }
-            const fn_str = std.fmt.allocPrint(arena, "function() {{ this.focus(); this.value = '{s}'; this.dispatchEvent(new Event('input', {{bubbles:true}})); return 'filled'; }}", .{escaped_v}) catch {
+            break :blk value_action_fn;
+        },
+        .select => blk: {
+            const v = value orelse {
+                resp.sendError(request, 400, "Missing value parameter for select");
+                return;
+            };
+            _ = v;
+            break :blk select_action_fn;
+        },
+        .scroll, .press => unreachable,
+    };
+
+    const escaped_js_fn = jsonEscapeAlloc(arena, js_fn) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    // Step 3: Call function on the resolved object
+    const call_params = switch (kind) {
+        .fill, .@"type" => blk: {
+            const v = value orelse {
+                resp.sendError(request, 400, "Missing value parameter for fill/type");
+                return;
+            };
+            const escaped_v = jsonEscapeAlloc(arena, v) orelse {
                 resp.sendError(request, 500, "Internal Server Error");
                 return;
             };
-            break :blk fn_str;
+            break :blk std.fmt.allocPrint(
+                arena,
+                "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}},{{\"value\":{s}}}],\"returnByValue\":true}}",
+                .{ object_id, escaped_js_fn, escaped_v, if (kind == .@"type") "true" else "false" },
+            );
         },
         .select => blk: {
             const v = value orelse {
@@ -809,17 +940,18 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                 resp.sendError(request, 500, "Internal Server Error");
                 return;
             };
-            const fn_str = std.fmt.allocPrint(arena, "function() {{ this.value = '{s}'; this.dispatchEvent(new Event('change', {{bubbles:true}})); return 'selected'; }}", .{escaped_v}) catch {
-                resp.sendError(request, 500, "Internal Server Error");
-                return;
-            };
-            break :blk fn_str;
+            break :blk std.fmt.allocPrint(
+                arena,
+                "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}}],\"returnByValue\":true}}",
+                .{ object_id, escaped_js_fn, escaped_v },
+            );
         },
-        .scroll, .press => unreachable,
-    };
-
-    // Step 3: Call function on the resolved object
-    const call_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, js_fn }) catch {
+        else => std.fmt.allocPrint(
+            arena,
+            "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}",
+            .{ object_id, escaped_js_fn },
+        ),
+    } catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -842,15 +974,20 @@ fn handleText(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         return;
     };
 
-    const selector = getQueryParam(target, "selector");
-    const params = if (selector) |sel|
-        std.fmt.allocPrint(arena,
-            "{{\"expression\":\"document.querySelector('{s}')?.innerText || null\",\"returnByValue\":true}}", .{sel}) catch {
+    const selector = getDecodedQueryParamAlloc(arena, target, "selector");
+    const params = if (selector) |sel| blk: {
+        const escaped_sel = jsonEscapeAlloc(arena, sel) orelse {
             resp.sendError(request, 500, "Internal Server Error");
             return;
-        }
+        };
+        break :blk std.fmt.allocPrint(arena,
+            "{{\"expression\":\"(() => {{ const el = document.querySelector(\\\"{s}\\\"); return el ? (el.innerText ?? '') : ''; }})()\",\"returnByValue\":true}}", .{escaped_sel}) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+    }
     else
-        @as([]const u8, "{\"expression\":\"document.body.innerText\",\"returnByValue\":true}");
+        @as([]const u8, "{\"expression\":\"document.body ? document.body.innerText : ''\",\"returnByValue\":true}");
     const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
@@ -912,8 +1049,12 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         return;
     };
 
+    const escaped_expr = jsonEscapeAlloc(arena, expr) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
     const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{expr}) catch {
+        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3822,7 +3963,7 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         resp.sendError(request, 400, "Missing 'by' parameter (role|text|label|placeholder|testid|alt|title)");
         return;
     };
-    const value = getQueryParam(target, "value") orelse {
+    const value = getDecodedQueryParamAlloc(arena, target, "value") orelse {
         resp.sendError(request, 400, "Missing 'value' parameter");
         return;
     };
@@ -3834,32 +3975,37 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         return;
     };
 
+    const escaped_value = jsonEscapeAlloc(arena, value) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
     // Build JS to find elements by semantic locator
     const js = if (std.mem.eql(u8, by, "role"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[role=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100),ref:'found_'+i}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('[role=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100),ref:'found_'+i}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "text"))
         if (exact != null and std.mem.eql(u8, exact.?, "true"))
             std.fmt.allocPrint(arena,
-                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.trim()==='{s}'&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{value})
+                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.trim()===\"{s}\"&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
         else
             std.fmt.allocPrint(arena,
-                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.includes('{s}')&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{value})
+                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.includes(\"{s}\")&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "label"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('label')].filter(l=>l.innerText.includes('{s}')).map((l,i)=>{{var el=l.htmlFor?document.getElementById(l.htmlFor):l.querySelector('input,select,textarea');return {{index:i,label:l.innerText.substring(0,100),tag:el?el.tagName:'none'}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('label')].filter(l=>l.innerText.includes(\"{s}\")).map((l,i)=>{{var el=l.htmlFor?document.getElementById(l.htmlFor):l.querySelector('input,select,textarea');return {{index:i,label:l.innerText.substring(0,100),tag:el?el.tagName:'none'}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "placeholder"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[placeholder]')].filter(el=>el.placeholder.includes('{s}')).map((el,i)=>{{return {{index:i,tag:el.tagName,placeholder:el.placeholder}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('[placeholder]')].filter(el=>el.placeholder.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,placeholder:el.placeholder}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "testid"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[data-testid=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('[data-testid=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "alt"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[alt]')].filter(el=>el.alt.includes('{s}')).map((el,i)=>{{return {{index:i,tag:el.tagName,alt:el.alt}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('[alt]')].filter(el=>el.alt.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,alt:el.alt}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "title"))
         std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[title]')].filter(el=>el.title.includes('{s}')).map((el,i)=>{{return {{index:i,tag:el.tagName,title:el.title}}}}))", .{value})
+            "JSON.stringify([...document.querySelectorAll('[title]')].filter(el=>el.title.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,title:el.title}}}}))", .{escaped_value})
     else {
         resp.sendError(request, 400, "Unknown 'by' type. Use: role|text|label|placeholder|testid|alt|title");
         return;
@@ -3870,8 +4016,12 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         return;
     };
 
+    const escaped_expr = jsonEscapeAlloc(arena, expr) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
     const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{expr}) catch {
+        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4088,7 +4238,7 @@ fn handleSetUserAgent(request: *std.http.Server.Request, arena: std.mem.Allocato
         resp.sendError(request, 400, "Missing tab_id parameter");
         return;
     };
-    const ua = getQueryParam(target, "ua") orelse {
+    const ua = getDecodedQueryParamAlloc(arena, target, "ua") orelse {
         resp.sendError(request, 400, "Missing ua parameter");
         return;
     };
@@ -4096,7 +4246,11 @@ fn handleSetUserAgent(request: *std.http.Server.Request, arena: std.mem.Allocato
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const params = std.fmt.allocPrint(arena, "{{\"userAgent\":\"{s}\"}}", .{ua}) catch {
+    const escaped_ua = jsonEscapeAlloc(arena, ua) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const params = std.fmt.allocPrint(arena, "{{\"userAgent\":\"{s}\"}}", .{escaped_ua}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4105,7 +4259,7 @@ fn handleSetUserAgent(request: *std.http.Server.Request, arena: std.mem.Allocato
         return;
     };
     _ = response;
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"userAgent\":\"{s}\"}}", .{ua}) catch {
+    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"userAgent\":\"{s}\"}}", .{escaped_ua}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4842,6 +4996,18 @@ test "buildGetExpression box" {
     const expr = buildGetExpression(std.testing.allocator, "box", "div.card", null) orelse unreachable;
     defer std.testing.allocator.free(expr);
     try std.testing.expect(std.mem.indexOf(u8, expr, "getBoundingClientRect") != null);
+}
+
+test "runtime evaluate payload escapes embedded expression quotes" {
+    const arena = std.testing.allocator;
+    const expr = "JSON.stringify([...document.querySelectorAll('label')].filter(l=>l.innerText.includes(\"Text input\")))";
+    const escaped = jsonEscapeAlloc(arena, expr).?;
+    defer if (escaped.ptr != expr.ptr) arena.free(escaped);
+    const payload = try std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped});
+    defer arena.free(payload);
+
+    try std.testing.expect(std.mem.indexOf(u8, payload, "\\\"Text input\\\"") != null);
+    try std.testing.expect(std.mem.startsWith(u8, payload, "{\"expression\":\""));
 }
 
 test "buildGetExpression html without selector returns null" {

--- a/src/snapshot/a11y.zig
+++ b/src/snapshot/a11y.zig
@@ -223,22 +223,21 @@ pub fn buildSnapshot(
 /// ~6x fewer tokens than JSON for the same data.
 pub fn formatCompact(nodes: []const A11yNode, allocator: std.mem.Allocator) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const w = buf.writer(allocator);
 
     for (nodes) |node| {
         // Indent by depth
         var d: u16 = 0;
-        while (d < node.depth) : (d += 1) try w.writeAll("  ");
+        while (d < node.depth) : (d += 1) try buf.appendSlice(allocator, "  ");
 
-        try w.writeAll(node.role);
+        try buf.appendSlice(allocator, node.role);
         if (node.name.len > 0) {
-            try w.print(" \"{s}\"", .{node.name});
+            try buf.print(allocator, " \"{s}\"", .{node.name});
         }
-        if (node.ref.len > 0) try w.print(" @{s}", .{node.ref});
+        if (node.ref.len > 0) try buf.print(allocator, " @{s}", .{node.ref});
         if (node.value.len > 0) {
-            try w.print(" = {s}", .{node.value});
+            try buf.print(allocator, " = {s}", .{node.value});
         }
-        try w.writeAll("\n");
+        try buf.appendSlice(allocator, "\n");
     }
 
     return buf.toOwnedSlice(allocator);
@@ -247,20 +246,19 @@ pub fn formatCompact(nodes: []const A11yNode, allocator: std.mem.Allocator) ![]c
 /// Legacy indented text format (kept for --text flag).
 pub fn formatText(nodes: []const A11yNode, allocator: std.mem.Allocator) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
-    const writer = buf.writer(allocator);
 
     for (nodes) |node| {
         for (0..node.depth) |_| {
-            try writer.writeAll("  ");
+            try buf.appendSlice(allocator, "  ");
         }
-        try writer.print("[{s}] {s}", .{ node.ref, node.role });
+        try buf.print(allocator, "[{s}] {s}", .{ node.ref, node.role });
         if (node.name.len > 0) {
-            try writer.print(" \"{s}\"", .{node.name});
+            try buf.print(allocator, " \"{s}\"", .{node.name});
         }
         if (node.value.len > 0) {
-            try writer.print(" value=\"{s}\"", .{node.value});
+            try buf.print(allocator, " value=\"{s}\"", .{node.value});
         }
-        try writer.writeAll("\n");
+        try buf.appendSlice(allocator, "\n");
     }
 
     return buf.toOwnedSlice(allocator);

--- a/src/storage/auth_profiles.zig
+++ b/src/storage/auth_profiles.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
 const std = @import("std");
 const json_util = @import("../util/json.zig");
+const compat = @import("../compat.zig");
 
 pub const Backend = enum {
     keychain,
@@ -33,7 +34,7 @@ pub fn saveProfile(
 
     const dir_path = try authProfilesDir(allocator, state_dir);
     defer allocator.free(dir_path);
-    try std.fs.cwd().makePath(dir_path);
+    try compat.cwdMakePath(dir_path);
 
     switch (backend) {
         .keychain => {
@@ -46,7 +47,7 @@ pub fn saveProfile(
     try writeMetaFile(allocator, dir_path, safe_name, .{
         .name = name,
         .origin = origin,
-        .saved_at = std.time.timestamp(),
+        .saved_at = compat.timestampSeconds(),
         .backend = backend,
     });
 
@@ -97,10 +98,7 @@ pub fn deleteProfile(
 
     const meta_path = try metaFilePath(allocator, dir_path, safe_name);
     defer allocator.free(meta_path);
-    std.fs.cwd().deleteFile(meta_path) catch |err| switch (err) {
-        error.FileNotFound => {},
-        else => return err,
-    };
+    compat.cwdDeleteFile(meta_path) catch {};
 }
 
 pub fn listProfiles(
@@ -110,20 +108,24 @@ pub fn listProfiles(
     const dir_path = try authProfilesDir(allocator, state_dir);
     defer allocator.free(dir_path);
 
-    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |err| switch (err) {
-        error.FileNotFound => return allocator.alloc(AuthProfileMeta, 0),
-        else => return err,
-    };
-    defer dir.close();
+    var path_buf: [4096]u8 = undefined;
+    if (dir_path.len >= path_buf.len) return error.NameTooLong;
+    @memcpy(path_buf[0..dir_path.len], dir_path);
+    path_buf[dir_path.len] = 0;
+    const dir_z: [*:0]const u8 = path_buf[0..dir_path.len :0];
+
+    const dp = std.c.opendir(dir_z) orelse return allocator.alloc(AuthProfileMeta, 0);
+    defer _ = std.c.closedir(dp);
 
     var list: std.ArrayList(AuthProfileMeta) = .empty;
     defer list.deinit(allocator);
 
-    var iter = dir.iterate();
-    while (try iter.next()) |entry| {
-        if (!std.mem.endsWith(u8, entry.name, ".meta.json")) continue;
+    while (std.c.readdir(dp)) |entry| {
+        const name_ptr: [*:0]const u8 = @ptrCast(&entry.name);
+        const name = std.mem.sliceTo(name_ptr, 0);
+        if (!std.mem.endsWith(u8, name, ".meta.json")) continue;
 
-        const safe_name = entry.name[0 .. entry.name.len - ".meta.json".len];
+        const safe_name = name[0 .. name.len - ".meta.json".len];
         const meta = readMetaFile(allocator, dir_path, safe_name) catch continue;
         try list.append(allocator, meta);
     }
@@ -221,7 +223,7 @@ fn readMetaFile(
     const path = try metaFilePath(allocator, dir_path, safe_name);
     defer allocator.free(path);
 
-    const body = try std.fs.cwd().readFileAlloc(allocator, path, 1024 * 1024);
+    const body = try compat.cwdReadFile(allocator, path, 1024 * 1024);
     defer allocator.free(body);
 
     const name = extractStringField(body, "\"name\"") orelse return error.InvalidProfileMeta;
@@ -255,7 +257,7 @@ fn readSecretFile(
 ) ![]u8 {
     const path = try secretFilePath(allocator, dir_path, safe_name);
     defer allocator.free(path);
-    return std.fs.cwd().readFileAlloc(allocator, path, 8 * 1024 * 1024);
+    return compat.cwdReadFile(allocator, path, 8 * 1024 * 1024);
 }
 
 fn deleteSecretFile(
@@ -265,16 +267,11 @@ fn deleteSecretFile(
 ) !void {
     const path = try secretFilePath(allocator, dir_path, safe_name);
     defer allocator.free(path);
-    std.fs.cwd().deleteFile(path) catch |err| switch (err) {
-        error.FileNotFound => {},
-        else => return err,
-    };
+    compat.cwdDeleteFile(path) catch {};
 }
 
 fn writeFile(path: []const u8, contents: []const u8) !void {
-    const file = try std.fs.cwd().createFile(path, .{ .truncate = true });
-    defer file.close();
-    try file.writeAll(contents);
+    try compat.cwdWriteFile(path, contents);
 }
 
 fn extractStringField(json: []const u8, field: []const u8) ?[]const u8 {
@@ -337,27 +334,69 @@ fn keychainDelete(allocator: std.mem.Allocator, name: []const u8) !void {
 }
 
 fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8) ![]u8 {
-    const result = try std.process.Child.run(.{
-        .allocator = allocator,
-        .argv = argv,
-        .max_output_bytes = 8 * 1024 * 1024,
-    });
-    defer allocator.free(result.stderr);
-    errdefer allocator.free(result.stdout);
+    // Build null-terminated argv for execve
+    const argv_z = try allocator.alloc(?[*:0]const u8, argv.len + 1);
+    defer allocator.free(argv_z);
+    for (argv, 0..) |arg, i| {
+        argv_z[i] = @ptrCast(arg.ptr);
+    }
+    argv_z[argv.len] = null;
 
-    switch (result.term) {
-        .Exited => |code| {
-            if (code != 0) return error.CommandFailed;
-        },
-        else => return error.CommandFailed,
+    // Create pipe for capturing stdout
+    var pipe_fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&pipe_fds) != 0) return error.CommandFailed;
+
+    const pid = std.c.fork();
+    if (pid < 0) return error.CommandFailed;
+
+    if (pid == 0) {
+        // Child: close read end, redirect stdout to pipe write end
+        _ = std.c.close(pipe_fds[0]);
+        _ = std.c.dup2(pipe_fds[1], 1);
+        _ = std.c.close(pipe_fds[1]);
+        // Redirect stderr to /dev/null
+        const devnull = std.c.open("/dev/null", .{ .ACCMODE = .WRONLY }, @as(c_uint, 0));
+        if (devnull >= 0) {
+            _ = std.c.dup2(devnull, 2);
+            _ = std.c.close(devnull);
+        }
+        _ = std.c.execve(argv_z[0].?, @ptrCast(argv_z.ptr), @ptrCast(std.c.environ));
+        std.c.exit(127);
     }
 
-    const trimmed = std.mem.trim(u8, result.stdout, "\r\n");
-    if (trimmed.len == result.stdout.len) return result.stdout;
+    // Parent: close write end, read stdout from pipe
+    _ = std.c.close(pipe_fds[1]);
+    defer _ = std.c.close(pipe_fds[0]);
 
-    const duped = try allocator.dupe(u8, trimmed);
-    allocator.free(result.stdout);
-    return duped;
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(allocator);
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.c.read(pipe_fds[0], &buf, buf.len);
+        if (n <= 0) break;
+        try output.appendSlice(allocator, buf[0..@intCast(n)]);
+    }
+
+    var status: c_int = 0;
+    _ = std.c.waitpid(pid, &status, 0);
+    // Check exit status (WIFEXITED && WEXITSTATUS == 0)
+    if ((status & 0x7f) != 0 or ((status >> 8) & 0xff) != 0) return error.CommandFailed;
+
+    const trimmed = std.mem.trim(u8, output.items, "\r\n");
+    return try allocator.dupe(u8, trimmed);
+}
+
+fn deleteTreeAbsolute(dir: []const u8) void {
+    var buf: [4096]u8 = undefined;
+    const cmd = std.fmt.bufPrint(&buf, "rm -rf {s}", .{dir}) catch return;
+    buf[cmd.len] = 0;
+    const pid = std.c.fork();
+    if (pid == 0) {
+        const argv = [_:null]?[*:0]const u8{ "/bin/sh", "-c", buf[0..cmd.len :0], null };
+        _ = std.c.execve("/bin/sh", &argv, @ptrCast(std.c.environ));
+        std.c.exit(127);
+    }
+    if (pid > 0) _ = std.c.waitpid(pid, null, 0);
 }
 
 test "sanitizeName normalizes unsafe characters" {
@@ -368,13 +407,13 @@ test "sanitizeName normalizes unsafe characters" {
 
 test "file-backed auth profile round trip" {
     const allocator = std.testing.allocator;
-    const dir = try std.fmt.allocPrint(allocator, "/tmp/kuri_auth_profile_test_{d}", .{std.time.timestamp()});
+    const dir = try std.fmt.allocPrint(allocator, "/tmp/kuri_auth_profile_test_{d}", .{compat.timestampSeconds()});
     defer allocator.free(dir);
-    defer std.fs.deleteTreeAbsolute(dir) catch {};
+    defer deleteTreeAbsolute(dir);
 
     const profiles_dir = try authProfilesDir(allocator, dir);
     defer allocator.free(profiles_dir);
-    try std.fs.cwd().makePath(profiles_dir);
+    try compat.cwdMakePath(profiles_dir);
 
     const safe_name = try sanitizeName(allocator, "demo");
     defer allocator.free(safe_name);

--- a/src/storage/local.zig
+++ b/src/storage/local.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 
 /// Generate a filename from URL and format.
 /// Format: {domain}_{path}_{date}.{ext}
 pub fn generateFilename(url: []const u8, ext: []const u8, allocator: std.mem.Allocator) ![]const u8 {
     const domain = extractDomain(url);
-    const epoch: u64 = @intCast(std.time.timestamp());
+    const epoch: u64 = @intCast(compat.timestampSeconds());
     const epoch_secs = epoch;
 
     // Simple date: use epoch seconds for uniqueness
@@ -57,22 +58,19 @@ pub fn saveToLocal(
     if (!validateOutputDir(output_dir)) return error.InvalidPath;
 
     // Create directory if it doesn't exist
-    std.fs.cwd().makePath(output_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => return err,
-    };
+    compat.cwdMakePath(output_dir) catch {};
 
     const filename = try generateFilename(url, ext, allocator);
     defer allocator.free(filename);
 
     const filepath = try std.fs.path.join(allocator, &.{ output_dir, filename });
 
-    const file = std.fs.cwd().createFile(filepath, .{ .exclusive = false }) catch |err| {
+    const fd = compat.cwdCreateFile(filepath) catch |err| {
         allocator.free(filepath);
         return err;
     };
-    defer file.close();
-    file.writeAll(content) catch |err| {
+    defer compat.fdClose(fd);
+    compat.fdWriteAll(fd, content) catch |err| {
         allocator.free(filepath);
         return err;
     };
@@ -107,7 +105,7 @@ test "getDomainName returns domain with dots" {
 
 test "saveToLocal writes file and returns path" {
     const allocator = std.testing.allocator;
-    const epoch: u64 = @intCast(std.time.timestamp());
+    const epoch: u64 = @intCast(compat.timestampSeconds());
     const dir = try std.fmt.allocPrint(allocator, "/tmp/browdie_test_{d}", .{epoch});
     defer allocator.free(dir);
 
@@ -115,14 +113,25 @@ test "saveToLocal writes file and returns path" {
     defer allocator.free(filepath);
 
     // Verify file content
-    const file = try std.fs.cwd().openFile(filepath, .{});
-    defer file.close();
-    var buf: [64]u8 = undefined;
-    const n = try file.readAll(&buf);
-    try std.testing.expectEqualStrings("hello world", buf[0..n]);
+    const content = try compat.cwdReadFile(std.testing.allocator, filepath, 64);
+    defer std.testing.allocator.free(content);
+    try std.testing.expectEqualStrings("hello world", content);
 
     // Clean up test dir
-    std.fs.deleteTreeAbsolute(dir) catch {};
+    deleteTreeAbsolute(dir);
+}
+
+fn deleteTreeAbsolute(dir: []const u8) void {
+    var buf: [4096]u8 = undefined;
+    const cmd = std.fmt.bufPrint(&buf, "rm -rf {s}", .{dir}) catch return;
+    buf[cmd.len] = 0;
+    const pid = std.c.fork();
+    if (pid == 0) {
+        const argv = [_:null]?[*:0]const u8{ "/bin/sh", "-c", buf[0..cmd.len :0], null };
+        _ = std.c.execve("/bin/sh", &argv, @ptrCast(std.c.environ));
+        std.c.exit(127);
+    }
+    if (pid > 0) _ = std.c.waitpid(pid, null, 0);
 }
 
 test "saveToLocal rejects traversal" {

--- a/src/storage/r2.zig
+++ b/src/storage/r2.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const compat = @import("../compat.zig");
 
 pub const R2Config = struct {
     endpoint_url: []const u8,
@@ -8,10 +9,10 @@ pub const R2Config = struct {
 };
 
 pub fn loadConfig() ?R2Config {
-    const endpoint = std.posix.getenv("R2_ENDPOINT_URL") orelse return null;
-    const access_key = std.posix.getenv("R2_ACCESS_KEY") orelse return null;
-    const secret_key = std.posix.getenv("R2_SECRET_KEY") orelse return null;
-    const bucket = std.posix.getenv("R2_BUCKET_NAME") orelse return null;
+    const endpoint = compat.getenv("R2_ENDPOINT_URL") orelse return null;
+    const access_key = compat.getenv("R2_ACCESS_KEY") orelse return null;
+    const secret_key = compat.getenv("R2_SECRET_KEY") orelse return null;
+    const bucket = compat.getenv("R2_BUCKET_NAME") orelse return null;
 
     return .{
         .endpoint_url = endpoint,
@@ -50,7 +51,7 @@ pub fn generateObjectKey(url: []const u8, uuid: []const u8, ext: []const u8, all
     if (std.mem.indexOfScalar(u8, domain, '/')) |idx| {
         domain = domain[0..idx];
     }
-    const timestamp = std.time.timestamp();
+    const timestamp = compat.timestampSeconds();
     return std.fmt.allocPrint(allocator, "{s}/{s}/{d}.{s}", .{ uuid, domain, timestamp, ext });
 }
 

--- a/src/test/harness.zig
+++ b/src/test/harness.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const net = std.net;
+const compat = @import("../compat.zig");
 
 /// Test harness for agent-led browser automation testing.
 /// Provides helpers to launch Chrome, start Browdie, and hit API endpoints.
@@ -21,13 +21,12 @@ pub const TestHarness = struct {
 
     /// Send an HTTP GET request to Browdie and return the response body.
     pub fn get(self: *TestHarness, path: []const u8) ![]const u8 {
-        const address = try net.Address.parseIp4("127.0.0.1", self.browdie_port);
-        const stream = try net.tcpConnectToAddress(address);
+        const stream = try compat.tcpConnectToIp4(self.browdie_port);
         defer stream.close();
 
         // Set read timeout
         const timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-        std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+        stream.setSockOpt(std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout));
 
         const req = try std.fmt.allocPrint(self.allocator, "GET {s} HTTP/1.1\r\nHost: 127.0.0.1:{d}\r\nConnection: close\r\n\r\n", .{ path, self.browdie_port });
         defer self.allocator.free(req);
@@ -106,7 +105,7 @@ pub const TestHarness = struct {
         defer self.allocator.free(action_result);
 
         // Wait for page to settle
-        std.Thread.sleep(500 * std.time.ns_per_ms);
+        compat.threadSleep(500 * std.time.ns_per_ms);
 
         // After snapshot
         const after = try self.get(snap_path);

--- a/src/test/integration.zig
+++ b/src/test/integration.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const net = std.net;
+const compat = @import("../compat.zig");
 
 // Import all modules under test
 const config_mod = @import("../bridge/config.zig");
@@ -24,8 +24,7 @@ const FakeChromeServer = struct {
     fn start(body: []const u8) !FakeChromeServer {
         var port: u16 = 19440;
         while (port < 19540) : (port += 1) {
-            const address = try net.Address.parseIp4("127.0.0.1", port);
-            const server = address.listen(.{ .reuse_address = true }) catch |err| switch (err) {
+            const server = compat.tcpListen(port) catch |err| switch (err) {
                 error.AddressInUse => continue,
                 else => return err,
             };
@@ -39,7 +38,7 @@ const FakeChromeServer = struct {
         self.thread.join();
     }
 
-    fn serveOnce(server: net.Server, body: []const u8) !void {
+    fn serveOnce(server: compat.TcpServer, body: []const u8) !void {
         var tcp_server = server;
         defer tcp_server.deinit();
 
@@ -472,41 +471,35 @@ test "jsonEscape no escaping needed" {
 }
 
 test "writeJsonObject single field" {
-    var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    const writer = stream.writer();
-
+    var buf: std.ArrayList(u8) = .empty;
     const fields = [_][2][]const u8{
         .{ "key", "value" },
     };
-    try json_util.writeJsonObject(writer, &fields);
+    try json_util.writeJsonObject(&buf, std.testing.allocator, &fields);
+    defer std.testing.allocator.free(buf.toOwnedSlice(std.testing.allocator) catch unreachable);
 
-    try std.testing.expectEqualStrings("{\"key\":\"value\"}", stream.getWritten());
+    try std.testing.expectEqualStrings("{\"key\":\"value\"}", buf.items);
 }
 
 test "writeJsonObject multiple fields" {
-    var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    const writer = stream.writer();
-
+    var buf: std.ArrayList(u8) = .empty;
     const fields = [_][2][]const u8{
         .{ "a", "1" },
         .{ "b", "2" },
     };
-    try json_util.writeJsonObject(writer, &fields);
+    try json_util.writeJsonObject(&buf, std.testing.allocator, &fields);
+    defer std.testing.allocator.free(buf.toOwnedSlice(std.testing.allocator) catch unreachable);
 
-    try std.testing.expectEqualStrings("{\"a\":\"1\",\"b\":\"2\"}", stream.getWritten());
+    try std.testing.expectEqualStrings("{\"a\":\"1\",\"b\":\"2\"}", buf.items);
 }
 
 test "writeJsonObject empty" {
-    var buf: [256]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    const writer = stream.writer();
-
+    var buf: std.ArrayList(u8) = .empty;
     const fields: [0][2][]const u8 = .{};
-    try json_util.writeJsonObject(writer, &fields);
+    try json_util.writeJsonObject(&buf, std.testing.allocator, &fields);
+    defer std.testing.allocator.free(buf.toOwnedSlice(std.testing.allocator) catch unreachable);
 
-    try std.testing.expectEqualStrings("{}", stream.getWritten());
+    try std.testing.expectEqualStrings("{}", buf.items);
 }
 
 // ─── Harness Self-Tests ─────────────────────────────────────────────────

--- a/src/test/merjs_e2e.zig
+++ b/src/test/merjs_e2e.zig
@@ -8,7 +8,7 @@
 /// Exit 0 = all pass.  Exit 1 = any failure.
 
 const std = @import("std");
-const net = std.net;
+const compat = @import("compat");
 
 const BROWDIE_PORT: u16 = 8080;
 const MERJS_PORT: u16 = 3000;
@@ -18,12 +18,11 @@ const NAV_SETTLE_MS: u64 = 1_500;
 // ── HTTP helpers ─────────────────────────────────────────────────────────────
 
 fn httpGet(allocator: std.mem.Allocator, port: u16, path: []const u8) ![]const u8 {
-    const addr = try net.Address.parseIp4("127.0.0.1", port);
-    const stream = try net.tcpConnectToAddress(addr);
+    const stream = try compat.tcpConnectToIp4(port);
     defer stream.close();
 
     const timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
-    std.posix.setsockopt(stream.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+    stream.setSockOpt(std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout));
 
     const req = try std.fmt.allocPrint(allocator, "GET {s} HTTP/1.1\r\nHost: 127.0.0.1:{d}\r\nConnection: close\r\n\r\n", .{ path, port });
     defer allocator.free(req);
@@ -82,7 +81,7 @@ fn pageText(a: std.mem.Allocator, tab_id: []const u8, path: []const u8) ![]const
     const url = try std.fmt.allocPrint(a, MERJS_HOST ++ "{s}", .{path});
     const nav = try std.fmt.allocPrint(a, "/navigate?url={s}&tab_id={s}", .{ url, tab_id });
     _ = try httpGet(a, BROWDIE_PORT, nav);
-    std.Thread.sleep(NAV_SETTLE_MS * std.time.ns_per_ms);
+    compat.threadSleep(NAV_SETTLE_MS * std.time.ns_per_ms);
     const text_path = try std.fmt.allocPrint(a, "/text?tab_id={s}", .{tab_id});
     return httpGet(a, BROWDIE_PORT, text_path);
 }
@@ -92,7 +91,7 @@ fn pageSnap(a: std.mem.Allocator, tab_id: []const u8, path: []const u8) ![]const
     const url = try std.fmt.allocPrint(a, MERJS_HOST ++ "{s}", .{path});
     const nav = try std.fmt.allocPrint(a, "/navigate?url={s}&tab_id={s}", .{ url, tab_id });
     _ = try httpGet(a, BROWDIE_PORT, nav);
-    std.Thread.sleep(NAV_SETTLE_MS * std.time.ns_per_ms);
+    compat.threadSleep(NAV_SETTLE_MS * std.time.ns_per_ms);
     const snap_path = try std.fmt.allocPrint(a, "/snapshot?tab_id={s}&filter=interactive&format=text", .{tab_id});
     return httpGet(a, BROWDIE_PORT, snap_path);
 }
@@ -100,7 +99,7 @@ fn pageSnap(a: std.mem.Allocator, tab_id: []const u8, path: []const u8) ![]const
 // ── main ─────────────────────────────────────────────────────────────────────
 
 pub fn main() !void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     var arena_impl: std.heap.ArenaAllocator = .init(gpa_impl.allocator());
     defer arena_impl.deinit();

--- a/src/util/http_fetch.zig
+++ b/src/util/http_fetch.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const compat = @import("../compat.zig");
+
+pub fn fetchHttp(allocator: std.mem.Allocator, url: []const u8, user_agent: []const u8) ![]const u8 {
+    return fetchHttpStd(allocator, url, user_agent) catch |err| switch (err) {
+        error.TlsInitializationFailed, error.CertificateBundleLoadFailure => {
+            if (fetchHttpCurl(allocator, url, user_agent)) |body| {
+                return body;
+            } else |_| {
+                return err;
+            }
+        },
+        else => return err,
+    };
+}
+
+fn fetchHttpStd(allocator: std.mem.Allocator, url: []const u8, user_agent: []const u8) ![]const u8 {
+    var client: std.http.Client = .{ .allocator = allocator, .io = std.Io.Threaded.global_single_threaded.io() };
+    defer client.deinit();
+
+    const uri = try std.Uri.parse(url);
+
+    var req = try client.request(.GET, uri, .{
+        .extra_headers = &.{
+            .{ .name = "User-Agent", .value = user_agent },
+            .{ .name = "Accept", .value = "text/html,application/xhtml+xml,*/*" },
+            .{ .name = "Accept-Encoding", .value = "gzip, deflate" },
+        },
+    });
+    defer req.deinit();
+
+    try req.sendBodiless();
+
+    var redirect_buf: [8192]u8 = undefined;
+    var response = try req.receiveHead(&redirect_buf);
+
+    if (response.head.status != .ok) {
+        std.debug.print("HTTP {d}\n", .{@intFromEnum(response.head.status)});
+        return error.HttpError;
+    }
+
+    var body: std.ArrayList(u8) = .empty;
+    var transfer_buf: [8192]u8 = undefined;
+    var decompress: std.http.Decompress = undefined;
+    var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
+    const reader = response.readerDecompressing(&transfer_buf, &decompress, &decompress_buf);
+    try reader.appendRemainingUnlimited(allocator, &body);
+
+    return body.items;
+}
+
+fn fetchHttpCurl(allocator: std.mem.Allocator, url: []const u8, user_agent: []const u8) ![]const u8 {
+    const result = try compat.runCommand(allocator, &.{
+        "curl",
+        "-fsSL",
+        "--compressed",
+        "-A",
+        user_agent,
+        url,
+    }, 16 * 1024 * 1024);
+    if (result.term != 0 or result.stdout.len == 0) return error.CommandFailed;
+    return result.stdout;
+}

--- a/src/util/json.zig
+++ b/src/util/json.zig
@@ -1,13 +1,13 @@
 const std = @import("std");
 
 /// Write a JSON object with string key-value pairs.
-pub fn writeJsonObject(writer: anytype, fields: []const [2][]const u8) !void {
-    try writer.writeAll("{");
+pub fn writeJsonObject(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, fields: []const [2][]const u8) !void {
+    try buf.appendSlice(allocator, "{");
     for (fields, 0..) |field, i| {
-        if (i > 0) try writer.writeAll(",");
-        try writer.print("\"{s}\":\"{s}\"", .{ field[0], field[1] });
+        if (i > 0) try buf.appendSlice(allocator, ",");
+        try buf.print(allocator, "\"{s}\":\"{s}\"", .{ field[0], field[1] });
     }
-    try writer.writeAll("}");
+    try buf.appendSlice(allocator, "}");
 }
 
 /// Escape a string for JSON output.
@@ -22,7 +22,7 @@ pub fn jsonEscape(input: []const u8, allocator: std.mem.Allocator) ![]const u8 {
             '\t' => try buf.appendSlice(allocator, "\\t"),
             else => {
                 if (c < 0x20) {
-                    try buf.writer(allocator).print("\\u{x:0>4}", .{c});
+                    try buf.print(allocator, "\\u{x:0>4}", .{c});
                 } else {
                     try buf.append(allocator, c);
                 }

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/build.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/build.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    // C headers
+    const c = translateC(b, target, optimize);
+    const c_mod = c.addModule("quickjs_c");
+
+    // Library
+    const lib = try library(b, target, optimize);
+    b.installArtifact(lib);
+
+    // Zig module
+    const mod = b.addModule("quickjs", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{.{
+            .name = "quickjs_c",
+            .module = c_mod,
+        }},
+    });
+
+    // Tests
+    const tests = b.addTest(.{
+        .root_module = mod,
+        // Compiler crash without this.
+        .use_llvm = true,
+    });
+    tests.root_module.linkLibrary(lib);
+    const run_tests = b.addRunArtifact(tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_tests.step);
+}
+
+pub fn translateC(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) *std.Build.Step.TranslateC {
+    const upstream = b.dependency("quickjs", .{});
+
+    const translate = b.addTranslateC(.{
+        .root_source_file = upstream.path("quickjs.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    translate.addIncludePath(upstream.path(""));
+    return translate;
+}
+
+pub fn library(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) !*std.Build.Step.Compile {
+    const upstream = b.dependency("quickjs", .{});
+
+    const lib = b.addLibrary(.{
+        .name = "quickjs-ng",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .linkage = .static,
+    });
+
+    lib.root_module.addIncludePath(upstream.path(""));
+    lib.installHeader(
+        upstream.path("quickjs.h"),
+        "quickjs.h",
+    );
+
+    var flags: std.ArrayList([]const u8) = .empty;
+    try flags.appendSlice(b.allocator, &.{
+        "-D_GNU_SOURCE",
+        "-funsigned-char",
+        "-fno-omit-frame-pointer",
+        "-fno-sanitize=undefined",
+        "-fno-sanitize-trap=undefined",
+        "-fvisibility=hidden",
+    });
+    lib.root_module.addCSourceFiles(.{
+        .root = upstream.path(""),
+        .files = &.{
+            "cutils.c",
+            "dtoa.c",
+            "libregexp.c",
+            "libunicode.c",
+            "quickjs.c",
+        },
+        .flags = flags.items,
+    });
+
+    return lib;
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/build.zig.zon
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .quickjs_ng,
+    .version = "0.0.0",
+    .fingerprint = 0xb2bca9fa0367c6d1,
+    .minimum_zig_version = "0.14.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+    .dependencies = .{
+        // quickjs-ng/quickjs
+        .quickjs = .{
+            .url = "https://github.com/quickjs-ng/quickjs/archive/85640f81e04bc93940acc2756c792c66076dd768.tar.gz",
+            .hash = "N-V-__8AAIZ_PAA7y10jIaLigzkK4qd5-jfKEoTOOfHCsIGM",
+        },
+    },
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/atom.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/atom.zig
@@ -1,0 +1,378 @@
+const std = @import("std");
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Context = @import("context.zig").Context;
+const Runtime = @import("runtime.zig").Runtime;
+const Value = @import("value.zig").Value;
+
+/// Wrapper for the QuickJS `JSAtom`.
+///
+/// Atoms are interned strings used for property names and symbols.
+/// They are reference-counted and must be freed with `deinit` when no
+/// longer needed.
+///
+/// C: `JSAtom`
+pub const Atom = enum(u32) {
+    null = 0,
+    _,
+
+    /// Creates an atom from a null-terminated string.
+    ///
+    /// C: `JS_NewAtom`
+    pub fn init(ctx: *Context, str: [:0]const u8) Atom {
+        return @enumFromInt(c.JS_NewAtom(ctx.cval(), str.ptr));
+    }
+
+    /// Creates an atom from a string slice.
+    ///
+    /// C: `JS_NewAtomLen`
+    pub fn initLen(ctx: *Context, str: []const u8) Atom {
+        return @enumFromInt(c.JS_NewAtomLen(ctx.cval(), str.ptr, str.len));
+    }
+
+    /// Creates an atom from an unsigned 32-bit integer.
+    ///
+    /// C: `JS_NewAtomUInt32`
+    pub fn initUint32(ctx: *Context, n: u32) Atom {
+        return @enumFromInt(c.JS_NewAtomUInt32(ctx.cval(), n));
+    }
+
+    /// Creates an atom from a JavaScript value.
+    ///
+    /// The value is converted to a string and interned as an atom.
+    ///
+    /// C: `JS_ValueToAtom`
+    pub fn fromValue(ctx: *Context, val: Value) Atom {
+        return @enumFromInt(c.JS_ValueToAtom(ctx.cval(), val.cval()));
+    }
+
+    /// Duplicates the atom, incrementing its reference count.
+    ///
+    /// The returned atom must also be freed with `deinit`.
+    ///
+    /// C: `JS_DupAtom`
+    pub fn dup(self: Atom, ctx: *Context) Atom {
+        return @enumFromInt(c.JS_DupAtom(ctx.cval(), @intFromEnum(self)));
+    }
+
+    /// Duplicates the atom using the runtime, incrementing its reference count.
+    ///
+    /// The returned atom must also be freed with `deinitRT`.
+    ///
+    /// C: `JS_DupAtomRT`
+    pub fn dupRT(self: Atom, rt: *Runtime) Atom {
+        return @enumFromInt(c.JS_DupAtomRT(rt.cval(), @intFromEnum(self)));
+    }
+
+    /// Frees the atom, decrementing its reference count.
+    ///
+    /// C: `JS_FreeAtom`
+    pub fn deinit(self: Atom, ctx: *Context) void {
+        c.JS_FreeAtom(ctx.cval(), @intFromEnum(self));
+    }
+
+    /// Frees the atom using the runtime, decrementing its reference count.
+    ///
+    /// C: `JS_FreeAtomRT`
+    pub fn deinitRT(self: Atom, rt: *Runtime) void {
+        c.JS_FreeAtomRT(rt.cval(), @intFromEnum(self));
+    }
+
+    /// Converts the atom to a JavaScript value (symbol).
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_AtomToValue`
+    pub fn toValue(self: Atom, ctx: *Context) Value {
+        return Value.fromCVal(c.JS_AtomToValue(ctx.cval(), @intFromEnum(self)));
+    }
+
+    /// Converts the atom to a JavaScript string value.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_AtomToString`
+    pub fn toString(self: Atom, ctx: *Context) Value {
+        return Value.fromCVal(c.JS_AtomToString(ctx.cval(), @intFromEnum(self)));
+    }
+
+    /// Converts the atom to a C string.
+    ///
+    /// Returns null if the atom is invalid. The returned string must be
+    /// freed with `Context.freeCString`.
+    ///
+    /// C: `JS_AtomToCString`
+    pub fn toCString(self: Atom, ctx: *Context) ?[*:0]const u8 {
+        const ptr = c.JS_AtomToCString(ctx.cval(), @intFromEnum(self));
+        return @ptrCast(ptr);
+    }
+
+    /// Converts the atom to a C string with length.
+    ///
+    /// Returns null if the atom is invalid. The returned pointer must be
+    /// freed with `Context.freeCString`.
+    ///
+    /// C: `JS_AtomToCStringLen`
+    pub fn toCStringLen(self: Atom, ctx: *Context) ?struct { ptr: [*:0]const u8, len: usize } {
+        var len: usize = 0;
+        const ptr = c.JS_AtomToCStringLen(ctx.cval(), &len, @intFromEnum(self));
+        if (ptr == null) return null;
+        return .{ .ptr = @ptrCast(ptr), .len = len };
+    }
+
+    /// Converts the atom to a Zig string slice.
+    ///
+    /// Returns null if the atom is invalid. The returned slice must be
+    /// freed by passing the pointer to `Context.freeCString`.
+    ///
+    /// C: `JS_AtomToCStringLen`
+    pub fn toZigSlice(self: Atom, ctx: *Context) ?[:0]const u8 {
+        const result = self.toCStringLen(ctx) orelse return null;
+        return result.ptr[0..result.len :0];
+    }
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "Atom init and deinit" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "testProperty");
+    defer atom.deinit(ctx);
+
+    try testing.expect(atom != .null);
+}
+
+test "Atom initLen" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const str = "helloWorld";
+    const atom = Atom.initLen(ctx, str[0..5]);
+    defer atom.deinit(ctx);
+
+    const cstr = atom.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+
+    try testing.expectEqualStrings("hello", std.mem.span(cstr));
+}
+
+test "Atom initUint32" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.initUint32(ctx, 42);
+    defer atom.deinit(ctx);
+
+    const cstr = atom.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+
+    try testing.expectEqualStrings("42", std.mem.span(cstr));
+}
+
+test "Atom fromValue" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const str_val = Value.initString(ctx, "myProperty");
+    defer str_val.deinit(ctx);
+
+    const atom = Atom.fromValue(ctx, str_val);
+    defer atom.deinit(ctx);
+
+    const cstr = atom.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+
+    try testing.expectEqualStrings("myProperty", std.mem.span(cstr));
+}
+
+test "Atom dup" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom1 = Atom.init(ctx, "shared");
+    defer atom1.deinit(ctx);
+
+    const atom2 = atom1.dup(ctx);
+    defer atom2.deinit(ctx);
+
+    try testing.expectEqual(@intFromEnum(atom1), @intFromEnum(atom2));
+}
+
+test "Atom dupRT and deinitRT" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom1 = Atom.init(ctx, "runtimeAtom");
+    defer atom1.deinit(ctx);
+
+    const atom2 = atom1.dupRT(rt);
+    defer atom2.deinitRT(rt);
+
+    try testing.expectEqual(@intFromEnum(atom1), @intFromEnum(atom2));
+}
+
+test "Atom toValue" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "symbolName");
+    defer atom.deinit(ctx);
+
+    const val = atom.toValue(ctx);
+    defer val.deinit(ctx);
+
+    try testing.expect(!val.isException());
+}
+
+test "Atom toString" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "stringAtom");
+    defer atom.deinit(ctx);
+
+    const str_val = atom.toString(ctx);
+    defer str_val.deinit(ctx);
+
+    try testing.expect(str_val.isString());
+
+    const cstr = str_val.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+
+    try testing.expectEqualStrings("stringAtom", std.mem.span(cstr));
+}
+
+test "Atom toCString" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "cstringTest");
+    defer atom.deinit(ctx);
+
+    const cstr = atom.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+
+    try testing.expectEqualStrings("cstringTest", std.mem.span(cstr));
+}
+
+test "Atom toCStringLen" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "lengthTest");
+    defer atom.deinit(ctx);
+
+    const result = atom.toCStringLen(ctx).?;
+    defer ctx.freeCString(result.ptr);
+
+    try testing.expectEqualStrings("lengthTest", result.ptr[0..result.len]);
+    try testing.expectEqual(@as(usize, 10), result.len);
+}
+
+test "Atom toZigSlice" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom = Atom.init(ctx, "sliceTest");
+    defer atom.deinit(ctx);
+
+    const slice = atom.toZigSlice(ctx).?;
+    defer ctx.freeCString(slice.ptr);
+
+    try testing.expectEqualStrings("sliceTest", slice);
+    try testing.expectEqual(@as(usize, 9), slice.len);
+}
+
+test "Atom used as property name in JavaScript" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    const atom = Atom.init(ctx, "myProp");
+    defer atom.deinit(ctx);
+
+    const val = Value.initInt32(42);
+    try obj.setProperty(ctx, atom, val);
+
+    const retrieved = obj.getProperty(ctx, atom);
+    defer retrieved.deinit(ctx);
+
+    try testing.expectEqual(@as(i32, 42), try retrieved.toInt32(ctx));
+}
+
+test "Atom integer property access" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const arr = ctx.eval("[10, 20, 30]", "<test>", .{});
+    defer arr.deinit(ctx);
+
+    const atom = Atom.initUint32(ctx, 1);
+    defer atom.deinit(ctx);
+
+    const val = arr.getProperty(ctx, atom);
+    defer val.deinit(ctx);
+
+    try testing.expectEqual(@as(i32, 20), try val.toInt32(ctx));
+}
+
+test "Atom same strings share same atom" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const atom1 = Atom.init(ctx, "sharedString");
+    defer atom1.deinit(ctx);
+
+    const atom2 = Atom.init(ctx, "sharedString");
+    defer atom2.deinit(ctx);
+
+    try testing.expectEqual(@intFromEnum(atom1), @intFromEnum(atom2));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/cfunc.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/cfunc.zig
@@ -1,0 +1,509 @@
+const std = @import("std");
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Context = @import("context.zig").Context;
+const Value = @import("value.zig").Value;
+const opaquepkg = @import("opaque.zig");
+const Opaque = opaquepkg.Opaque;
+
+/// C function prototype type.
+///
+/// C: `JSCFunctionEnum`
+pub const Proto = enum(c_uint) {
+    generic = c.JS_CFUNC_generic,
+    generic_magic = c.JS_CFUNC_generic_magic,
+    constructor = c.JS_CFUNC_constructor,
+    constructor_magic = c.JS_CFUNC_constructor_magic,
+    constructor_or_func = c.JS_CFUNC_constructor_or_func,
+    constructor_or_func_magic = c.JS_CFUNC_constructor_or_func_magic,
+    f_f = c.JS_CFUNC_f_f,
+    f_f_f = c.JS_CFUNC_f_f_f,
+    getter = c.JS_CFUNC_getter,
+    setter = c.JS_CFUNC_setter,
+    getter_magic = c.JS_CFUNC_getter_magic,
+    setter_magic = c.JS_CFUNC_setter_magic,
+    iterator_next = c.JS_CFUNC_iterator_next,
+};
+
+/// C function signature for simple functions.
+///
+/// C: `JSCFunction`
+pub const Func = *const fn (
+    ?*Context,
+    Value,
+    []const c.JSValue,
+) Value;
+
+/// Wraps a Zig-friendly Func into a C-callable function.
+pub fn wrapFunc(comptime func: Func) c.JSCFunction {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            argc: c_int,
+            argv: [*c]c.JSValue,
+        ) callconv(.c) c.JSValue {
+            const args: []const c.JSValue = if (argc > 0)
+                argv[0..@intCast(argc)]
+            else
+                &.{};
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                args,
+            }).cval();
+        }
+    }.callback;
+}
+
+/// C function signature for functions with magic value.
+///
+/// C: `JSCFunctionMagic`
+pub const FuncMagic = *const fn (
+    ?*Context,
+    Value,
+    []const c.JSValue,
+    c_int,
+) Value;
+
+/// Wraps a Zig-friendly FuncMagic into a C-callable function.
+pub fn wrapFuncMagic(comptime func: FuncMagic) c.JSCFunctionMagic {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            argc: c_int,
+            argv: [*c]c.JSValue,
+            magic: c_int,
+        ) callconv(.c) c.JSValue {
+            const args: []const c.JSValue = if (argc > 0)
+                argv[0..@intCast(argc)]
+            else
+                &.{};
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                args,
+                magic,
+            }).cval();
+        }
+    }.callback;
+}
+
+/// C function signature for functions with closure data.
+///
+/// The magic parameter is the magic value passed at construction.
+/// The func_data pointer points to the array of data values passed at construction.
+///
+/// C: `JSCFunctionData`
+pub const FuncData = *const fn (
+    ?*Context,
+    Value,
+    []const c.JSValue,
+    c_int,
+    [*c]c.JSValue,
+) Value;
+
+/// Wraps a Zig-friendly FuncData into a C-callable function.
+pub fn wrapFuncData(comptime func: FuncData) c.JSCFunctionData {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            argc: c_int,
+            argv: [*c]c.JSValue,
+            magic: c_int,
+            data: [*c]c.JSValue,
+        ) callconv(.c) c.JSValue {
+            const args: []const c.JSValue = if (argc > 0)
+                argv[0..@intCast(argc)]
+            else
+                &.{};
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                args,
+                magic,
+                data,
+            }).cval();
+        }
+    }.callback;
+}
+
+/// C closure function signature.
+///
+/// C: `JSCClosure`
+pub fn Closure(comptime T: type) type {
+    return *const fn (
+        ?*Context,
+        Value,
+        []const c.JSValue,
+        c_int,
+        Opaque(T),
+    ) Value;
+}
+
+/// Wraps a Zig-friendly Closure into a C-callable function.
+pub fn wrapClosure(comptime T: type, comptime func: Closure(T)) c.JSCClosure {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            argc: c_int,
+            argv: [*c]c.JSValue,
+            magic: c_int,
+            opaque_ptr: ?*anyopaque,
+        ) callconv(.c) c.JSValue {
+            const args: []const c.JSValue = if (argc > 0)
+                argv[0..@intCast(argc)]
+            else
+                &.{};
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                args,
+                magic,
+                opaquepkg.fromC(T, opaque_ptr),
+            }).cval();
+        }
+    }.callback;
+}
+
+/// Finalizer function for C closures.
+///
+/// C: `JSCClosureFinalizerFunc`
+pub fn ClosureFinalizer(comptime T: type) type {
+    return *const fn (Opaque(T)) void;
+}
+
+/// Wraps a Zig-friendly ClosureFinalizer into a C-callable function.
+pub fn wrapClosureFinalizer(comptime T: type, comptime func: ClosureFinalizer(T)) c.JSCClosureFinalizerFunc {
+    return struct {
+        fn callback(opaque_ptr: ?*anyopaque) callconv(.c) void {
+            @call(.always_inline, func, .{opaquepkg.fromC(T, opaque_ptr)});
+        }
+    }.callback;
+}
+
+/// Getter function signature.
+///
+/// C: getter in `JSCFunctionType`
+pub const Getter = *const fn (?*Context, Value) Value;
+
+const CGetterFn = ?*const fn (?*c.JSContext, c.JSValue) callconv(.c) c.JSValue;
+
+/// Wraps a Zig-friendly Getter into a C-callable function.
+pub fn wrapGetter(comptime func: Getter) CGetterFn {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+        ) callconv(.c) c.JSValue {
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+            }).cval();
+        }
+    }.callback;
+}
+
+/// Setter function signature.
+///
+/// C: setter in `JSCFunctionType`
+pub const Setter = *const fn (?*Context, Value, Value) Value;
+
+const CSetterFn = ?*const fn (?*c.JSContext, c.JSValue, c.JSValue) callconv(.c) c.JSValue;
+
+/// Wraps a Zig-friendly Setter into a C-callable function.
+pub fn wrapSetter(comptime func: Setter) CSetterFn {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            val: c.JSValue,
+        ) callconv(.c) c.JSValue {
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                @as(Value, @bitCast(val)),
+            }).cval();
+        }
+    }.callback;
+}
+
+/// Getter function signature with magic value.
+///
+/// C: getter_magic in `JSCFunctionType`
+pub const GetterMagic = *const fn (?*Context, Value, c_int) Value;
+
+const CGetterMagicFn = ?*const fn (?*c.JSContext, c.JSValue, c_int) callconv(.c) c.JSValue;
+
+/// Wraps a Zig-friendly GetterMagic into a C-callable function.
+pub fn wrapGetterMagic(comptime func: GetterMagic) CGetterMagicFn {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            magic: c_int,
+        ) callconv(.c) c.JSValue {
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                magic,
+            }).cval();
+        }
+    }.callback;
+}
+
+/// Setter function signature with magic value.
+///
+/// C: setter_magic in `JSCFunctionType`
+pub const SetterMagic = *const fn (?*Context, Value, Value, c_int) Value;
+
+const CSetterMagicFn = ?*const fn (?*c.JSContext, c.JSValue, c.JSValue, c_int) callconv(.c) c.JSValue;
+
+/// Wraps a Zig-friendly SetterMagic into a C-callable function.
+pub fn wrapSetterMagic(comptime func: SetterMagic) CSetterMagicFn {
+    return struct {
+        fn callback(
+            ctx: ?*c.JSContext,
+            this_val: c.JSValue,
+            val: c.JSValue,
+            magic: c_int,
+        ) callconv(.c) c.JSValue {
+            return @call(.always_inline, func, .{
+                @as(?*Context, @ptrCast(ctx)),
+                @as(Value, @bitCast(this_val)),
+                @as(Value, @bitCast(val)),
+                magic,
+            }).cval();
+        }
+    }.callback;
+}
+
+/// Definition type for function list entries.
+pub const DefType = enum(u8) {
+    cfunc = c.JS_DEF_CFUNC,
+    cgetset = c.JS_DEF_CGETSET,
+    cgetset_magic = c.JS_DEF_CGETSET_MAGIC,
+    prop_string = c.JS_DEF_PROP_STRING,
+    prop_int32 = c.JS_DEF_PROP_INT32,
+    prop_int64 = c.JS_DEF_PROP_INT64,
+    prop_double = c.JS_DEF_PROP_DOUBLE,
+    prop_undefined = c.JS_DEF_PROP_UNDEFINED,
+    object = c.JS_DEF_OBJECT,
+    alias = c.JS_DEF_ALIAS,
+};
+
+/// Property flags for function list entries.
+pub const PropFlags = packed struct(u8) {
+    configurable: bool = false,
+    writable: bool = false,
+    enumerable: bool = false,
+    _padding: u5 = 0,
+
+    pub const default: PropFlags = .{ .writable = true, .configurable = true };
+};
+
+/// Function list entry for bulk property definition.
+///
+/// C: `JSCFunctionListEntry`
+pub const FunctionListEntry = c.JSCFunctionListEntry;
+
+/// Helper functions for creating FunctionListEntry values.
+pub const FunctionListEntryHelpers = struct {
+    /// Creates a function definition entry.
+    pub fn func(
+        name: [:0]const u8,
+        length: u8,
+        comptime cfunc_ptr: Func,
+    ) FunctionListEntry {
+        return funcWithFlags(name, length, wrapFunc(cfunc_ptr), PropFlags.default);
+    }
+
+    /// Creates a function definition entry with custom flags.
+    pub fn funcWithFlags(
+        name: [:0]const u8,
+        length: u8,
+        cfunc_ptr: c.JSCFunction,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.cfunc);
+        entry.magic = 0;
+        entry.u.func.length = length;
+        entry.u.func.cproto = @intFromEnum(Proto.generic);
+        entry.u.func.cfunc.generic = cfunc_ptr;
+        return entry;
+    }
+
+    /// Creates a function definition with magic value.
+    pub fn funcMagic(
+        name: [:0]const u8,
+        length: u8,
+        comptime cfunc_ptr: FuncMagic,
+        magic: i16,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(PropFlags.default);
+        entry.def_type = @intFromEnum(DefType.cfunc);
+        entry.magic = magic;
+        entry.u.func.length = length;
+        entry.u.func.cproto = @intFromEnum(Proto.generic_magic);
+        entry.u.func.cfunc.generic_magic = wrapFuncMagic(cfunc_ptr);
+        return entry;
+    }
+
+    /// Creates a getter/setter property definition.
+    pub fn getset(
+        name: [:0]const u8,
+        comptime getter_fn: ?Getter,
+        comptime setter_fn: ?Setter,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = c.JS_PROP_CONFIGURABLE;
+        entry.def_type = @intFromEnum(DefType.cgetset);
+        entry.magic = 0;
+        entry.u.getset.get.getter = if (getter_fn) |g| wrapGetter(g) else null;
+        entry.u.getset.set.setter = if (setter_fn) |s| wrapSetter(s) else null;
+        return entry;
+    }
+
+    /// Creates a getter/setter property definition with magic value.
+    pub fn getsetMagic(
+        name: [:0]const u8,
+        comptime getter_fn: ?GetterMagic,
+        comptime setter_fn: ?SetterMagic,
+        magic: i16,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = c.JS_PROP_CONFIGURABLE;
+        entry.def_type = @intFromEnum(DefType.cgetset_magic);
+        entry.magic = magic;
+        entry.u.getset.get.getter_magic = if (getter_fn) |g| wrapGetterMagic(g) else null;
+        entry.u.getset.set.setter_magic = if (setter_fn) |s| wrapSetterMagic(s) else null;
+        return entry;
+    }
+
+    /// Creates a string property definition.
+    pub fn propString(
+        name: [:0]const u8,
+        value: [:0]const u8,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.prop_string);
+        entry.magic = 0;
+        entry.u.str = value.ptr;
+        return entry;
+    }
+
+    /// Creates an i32 property definition.
+    pub fn propInt32(
+        name: [:0]const u8,
+        value: i32,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.prop_int32);
+        entry.magic = 0;
+        entry.u.i32 = value;
+        return entry;
+    }
+
+    /// Creates an i64 property definition.
+    pub fn propInt64(
+        name: [:0]const u8,
+        value: i64,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.prop_int64);
+        entry.magic = 0;
+        entry.u.i64 = value;
+        return entry;
+    }
+
+    /// Creates a double property definition.
+    pub fn propDouble(
+        name: [:0]const u8,
+        value: f64,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.prop_double);
+        entry.magic = 0;
+        entry.u.f64 = value;
+        return entry;
+    }
+
+    /// Creates an undefined property definition.
+    pub fn propUndefined(
+        name: [:0]const u8,
+        flags: PropFlags,
+    ) FunctionListEntry {
+        var entry: FunctionListEntry = std.mem.zeroes(FunctionListEntry);
+        entry.name = name.ptr;
+        entry.prop_flags = @bitCast(flags);
+        entry.def_type = @intFromEnum(DefType.prop_undefined);
+        entry.magic = 0;
+        entry.u.i32 = 0;
+        return entry;
+    }
+};
+
+test "Proto enum matches C constants" {
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_generic), @intFromEnum(Proto.generic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_generic_magic), @intFromEnum(Proto.generic_magic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_constructor), @intFromEnum(Proto.constructor));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_constructor_magic), @intFromEnum(Proto.constructor_magic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_constructor_or_func), @intFromEnum(Proto.constructor_or_func));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_constructor_or_func_magic), @intFromEnum(Proto.constructor_or_func_magic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_f_f), @intFromEnum(Proto.f_f));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_f_f_f), @intFromEnum(Proto.f_f_f));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_getter), @intFromEnum(Proto.getter));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_setter), @intFromEnum(Proto.setter));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_getter_magic), @intFromEnum(Proto.getter_magic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_setter_magic), @intFromEnum(Proto.setter_magic));
+    try testing.expectEqual(@as(c_uint, c.JS_CFUNC_iterator_next), @intFromEnum(Proto.iterator_next));
+}
+
+test "DefType enum matches C constants" {
+    try testing.expectEqual(@as(u8, c.JS_DEF_CFUNC), @intFromEnum(DefType.cfunc));
+    try testing.expectEqual(@as(u8, c.JS_DEF_CGETSET), @intFromEnum(DefType.cgetset));
+    try testing.expectEqual(@as(u8, c.JS_DEF_CGETSET_MAGIC), @intFromEnum(DefType.cgetset_magic));
+    try testing.expectEqual(@as(u8, c.JS_DEF_PROP_STRING), @intFromEnum(DefType.prop_string));
+    try testing.expectEqual(@as(u8, c.JS_DEF_PROP_INT32), @intFromEnum(DefType.prop_int32));
+    try testing.expectEqual(@as(u8, c.JS_DEF_PROP_INT64), @intFromEnum(DefType.prop_int64));
+    try testing.expectEqual(@as(u8, c.JS_DEF_PROP_DOUBLE), @intFromEnum(DefType.prop_double));
+    try testing.expectEqual(@as(u8, c.JS_DEF_PROP_UNDEFINED), @intFromEnum(DefType.prop_undefined));
+    try testing.expectEqual(@as(u8, c.JS_DEF_OBJECT), @intFromEnum(DefType.object));
+    try testing.expectEqual(@as(u8, c.JS_DEF_ALIAS), @intFromEnum(DefType.alias));
+}
+
+test "PropFlags matches C constants" {
+    const configurable: PropFlags = .{ .configurable = true };
+    try testing.expectEqual(@as(u8, c.JS_PROP_CONFIGURABLE), @as(u8, @bitCast(configurable)));
+
+    const writable: PropFlags = .{ .writable = true };
+    try testing.expectEqual(@as(u8, c.JS_PROP_WRITABLE), @as(u8, @bitCast(writable)));
+
+    const enumerable: PropFlags = .{ .enumerable = true };
+    try testing.expectEqual(@as(u8, c.JS_PROP_ENUMERABLE), @as(u8, @bitCast(enumerable)));
+
+    const default_flags: PropFlags = PropFlags.default;
+    try testing.expectEqual(@as(u8, c.JS_PROP_WRITABLE | c.JS_PROP_CONFIGURABLE), @as(u8, @bitCast(default_flags)));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/class.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/class.zig
@@ -1,0 +1,380 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Atom = @import("atom.zig").Atom;
+const Context = @import("context.zig").Context;
+const Runtime = @import("runtime.zig").Runtime;
+const Value = @import("value.zig").Value;
+
+/// Class identifier for custom JavaScript classes.
+///
+/// Class IDs are used to register custom native-backed classes with QuickJS.
+/// Each class has a unique ID that is used to associate objects with their
+/// class definition, prototype, and opaque data.
+///
+/// C: `JSClassID`
+pub const Id = enum(u32) {
+    /// Invalid class ID (returned when object has no class).
+    invalid = c.JS_INVALID_CLASS_ID,
+    _,
+
+    /// Creates a new unique class ID.
+    ///
+    /// C: `JS_NewClassID`
+    pub fn new(rt: *Runtime) Id {
+        var raw: u32 = 0;
+        return @enumFromInt(c.JS_NewClassID(rt.cval(), &raw));
+    }
+};
+
+/// Finalizer callback called when an object of this class is garbage collected.
+///
+/// C: `JSClassFinalizer`
+pub const Finalizer = *const fn (*Runtime, Value) callconv(.c) void;
+
+/// GC mark callback for marking references held by this class.
+///
+/// C: `JSClassGCMark`
+pub const GCMark = *const fn (*Runtime, Value, c.JS_MarkFunc) callconv(.c) void;
+
+/// Call callback for callable class objects.
+///
+/// If `flags & JS_CALL_FLAG_CONSTRUCTOR` is set, the object is being
+/// called as a constructor and `this_val` is `new.target`.
+///
+/// C: `JSClassCall`
+pub const Call = *const fn (
+    *Context,
+    Value,
+    Value,
+    c_int,
+    [*]Value,
+    c_int,
+) callconv(.c) Value;
+
+/// Exotic methods for customizing property access behavior.
+///
+/// These methods allow implementing Proxy-like behavior for custom classes.
+///
+/// C: `JSClassExoticMethods`
+pub const ExoticMethods = extern struct {
+    get_own_property: ?*const fn (
+        ?*c.JSContext,
+        [*c]c.JSPropertyDescriptor,
+        c.JSValue,
+        c.JSAtom,
+    ) callconv(.c) c_int = null,
+    get_own_property_names: ?*const fn (
+        ?*c.JSContext,
+        [*c][*c]c.JSPropertyEnum,
+        [*c]u32,
+        c.JSValue,
+    ) callconv(.c) c_int = null,
+    delete_property: ?*const fn (
+        ?*c.JSContext,
+        c.JSValue,
+        c.JSAtom,
+    ) callconv(.c) c_int = null,
+    define_own_property: ?*const fn (
+        ?*c.JSContext,
+        c.JSValue,
+        c.JSAtom,
+        c.JSValue,
+        c.JSValue,
+        c.JSValue,
+        c_int,
+    ) callconv(.c) c_int = null,
+    has_property: ?*const fn (
+        ?*c.JSContext,
+        c.JSValue,
+        c.JSAtom,
+    ) callconv(.c) c_int = null,
+    get_property: ?*const fn (
+        ?*c.JSContext,
+        c.JSValue,
+        c.JSAtom,
+        c.JSValue,
+    ) callconv(.c) c.JSValue = null,
+    set_property: ?*const fn (
+        ?*c.JSContext,
+        c.JSValue,
+        c.JSAtom,
+        c.JSValue,
+        c.JSValue,
+        c_int,
+    ) callconv(.c) c_int = null,
+};
+
+/// Definition for a custom JavaScript class.
+///
+/// Used with `Runtime.newClass` to register a custom class.
+///
+/// C: `JSClassDef`
+pub const Def = extern struct {
+    /// Class name (pure ASCII only).
+    class_name: [*:0]const u8 = "",
+    /// Finalizer called when objects of this class are garbage collected.
+    finalizer: ?*const c.JSClassFinalizer = null,
+    /// GC mark function for marking references.
+    gc_mark: ?*const c.JSClassGCMark = null,
+    /// Call function (makes instances of this class callable).
+    call: ?*const c.JSClassCall = null,
+    /// Exotic methods for custom property access.
+    exotic: ?*ExoticMethods = null,
+};
+
+/// Flag indicating a constructor call.
+pub const call_flag_constructor: c_int = 1 << 0;
+
+comptime {
+    assert(@intFromEnum(Id.invalid) == c.JS_INVALID_CLASS_ID);
+    assert(@sizeOf(Def) == @sizeOf(c.JSClassDef));
+    assert(@alignOf(Def) == @alignOf(c.JSClassDef));
+    assert(@sizeOf(ExoticMethods) == @sizeOf(c.JSClassExoticMethods));
+    assert(@alignOf(ExoticMethods) == @alignOf(c.JSClassExoticMethods));
+}
+
+test "Id.new allocates unique IDs" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const id1: Id = .new(rt);
+    const id2: Id = .new(rt);
+
+    try testing.expect(id1 != .invalid);
+    try testing.expect(id2 != .invalid);
+    try testing.expect(id1 != id2);
+}
+
+test "Runtime.newClass registers a class" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const class_id: Id = .new(rt);
+
+    try testing.expect(!rt.isRegisteredClass(class_id));
+
+    const def: Def = .{ .class_name = "TestClass" };
+    try rt.newClass(class_id, &def);
+
+    try testing.expect(rt.isRegisteredClass(class_id));
+}
+
+test "Runtime.getClassName returns class name" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    try testing.expect(!rt.isRegisteredClass(class_id));
+
+    const def: Def = .{ .class_name = "MyCustomClass" };
+    try rt.newClass(class_id, &def);
+
+    try testing.expect(rt.isRegisteredClass(class_id));
+
+    const name_atom = rt.getClassName(class_id);
+    defer name_atom.deinit(ctx);
+
+    try testing.expect(name_atom != .null);
+}
+
+test "Value.initObjectClass creates class instance" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def: Def = .{ .class_name = "InstanceTest" };
+    try rt.newClass(class_id, &def);
+
+    const proto = Value.initObject(ctx);
+    defer proto.deinit(ctx);
+    ctx.setClassProto(class_id, proto.dup(ctx));
+
+    const obj = Value.initObjectClass(ctx, class_id);
+    defer obj.deinit(ctx);
+
+    try testing.expect(obj.isObject());
+    try testing.expectEqual(class_id, obj.getClassId());
+}
+
+test "Value opaque data round-trip" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def: Def = .{ .class_name = "OpaqueTest" };
+    try rt.newClass(class_id, &def);
+
+    const proto = Value.initObject(ctx);
+    defer proto.deinit(ctx);
+    ctx.setClassProto(class_id, proto.dup(ctx));
+
+    const obj = Value.initObjectClass(ctx, class_id);
+    defer obj.deinit(ctx);
+
+    const TestData = struct { value: i32 };
+    var data: TestData = .{ .value = 42 };
+
+    try testing.expect(obj.setOpaque(&data));
+
+    const retrieved = obj.getOpaque(TestData, class_id);
+    try testing.expect(retrieved != null);
+    try testing.expectEqual(@as(i32, 42), retrieved.?.value);
+
+    const retrieved2 = obj.getOpaque2(ctx, TestData, class_id);
+    try testing.expect(retrieved2 != null);
+    try testing.expectEqual(@as(i32, 42), retrieved2.?.value);
+}
+
+test "Value.getAnyOpaque retrieves opaque with class ID" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def: Def = .{ .class_name = "AnyOpaqueTest" };
+    try rt.newClass(class_id, &def);
+
+    const proto = Value.initObject(ctx);
+    defer proto.deinit(ctx);
+    ctx.setClassProto(class_id, proto.dup(ctx));
+
+    const obj = Value.initObjectClass(ctx, class_id);
+    defer obj.deinit(ctx);
+
+    const TestData = struct { value: i32 };
+    var data: TestData = .{ .value = 99 };
+    try testing.expect(obj.setOpaque(&data));
+
+    const result = obj.getAnyOpaque(TestData);
+    try testing.expect(result.ptr != null);
+    try testing.expectEqual(class_id, result.class_id);
+    try testing.expectEqual(@as(i32, 99), result.ptr.?.value);
+}
+
+test "Value.getClassId returns class ID for class objects" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def: Def = .{ .class_name = "ClassIdTest" };
+    try rt.newClass(class_id, &def);
+
+    const proto = Value.initObject(ctx);
+    defer proto.deinit(ctx);
+    ctx.setClassProto(class_id, proto.dup(ctx));
+
+    const obj = Value.initObjectClass(ctx, class_id);
+    defer obj.deinit(ctx);
+
+    try testing.expectEqual(class_id, obj.getClassId());
+}
+
+test "Value.getClassId returns invalid for non-objects" {
+    const num = Value.initInt32(42);
+    try testing.expectEqual(Id.invalid, num.getClassId());
+}
+
+test "Context.setClassProto and getClassProto" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def: Def = .{ .class_name = "ProtoTest" };
+    try rt.newClass(class_id, &def);
+
+    const proto = Value.initObject(ctx);
+    try proto.setPropertyStr(ctx, "testProp", Value.initInt32(123));
+    ctx.setClassProto(class_id, proto);
+
+    const retrieved = ctx.getClassProto(class_id);
+    defer retrieved.deinit(ctx);
+
+    try testing.expect(retrieved.isObject());
+
+    const prop = retrieved.getPropertyStr(ctx, "testProp");
+    defer prop.deinit(ctx);
+    try testing.expectEqual(@as(i32, 123), try prop.toInt32(ctx));
+}
+
+test "Value.setConstructorBit" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const func = ctx.eval("(function MyClass() {})", "<test>", .{});
+    defer func.deinit(ctx);
+
+    try testing.expect(func.isFunction(ctx));
+
+    _ = func.setConstructorBit(ctx, false);
+
+    const can_construct_before = ctx.eval("try { new MyClass(); true } catch(e) { false }", "<test>", .{});
+    defer can_construct_before.deinit(ctx);
+
+    _ = func.setConstructorBit(ctx, true);
+
+    try testing.expect(!func.isException());
+}
+
+test "Class with finalizer" {
+    const State = struct {
+        var finalized: bool = false;
+    };
+
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const class_id: Id = .new(rt);
+
+    const def = Def{
+        .class_name = "FinalizerTest",
+        .finalizer = &struct {
+            fn finalize(_: ?*c.JSRuntime, _: c.JSValue) callconv(.c) void {
+                State.finalized = true;
+            }
+        }.finalize,
+    };
+    try rt.newClass(class_id, &def);
+
+    {
+        const ctx: *Context = try .init(rt);
+        defer ctx.deinit();
+
+        const proto = Value.initObject(ctx);
+        ctx.setClassProto(class_id, proto);
+
+        const obj = Value.initObjectClass(ctx, class_id);
+        obj.deinit(ctx);
+    }
+
+    rt.runGC();
+
+    try testing.expect(State.finalized);
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/context.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/context.zig
@@ -1,0 +1,1256 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const c = @import("quickjs_c");
+const Atom = @import("atom.zig").Atom;
+const ModuleDef = @import("module.zig").ModuleDef;
+const Runtime = @import("runtime.zig").Runtime;
+const Value = @import("value.zig").Value;
+const class = @import("class.zig");
+
+/// Wrapper for the QuickJS `JSContext`.
+///
+/// A context represents an isolated JavaScript execution environment
+/// with its own global object and set of built-in objects. Multiple
+/// contexts can be created from the same runtime and share atoms
+/// and certain resources, but have separate global states.
+pub const Context = opaque {
+    /// Creates a new JavaScript context within the given runtime.
+    ///
+    /// The context must be freed with `deinit` when no longer needed.
+    /// Contexts must be freed before freeing the runtime they belong to.
+    ///
+    /// C: `JS_NewContext`
+    pub fn init(rt: *Runtime) Allocator.Error!*Context {
+        const ctx = c.JS_NewContext(rt.cval());
+        if (ctx == null) return error.OutOfMemory;
+        return @ptrCast(ctx);
+    }
+
+    /// Creates a raw JavaScript context without any intrinsic objects.
+    ///
+    /// Use this to create a minimal context, then add only the intrinsics
+    /// you need with the `addIntrinsic*` methods.
+    ///
+    /// C: `JS_NewContextRaw`
+    pub fn initRaw(rt: *Runtime) Allocator.Error!*Context {
+        const ctx = c.JS_NewContextRaw(rt.cval());
+        if (ctx == null) return error.OutOfMemory;
+        return @ptrCast(ctx);
+    }
+
+    /// Frees the JavaScript context and all associated resources.
+    ///
+    /// All values created in this context should be freed before
+    /// calling this function.
+    ///
+    /// C: `JS_FreeContext`
+    pub fn deinit(self: *Context) void {
+        c.JS_FreeContext(self.cval());
+    }
+
+    pub inline fn cval(self: *Context) *c.JSContext {
+        return @ptrCast(self);
+    }
+
+    /// Gets the runtime associated with this context.
+    ///
+    /// C: `JS_GetRuntime`
+    pub fn getRuntime(self: *Context) *Runtime {
+        return @ptrCast(c.JS_GetRuntime(self.cval()));
+    }
+
+    /// Gets the global object for this context.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetGlobalObject`
+    pub fn getGlobalObject(self: *Context) Value {
+        return Value.fromCVal(c.JS_GetGlobalObject(self.cval()));
+    }
+
+    /// Gets the current exception, if any.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetException`
+    pub fn getException(self: *Context) Value {
+        return Value.fromCVal(c.JS_GetException(self.cval()));
+    }
+
+    /// Checks if there is a pending exception.
+    ///
+    /// C: `JS_HasException`
+    pub fn hasException(self: *Context) bool {
+        return c.JS_HasException(self.cval());
+    }
+
+    /// Resets the uncatchable error flag on the current exception.
+    ///
+    /// C: `JS_ResetUncatchableError`
+    pub fn resetUncatchableError(self: *Context) void {
+        c.JS_ResetUncatchableError(self.cval());
+    }
+
+    /// Frees a C string allocated by QuickJS.
+    ///
+    /// C: `JS_FreeCString`
+    pub fn freeCString(self: *Context, ptr: [*:0]const u8) void {
+        c.JS_FreeCString(self.cval(), ptr);
+    }
+
+    /// Throws an out of memory exception.
+    ///
+    /// C: `JS_ThrowOutOfMemory`
+    pub fn throwOutOfMemory(self: *Context) Value {
+        return Value.fromCVal(c.JS_ThrowOutOfMemory(self.cval()));
+    }
+
+    /// Evaluates JavaScript code and returns the result.
+    ///
+    /// The input is evaluated as a script (not a module) by default.
+    /// Use `flags` to customize evaluation behavior.
+    ///
+    /// The returned value must be freed with `Value.deinit` when no
+    /// longer needed. Check `Value.isException` to detect errors.
+    ///
+    /// C: `JS_Eval`
+    pub fn eval(self: *Context, input: []const u8, filename: [:0]const u8, flags: EvalFlags) Value {
+        return Value.fromCVal(c.JS_Eval(
+            self.cval(),
+            input.ptr,
+            input.len,
+            filename.ptr,
+            @bitCast(flags),
+        ));
+    }
+
+    /// Evaluates JavaScript code with extended options.
+    ///
+    /// This is an extended version of `eval` that accepts an `EvalOptions`
+    /// struct for more control over evaluation, including line number offset.
+    ///
+    /// The returned value must be freed with `Value.deinit` when no
+    /// longer needed. Check `Value.isException` to detect errors.
+    ///
+    /// C: `JS_Eval2`
+    pub fn eval2(self: *Context, input: []const u8, options: *EvalOptions) Value {
+        return Value.fromCVal(c.JS_Eval2(
+            self.cval(),
+            input.ptr,
+            input.len,
+            @ptrCast(options),
+        ));
+    }
+
+    /// Evaluates JavaScript code with a custom `this` object.
+    ///
+    /// The returned value must be freed with `Value.deinit` when no
+    /// longer needed. Check `Value.isException` to detect errors.
+    ///
+    /// C: `JS_EvalThis`
+    pub fn evalThis(self: *Context, this_obj: Value, input: []const u8, filename: [:0]const u8, flags: EvalFlags) Value {
+        return Value.fromCVal(c.JS_EvalThis(
+            self.cval(),
+            this_obj.cval(),
+            input.ptr,
+            input.len,
+            filename.ptr,
+            @bitCast(flags),
+        ));
+    }
+
+    /// Evaluates JavaScript code with a custom `this` object and extended options.
+    ///
+    /// This combines the functionality of `evalThis` and `eval2`.
+    ///
+    /// The returned value must be freed with `Value.deinit` when no
+    /// longer needed. Check `Value.isException` to detect errors.
+    ///
+    /// C: `JS_EvalThis2`
+    pub fn evalThis2(self: *Context, this_obj: Value, input: []const u8, options: *EvalOptions) Value {
+        return Value.fromCVal(c.JS_EvalThis2(
+            self.cval(),
+            this_obj.cval(),
+            input.ptr,
+            input.len,
+            @ptrCast(options),
+        ));
+    }
+
+    /// Executes a compiled bytecode function.
+    ///
+    /// The function object must be a bytecode function created with
+    /// `EvalFlags.compile_only = true`. Takes ownership of the function
+    /// object.
+    ///
+    /// The returned value must be freed with `Value.deinit` when no
+    /// longer needed. Check `Value.isException` to detect errors.
+    ///
+    /// C: `JS_EvalFunction`
+    pub fn evalFunction(self: *Context, func_obj: Value) Value {
+        return Value.fromCVal(c.JS_EvalFunction(self.cval(), func_obj.cval()));
+    }
+
+    // =========================================================================
+    // Module Loading
+    // =========================================================================
+
+    /// Loads a module by filename.
+    ///
+    /// Uses the module loader function set on the runtime. The basename
+    /// is used for resolving relative imports within the module.
+    ///
+    /// Returns the module value or an exception on error.
+    ///
+    /// C: `JS_LoadModule`
+    pub fn loadModule(self: *Context, basename: [*:0]const u8, filename: [*:0]const u8) Value {
+        return Value.fromCVal(c.JS_LoadModule(self.cval(), basename, filename));
+    }
+
+    /// Gets the name of the current script or module.
+    ///
+    /// The `n_stack_levels` parameter specifies how many stack levels to
+    /// go up (0 = current function).
+    ///
+    /// Returns the script/module name as an atom, or `Atom.null` if not available.
+    /// The returned atom must be freed with `Atom.deinit`.
+    ///
+    /// C: `JS_GetScriptOrModuleName`
+    pub fn getScriptOrModuleName(self: *Context, n_stack_levels: i32) Atom {
+        return @enumFromInt(c.JS_GetScriptOrModuleName(self.cval(), n_stack_levels));
+    }
+
+    // =========================================================================
+    // Job Queue
+    // =========================================================================
+
+    /// Enqueues a job to be executed later.
+    ///
+    /// The job function will be called with the provided arguments when
+    /// `Runtime.executePendingJob` is called. The arguments are duplicated
+    /// (reference count incremented) when enqueued and freed after the job runs.
+    ///
+    /// Returns an error if the job could not be enqueued.
+    ///
+    /// C: `JS_EnqueueJob`
+    pub fn enqueueJob(
+        self: *Context,
+        comptime job_func: *const fn (*Context, []const Value) Value,
+        args: []const Value,
+    ) Allocator.Error!void {
+        const Wrapper = struct {
+            fn callback(
+                ctx: ?*c.JSContext,
+                argc: c_int,
+                argv: [*c]c.JSValue,
+            ) callconv(.c) c.JSValue {
+                const zig_ctx: *Context = @ptrCast(ctx);
+                const zig_args: []const Value = if (argc > 0)
+                    @ptrCast(argv[0..@intCast(argc)])
+                else
+                    &.{};
+                return @call(.always_inline, job_func, .{ zig_ctx, zig_args }).cval();
+            }
+        };
+        const result = c.JS_EnqueueJob(
+            self.cval(),
+            &Wrapper.callback,
+            @intCast(args.len),
+            @ptrCast(@constCast(args.ptr)),
+        );
+        if (result < 0) return error.OutOfMemory;
+    }
+
+    // =========================================================================
+    // Context Duplication
+    // =========================================================================
+
+    /// Duplicates the context, incrementing its reference count.
+    ///
+    /// The returned context must also be freed with `deinit`.
+    ///
+    /// C: `JS_DupContext`
+    pub fn dup(self: *Context) *Context {
+        return @ptrCast(c.JS_DupContext(self.cval()));
+    }
+
+    // =========================================================================
+    // Opaque Data
+    // =========================================================================
+
+    /// Gets the opaque pointer associated with this context.
+    ///
+    /// C: `JS_GetContextOpaque`
+    pub fn getOpaque(self: *Context, comptime T: type) ?*T {
+        return @ptrCast(@alignCast(c.JS_GetContextOpaque(self.cval())));
+    }
+
+    /// Sets the opaque pointer for this context.
+    ///
+    /// C: `JS_SetContextOpaque`
+    pub fn setOpaque(self: *Context, comptime T: type, ptr: ?*T) void {
+        c.JS_SetContextOpaque(self.cval(), ptr);
+    }
+
+    // =========================================================================
+    // Intrinsics
+    // =========================================================================
+
+    /// Adds base objects (Object, Function, Array, etc.).
+    ///
+    /// C: `JS_AddIntrinsicBaseObjects`
+    pub fn addIntrinsicBaseObjects(self: *Context) void {
+        c.JS_AddIntrinsicBaseObjects(self.cval());
+    }
+
+    /// Adds the Date constructor and prototype.
+    ///
+    /// C: `JS_AddIntrinsicDate`
+    pub fn addIntrinsicDate(self: *Context) void {
+        c.JS_AddIntrinsicDate(self.cval());
+    }
+
+    /// Adds eval() function.
+    ///
+    /// C: `JS_AddIntrinsicEval`
+    pub fn addIntrinsicEval(self: *Context) void {
+        c.JS_AddIntrinsicEval(self.cval());
+    }
+
+    /// Adds RegExp compiler (needed for literal regexp support).
+    ///
+    /// C: `JS_AddIntrinsicRegExpCompiler`
+    pub fn addIntrinsicRegExpCompiler(self: *Context) void {
+        c.JS_AddIntrinsicRegExpCompiler(self.cval());
+    }
+
+    /// Adds the RegExp constructor and prototype.
+    ///
+    /// C: `JS_AddIntrinsicRegExp`
+    pub fn addIntrinsicRegExp(self: *Context) void {
+        c.JS_AddIntrinsicRegExp(self.cval());
+    }
+
+    /// Adds JSON object with parse() and stringify().
+    ///
+    /// C: `JS_AddIntrinsicJSON`
+    pub fn addIntrinsicJSON(self: *Context) void {
+        c.JS_AddIntrinsicJSON(self.cval());
+    }
+
+    /// Adds the Proxy constructor and Reflect object.
+    ///
+    /// C: `JS_AddIntrinsicProxy`
+    pub fn addIntrinsicProxy(self: *Context) void {
+        c.JS_AddIntrinsicProxy(self.cval());
+    }
+
+    /// Adds Map and Set constructors and prototypes.
+    ///
+    /// C: `JS_AddIntrinsicMapSet`
+    pub fn addIntrinsicMapSet(self: *Context) void {
+        c.JS_AddIntrinsicMapSet(self.cval());
+    }
+
+    /// Adds TypedArray and ArrayBuffer constructors.
+    ///
+    /// C: `JS_AddIntrinsicTypedArrays`
+    pub fn addIntrinsicTypedArrays(self: *Context) void {
+        c.JS_AddIntrinsicTypedArrays(self.cval());
+    }
+
+    /// Adds Promise constructor and related functions.
+    ///
+    /// C: `JS_AddIntrinsicPromise`
+    pub fn addIntrinsicPromise(self: *Context) void {
+        c.JS_AddIntrinsicPromise(self.cval());
+    }
+
+    /// Adds BigInt constructor and prototype.
+    ///
+    /// C: `JS_AddIntrinsicBigInt`
+    pub fn addIntrinsicBigInt(self: *Context) void {
+        c.JS_AddIntrinsicBigInt(self.cval());
+    }
+
+    /// Adds WeakRef and FinalizationRegistry.
+    ///
+    /// C: `JS_AddIntrinsicWeakRef`
+    pub fn addIntrinsicWeakRef(self: *Context) void {
+        c.JS_AddIntrinsicWeakRef(self.cval());
+    }
+
+    /// Adds performance object with now().
+    ///
+    /// C: `JS_AddPerformance`
+    pub fn addPerformance(self: *Context) void {
+        c.JS_AddPerformance(self.cval());
+    }
+
+    /// Adds DOMException constructor.
+    ///
+    /// C: `JS_AddIntrinsicDOMException`
+    pub fn addIntrinsicDOMException(self: *Context) void {
+        c.JS_AddIntrinsicDOMException(self.cval());
+    }
+
+    // =========================================================================
+    // Class Prototypes
+    // =========================================================================
+
+    /// Gets the prototype for a class ID.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetClassProto`
+    pub fn getClassProto(self: *Context, class_id: class.Id) Value {
+        return Value.fromCVal(c.JS_GetClassProto(self.cval(), @intFromEnum(class_id)));
+    }
+
+    /// Sets the prototype for a class ID.
+    ///
+    /// Takes ownership of the prototype value.
+    ///
+    /// C: `JS_SetClassProto`
+    pub fn setClassProto(self: *Context, class_id: class.Id, proto: Value) void {
+        c.JS_SetClassProto(self.cval(), @intFromEnum(class_id), proto.cval());
+    }
+
+    /// Gets the Function prototype object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetFunctionProto`
+    pub fn getFunctionProto(self: *Context) Value {
+        return Value.fromCVal(c.JS_GetFunctionProto(self.cval()));
+    }
+
+    // =========================================================================
+    // Error Factories
+    // =========================================================================
+
+    /// Creates a new TypeError object (does not throw).
+    ///
+    /// C: `JS_NewTypeError`
+    pub fn newTypeError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_NewTypeError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Creates a new SyntaxError object (does not throw).
+    ///
+    /// C: `JS_NewSyntaxError`
+    pub fn newSyntaxError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_NewSyntaxError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Creates a new ReferenceError object (does not throw).
+    ///
+    /// C: `JS_NewReferenceError`
+    pub fn newReferenceError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_NewReferenceError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Creates a new RangeError object (does not throw).
+    ///
+    /// C: `JS_NewRangeError`
+    pub fn newRangeError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_NewRangeError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Creates a new InternalError object (does not throw).
+    ///
+    /// C: `JS_NewInternalError`
+    pub fn newInternalError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_NewInternalError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Throws a TypeError and returns the exception value.
+    ///
+    /// C: `JS_ThrowTypeError`
+    pub fn throwTypeError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_ThrowTypeError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Throws a SyntaxError and returns the exception value.
+    ///
+    /// C: `JS_ThrowSyntaxError`
+    pub fn throwSyntaxError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_ThrowSyntaxError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Throws a ReferenceError and returns the exception value.
+    ///
+    /// C: `JS_ThrowReferenceError`
+    pub fn throwReferenceError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_ThrowReferenceError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Throws a RangeError and returns the exception value.
+    ///
+    /// C: `JS_ThrowRangeError`
+    pub fn throwRangeError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_ThrowRangeError(self.cval(), "%s", msg.ptr));
+    }
+
+    /// Throws an InternalError and returns the exception value.
+    ///
+    /// C: `JS_ThrowInternalError`
+    pub fn throwInternalError(self: *Context, msg: [:0]const u8) Value {
+        return Value.fromCVal(c.JS_ThrowInternalError(self.cval(), "%s", msg.ptr));
+    }
+};
+
+/// Evaluation flags for `Context.eval`.
+///
+/// C: `JS_EVAL_TYPE_*` and `JS_EVAL_FLAG_*`
+pub const EvalFlags = packed struct(c_int) {
+    /// Evaluation type (2 bits).
+    /// - global (0): evaluate in global scope
+    /// - module (1): evaluate as ES module
+    /// - direct (2): direct call to eval
+    /// - indirect (3): indirect call to eval
+    type: Type = .global,
+    _reserved: u1 = 0,
+    /// Force strict mode.
+    strict: bool = false,
+    _unused: u1 = 0,
+    /// Compile but don't run (returns bytecode).
+    compile_only: bool = false,
+    /// Don't include stack frames in Error objects.
+    backtrace_barrier: bool = false,
+    /// Evaluate as async module.
+    async_module: bool = false,
+    _padding: u24 = 0,
+
+    pub const Type = enum(u2) {
+        global = 0,
+        module = 1,
+        direct = 2,
+        indirect = 3,
+    };
+};
+
+/// Extended evaluation options for `eval2` and `evalThis2`.
+///
+/// C: `JSEvalOptions`
+pub const EvalOptions = extern struct {
+    /// Version field for ABI compatibility.
+    version: c_int = c.JS_EVAL_OPTIONS_VERSION,
+    /// Evaluation flags (type and behavior modifiers).
+    flags: EvalFlags = .{},
+    /// Source filename for error messages.
+    filename: [*:0]const u8 = "<eval>",
+    /// Starting line number for error messages (1-based).
+    line_num: c_int = 1,
+};
+
+comptime {
+    std.debug.assert(c.JS_EVAL_OPTIONS_VERSION == 1);
+    std.debug.assert(@sizeOf(EvalOptions) == @sizeOf(c.JSEvalOptions));
+    std.debug.assert(@alignOf(EvalOptions) == @alignOf(c.JSEvalOptions));
+}
+
+test "Context init and deinit" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+}
+
+test "EvalFlags bit layout matches C header" {
+    const testing = std.testing;
+
+    // Type values (bits 0-1)
+    try testing.expectEqual(c.JS_EVAL_TYPE_GLOBAL, @as(c_int, @bitCast(EvalFlags{ .type = .global })));
+    try testing.expectEqual(c.JS_EVAL_TYPE_MODULE, @as(c_int, @bitCast(EvalFlags{ .type = .module })));
+    try testing.expectEqual(c.JS_EVAL_TYPE_DIRECT, @as(c_int, @bitCast(EvalFlags{ .type = .direct })));
+    try testing.expectEqual(c.JS_EVAL_TYPE_INDIRECT, @as(c_int, @bitCast(EvalFlags{ .type = .indirect })));
+
+    // Flag values (bits 3, 5-7)
+    try testing.expectEqual(c.JS_EVAL_FLAG_STRICT, @as(c_int, @bitCast(EvalFlags{ .strict = true })));
+    try testing.expectEqual(c.JS_EVAL_FLAG_COMPILE_ONLY, @as(c_int, @bitCast(EvalFlags{ .compile_only = true })));
+    try testing.expectEqual(c.JS_EVAL_FLAG_BACKTRACE_BARRIER, @as(c_int, @bitCast(EvalFlags{ .backtrace_barrier = true })));
+    try testing.expectEqual(c.JS_EVAL_FLAG_ASYNC, @as(c_int, @bitCast(EvalFlags{ .async_module = true })));
+
+    // Combined flags
+    try testing.expectEqual(
+        c.JS_EVAL_TYPE_MODULE | c.JS_EVAL_FLAG_STRICT,
+        @as(c_int, @bitCast(EvalFlags{ .type = .module, .strict = true })),
+    );
+}
+
+test "Context dup" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const ctx2 = ctx.dup();
+    defer ctx2.deinit();
+
+    // Both contexts should work and share the same runtime
+    try std.testing.expectEqual(rt, ctx2.getRuntime());
+
+    // Both should be able to evaluate
+    const result = ctx2.eval("1 + 1", "<test>", .{});
+    defer result.deinit(ctx2);
+    try std.testing.expectEqual(@as(i32, 2), try result.toInt32(ctx2));
+}
+
+test "Context opaque data" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const TestData = struct {
+        value: i32,
+    };
+
+    var data: TestData = .{ .value = 42 };
+
+    // Initially null
+    try std.testing.expectEqual(@as(?*TestData, null), ctx.getOpaque(TestData));
+
+    // Set opaque
+    ctx.setOpaque(TestData, &data);
+
+    // Get opaque
+    const retrieved = ctx.getOpaque(TestData);
+    try std.testing.expect(retrieved != null);
+    try std.testing.expectEqual(@as(i32, 42), retrieved.?.value);
+
+    // Modify through pointer
+    retrieved.?.value = 100;
+    try std.testing.expectEqual(@as(i32, 100), data.value);
+
+    // Clear
+    ctx.setOpaque(TestData, null);
+    try std.testing.expectEqual(@as(?*TestData, null), ctx.getOpaque(TestData));
+}
+
+test "Context initRaw" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .initRaw(rt);
+    defer ctx.deinit();
+
+    // Just test that raw context can be created
+    try std.testing.expectEqual(rt, ctx.getRuntime());
+}
+
+test "Context addIntrinsicBaseObjects" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .initRaw(rt);
+    defer ctx.deinit();
+
+    // Just test that the method doesn't crash
+    ctx.addIntrinsicBaseObjects();
+}
+
+test "Context addIntrinsicDate" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Date should already be available in normal context
+    const result = ctx.eval("new Date(0).getTime()", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i64, 0), try result.toInt64(ctx));
+}
+
+test "Context addIntrinsicEval" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .initRaw(rt);
+    defer ctx.deinit();
+
+    ctx.addIntrinsicBaseObjects();
+    ctx.addIntrinsicEval();
+
+    // eval() should work now
+    const result = ctx.eval("eval('2 + 3')", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i32, 5), try result.toInt32(ctx));
+}
+
+test "Context addIntrinsicJSON" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // JSON should work
+    const result = ctx.eval("JSON.parse('{\"a\": 42}').a", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+}
+
+test "Context addIntrinsicMapSet" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Map and Set should work
+    const result = ctx.eval(
+        \\const m = new Map();
+        \\m.set('key', 123);
+        \\m.get('key')
+    , "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i32, 123), try result.toInt32(ctx));
+}
+
+test "Context addIntrinsicPromise" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Promise should work
+    const result = ctx.eval("new Promise((r) => r(42))", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expect(result.isPromise());
+}
+
+test "Context addIntrinsicBigInt" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // BigInt should work
+    const result = ctx.eval("BigInt(9007199254740991)", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expect(result.isBigInt());
+}
+
+test "Context addIntrinsicRegExp" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // RegExp should work
+    const result = ctx.eval("/test/.test('test')", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expect(try result.toBool(ctx));
+}
+
+test "Context addIntrinsicProxy" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Proxy should work
+    const result = ctx.eval(
+        \\const target = { a: 1 };
+        \\const p = new Proxy(target, {});
+        \\p.a
+    , "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i32, 1), try result.toInt32(ctx));
+}
+
+test "Context addIntrinsicTypedArrays" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // TypedArray should work
+    const result = ctx.eval(
+        \\const arr = new Uint8Array([1, 2, 3]);
+        \\arr[1]
+    , "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expectEqual(@as(i32, 2), try result.toInt32(ctx));
+}
+
+test "Context addPerformance" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Use a full context since performance depends on other intrinsics
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // performance object should exist (added by default)
+    const result = ctx.eval("typeof performance", "<test>", .{});
+    defer result.deinit(ctx);
+    const str = result.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("object", std.mem.span(str));
+
+    // performance.now() should return a number
+    const result2 = ctx.eval("typeof performance.now()", "<test>", .{});
+    defer result2.deinit(ctx);
+    const str2 = result2.toCString(ctx).?;
+    defer ctx.freeCString(str2);
+    try std.testing.expectEqualStrings("number", std.mem.span(str2));
+}
+
+test "Context getFunctionProto" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const func_proto = ctx.getFunctionProto();
+    defer func_proto.deinit(ctx);
+
+    try std.testing.expect(func_proto.isObject());
+
+    // Verify it's the actual Function.prototype
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    const func_ctor = global.getPropertyStr(ctx, "Function");
+    defer func_ctor.deinit(ctx);
+    const expected_proto = func_ctor.getPropertyStr(ctx, "prototype");
+    defer expected_proto.deinit(ctx);
+
+    try std.testing.expect(func_proto.isStrictEqual(ctx, expected_proto));
+}
+
+test "Context newTypeError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const err = ctx.newTypeError("test type error");
+    defer err.deinit(ctx);
+
+    try std.testing.expect(err.isError());
+
+    // Verify it's a TypeError by checking constructor name
+    const ctor = err.getPropertyStr(ctx, "constructor");
+    defer ctor.deinit(ctx);
+    const name = ctor.getPropertyStr(ctx, "name");
+    defer name.deinit(ctx);
+    const str = name.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("TypeError", std.mem.span(str));
+}
+
+test "Context newSyntaxError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const err = ctx.newSyntaxError("test syntax error");
+    defer err.deinit(ctx);
+
+    try std.testing.expect(err.isError());
+
+    const ctor = err.getPropertyStr(ctx, "constructor");
+    defer ctor.deinit(ctx);
+    const name = ctor.getPropertyStr(ctx, "name");
+    defer name.deinit(ctx);
+    const str = name.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("SyntaxError", std.mem.span(str));
+}
+
+test "Context newReferenceError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const err = ctx.newReferenceError("test reference error");
+    defer err.deinit(ctx);
+
+    try std.testing.expect(err.isError());
+
+    const ctor = err.getPropertyStr(ctx, "constructor");
+    defer ctor.deinit(ctx);
+    const name = ctor.getPropertyStr(ctx, "name");
+    defer name.deinit(ctx);
+    const str = name.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("ReferenceError", std.mem.span(str));
+}
+
+test "Context newRangeError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const err = ctx.newRangeError("test range error");
+    defer err.deinit(ctx);
+
+    try std.testing.expect(err.isError());
+
+    const ctor = err.getPropertyStr(ctx, "constructor");
+    defer ctor.deinit(ctx);
+    const name = ctor.getPropertyStr(ctx, "name");
+    defer name.deinit(ctx);
+    const str = name.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("RangeError", std.mem.span(str));
+}
+
+test "Context newInternalError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const err = ctx.newInternalError("test internal error");
+    defer err.deinit(ctx);
+
+    try std.testing.expect(err.isError());
+
+    const ctor = err.getPropertyStr(ctx, "constructor");
+    defer ctor.deinit(ctx);
+    const name = ctor.getPropertyStr(ctx, "name");
+    defer name.deinit(ctx);
+    const str = name.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("InternalError", std.mem.span(str));
+}
+
+test "Context throwTypeError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = ctx.throwTypeError("expected a number");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(ctx.hasException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try std.testing.expect(exc.isError());
+
+    const msg = exc.getPropertyStr(ctx, "message");
+    defer msg.deinit(ctx);
+    const str = msg.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("expected a number", std.mem.span(str));
+}
+
+test "Context throwSyntaxError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = ctx.throwSyntaxError("unexpected token");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(ctx.hasException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try std.testing.expect(exc.isError());
+}
+
+test "Context throwReferenceError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = ctx.throwReferenceError("x is not defined");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(ctx.hasException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try std.testing.expect(exc.isError());
+}
+
+test "Context throwRangeError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = ctx.throwRangeError("value out of range");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(ctx.hasException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try std.testing.expect(exc.isError());
+}
+
+test "Context throwInternalError" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = ctx.throwInternalError("internal failure");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(ctx.hasException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try std.testing.expect(exc.isError());
+}
+
+test "Context error message preserved in JavaScript" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Throw a TypeError
+    _ = ctx.throwTypeError("custom error message");
+
+    // Get the exception and verify message
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+
+    const msg = exc.getPropertyStr(ctx, "message");
+    defer msg.deinit(ctx);
+    const str = msg.toCString(ctx).?;
+    defer ctx.freeCString(str);
+    try std.testing.expectEqualStrings("custom error message", std.mem.span(str));
+
+    // Verify stack trace exists
+    const stack = exc.getPropertyStr(ctx, "stack");
+    defer stack.deinit(ctx);
+    try std.testing.expect(stack.isString());
+}
+
+test "Context raw with selective intrinsics" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Create a minimal context with only what we need
+    const ctx: *Context = try .initRaw(rt);
+    defer ctx.deinit();
+
+    // Test that we can add multiple intrinsics without crashing
+    ctx.addIntrinsicBaseObjects();
+    ctx.addIntrinsicJSON();
+    ctx.addIntrinsicDate();
+    ctx.addIntrinsicPromise();
+
+    // The context should still be valid
+    try std.testing.expectEqual(rt, ctx.getRuntime());
+}
+
+test "Context getScriptOrModuleName in module" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const loader = struct {
+        fn load(
+            _: void,
+            load_ctx: *Context,
+            name: [:0]const u8,
+        ) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "name_test")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "dummy");
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "dummy", Value.initInt32(1))) return false;
+            return true;
+        }
+    };
+
+    rt.setModuleLoaderFunc(void, {}, null, loader.load);
+
+    const result = ctx.eval(
+        \\import { dummy } from "name_test";
+        \\dummy
+    , "test_script.js", .{ .type = .module });
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+}
+
+test "Context loadModule with loader" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const loader = struct {
+        fn load(
+            _: void,
+            load_ctx: *Context,
+            name: [:0]const u8,
+        ) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "loaded_module")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "value");
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "value", Value.initInt32(999))) return false;
+            return true;
+        }
+    };
+
+    rt.setModuleLoaderFunc(void, {}, null, loader.load);
+
+    const result = ctx.loadModule(".", "loaded_module");
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+}
+
+test "Context eval2" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    var options: EvalOptions = .{
+        .filename = "test.js",
+        .line_num = 10,
+    };
+    const result = ctx.eval2("1 + 2", &options);
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+    try std.testing.expectEqual(@as(i32, 3), try result.toInt32(ctx));
+}
+
+test "Context evalThis" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const this_obj = Value.initObject(ctx);
+    defer this_obj.deinit(ctx);
+    try this_obj.setPropertyStr(ctx, "x", Value.initInt32(42));
+
+    const result = ctx.evalThis(this_obj, "this.x", "<test>", .{});
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+    try std.testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+}
+
+test "Context evalThis2" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const this_obj = Value.initObject(ctx);
+    defer this_obj.deinit(ctx);
+    try this_obj.setPropertyStr(ctx, "value", Value.initInt32(100));
+
+    var options: EvalOptions = .{
+        .filename = "custom.js",
+        .line_num = 5,
+    };
+    const result = ctx.evalThis2(this_obj, "this.value * 2", &options);
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+    try std.testing.expectEqual(@as(i32, 200), try result.toInt32(ctx));
+}
+
+test "Context evalFunction" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const bytecode = ctx.eval("1 + 2", "<test>", .{ .compile_only = true });
+    try std.testing.expect(!bytecode.isException());
+
+    const result = ctx.evalFunction(bytecode);
+    defer result.deinit(ctx);
+
+    try std.testing.expect(!result.isException());
+    try std.testing.expectEqual(@as(i32, 3), try result.toInt32(ctx));
+}
+
+test "Context enqueueJob" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+
+    try global.setPropertyStr(ctx, "jobRan", Value.initBool(false));
+
+    const job = struct {
+        fn run(job_ctx: *Context, _: []const Value) Value {
+            const g = job_ctx.getGlobalObject();
+            defer g.deinit(job_ctx);
+            g.setPropertyStr(job_ctx, "jobRan", Value.initBool(true)) catch {};
+            return Value.undefined;
+        }
+    };
+
+    try ctx.enqueueJob(job.run, &.{});
+
+    try std.testing.expect(rt.isJobPending());
+
+    _ = try rt.executePendingJob();
+
+    const ran = global.getPropertyStr(ctx, "jobRan");
+    defer ran.deinit(ctx);
+    try std.testing.expect(try ran.toBool(ctx));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/main.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/main.zig
@@ -1,0 +1,48 @@
+const atom = @import("atom.zig");
+const class = @import("class.zig");
+const context = @import("context.zig");
+const module = @import("module.zig");
+const runtime = @import("runtime.zig");
+const value = @import("value.zig");
+
+pub const c = @import("quickjs_c");
+pub const cfunc = @import("cfunc.zig");
+pub const typed_array = @import("typed_array.zig");
+
+pub const Atom = atom.Atom;
+pub const Context = context.Context;
+pub const EvalFlags = context.EvalFlags;
+pub const ModuleDef = module.ModuleDef;
+pub const Runtime = runtime.Runtime;
+pub const DumpFlags = runtime.DumpFlags;
+pub const Value = value.Value;
+pub const Promise = value.Value.Promise;
+pub const PromiseState = value.PromiseState;
+pub const ClassId = class.Id;
+pub const ClassDef = class.Def;
+pub const ClassExoticMethods = class.ExoticMethods;
+
+pub fn version() [*:0]const u8 {
+    return c.JS_GetVersion();
+}
+
+/// Detects if input looks like an ES module.
+///
+/// Returns true if the input contains `import` or `export` statements
+/// at the top level.
+///
+/// C: `JS_DetectModule`
+pub fn detectModule(input: []const u8) bool {
+    return c.JS_DetectModule(input.ptr, input.len);
+}
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}
+
+test "detectModule" {
+    const testing = @import("std").testing;
+    try testing.expect(detectModule("import { foo } from 'bar';"));
+    try testing.expect(detectModule("export const x = 1;"));
+    try testing.expect(detectModule("export default function() {}"));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/module.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/module.zig
@@ -1,0 +1,297 @@
+const std = @import("std");
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Atom = @import("atom.zig").Atom;
+const Context = @import("context.zig").Context;
+const Runtime = @import("runtime.zig").Runtime;
+const Value = @import("value.zig").Value;
+
+/// Wrapper for the QuickJS `JSModuleDef`.
+///
+/// A module definition represents a JavaScript module created from native code.
+/// Use `init` to create a new C module, then add exports before the module is
+/// instantiated.
+///
+/// C: `JSModuleDef`
+pub const ModuleDef = opaque {
+    /// Module initialization function type.
+    ///
+    /// Called when the module is instantiated. Use this to set module exports.
+    /// Return true on success, false on error.
+    ///
+    /// C: `JSModuleInitFunc`
+    pub const InitFunc = *const fn (*Context, *ModuleDef) bool;
+
+    /// Creates a new C module with the given name.
+    ///
+    /// The `func` is called when the module is instantiated and should set
+    /// the module exports using `setExport`.
+    ///
+    /// Returns null on allocation failure.
+    ///
+    /// C: `JS_NewCModule`
+    pub fn init(ctx: *Context, name: [:0]const u8, comptime func: InitFunc) ?*ModuleDef {
+        const Wrapper = struct {
+            fn callback(inner_ctx: *Context, m: *ModuleDef) callconv(.c) c_int {
+                return @intFromBool(!@call(.always_inline, func, .{ inner_ctx, m }));
+            }
+        };
+        return @ptrCast(c.JS_NewCModule(ctx.cval(), name.ptr, @ptrCast(&Wrapper.callback)));
+    }
+
+    /// Declares an export for this module.
+    ///
+    /// Must be called before the module is instantiated. The actual value
+    /// is set later with `setExport` in the init function.
+    ///
+    /// Returns true on success.
+    ///
+    /// C: `JS_AddModuleExport`
+    pub fn addExport(self: *ModuleDef, ctx: *Context, name: [:0]const u8) bool {
+        return c.JS_AddModuleExport(ctx.cval(), @ptrCast(self), name.ptr) == 0;
+    }
+
+    /// Sets the value of a module export.
+    ///
+    /// Must be called after the module is instantiated, typically in the
+    /// init function. The value's ownership is transferred to the module.
+    ///
+    /// Returns true on success.
+    ///
+    /// C: `JS_SetModuleExport`
+    pub fn setExport(self: *ModuleDef, ctx: *Context, name: [:0]const u8, val: Value) bool {
+        return c.JS_SetModuleExport(ctx.cval(), @ptrCast(self), name.ptr, val.cval()) == 0;
+    }
+
+    /// Gets the import.meta object for this module.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetImportMeta`
+    pub fn getImportMeta(self: *ModuleDef, ctx: *Context) Value {
+        return Value.fromCVal(c.JS_GetImportMeta(ctx.cval(), @ptrCast(self)));
+    }
+
+    /// Gets the module name as an atom.
+    ///
+    /// The returned atom must be freed with `Atom.deinit`.
+    ///
+    /// C: `JS_GetModuleName`
+    pub fn getName(self: *ModuleDef, ctx: *Context) Atom {
+        return @enumFromInt(c.JS_GetModuleName(ctx.cval(), @ptrCast(self)));
+    }
+
+    /// Gets the module namespace object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetModuleNamespace`
+    pub fn getNamespace(self: *ModuleDef, ctx: *Context) Value {
+        return Value.fromCVal(c.JS_GetModuleNamespace(ctx.cval(), @ptrCast(self)));
+    }
+
+    pub inline fn cval(self: *ModuleDef) *c.JSModuleDef {
+        return @ptrCast(self);
+    }
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+fn testModuleInit(ctx: *Context, m: *ModuleDef) bool {
+    if (!m.setExport(ctx, "value", Value.initInt32(42))) return false;
+    if (!m.setExport(ctx, "greeting", Value.initString(ctx, "hello"))) return false;
+    return true;
+}
+
+test "ModuleDef init and addExport" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const m = ModuleDef.init(ctx, "test_module", testModuleInit);
+    try testing.expect(m != null);
+
+    try testing.expect(m.?.addExport(ctx, "value"));
+    try testing.expect(m.?.addExport(ctx, "greeting"));
+}
+
+test "ModuleDef getName" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const m = ModuleDef.init(ctx, "my_module", testModuleInit).?;
+    _ = m.addExport(ctx, "value");
+    _ = m.addExport(ctx, "greeting");
+
+    const name_atom = m.getName(ctx);
+    defer name_atom.deinit(ctx);
+
+    const name_str = name_atom.toCString(ctx).?;
+    defer ctx.freeCString(name_str);
+
+    try testing.expectEqualStrings("my_module", std.mem.span(name_str));
+}
+
+test "ModuleDef full module import via eval" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const loader = struct {
+        fn load(_: void, load_ctx: *Context, name: [:0]const u8) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "test_module")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "value");
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "value", Value.initInt32(123))) return false;
+            return true;
+        }
+    };
+
+    rt.setModuleLoaderFunc(void, {}, null, loader.load);
+
+    const result = ctx.eval(
+        \\import { value } from "test_module";
+        \\globalThis.testResult = value;
+    , "<test>", .{ .type = .module });
+    defer result.deinit(ctx);
+
+    if (result.isException()) {
+        const exc = ctx.getException();
+        defer exc.deinit(ctx);
+        if (exc.getPropertyStr(ctx, "message").toCString(ctx)) |msg| {
+            defer ctx.freeCString(msg);
+            std.debug.print("Exception: {s}\n", .{msg});
+        }
+        try testing.expect(false);
+    }
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    const test_result = global.getPropertyStr(ctx, "testResult");
+    defer test_result.deinit(ctx);
+
+    try testing.expectEqual(@as(i32, 123), try test_result.toInt32(ctx));
+}
+
+test "ModuleDef getImportMeta" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const State = struct { captured_module: ?*ModuleDef = null };
+
+    const loader = struct {
+        fn load(
+            state: ?*State,
+            load_ctx: *Context,
+            name: [:0]const u8,
+        ) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "meta_test")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "dummy");
+
+            state.?.captured_module = m;
+
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "dummy", Value.initInt32(1))) return false;
+            return true;
+        }
+    };
+
+    var state: State = .{};
+    rt.setModuleLoaderFunc(State, &state, null, loader.load);
+
+    const result = ctx.eval(
+        \\import { dummy } from "meta_test";
+        \\dummy
+    , "<test>", .{ .type = .module });
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+    try testing.expect(state.captured_module != null);
+
+    const meta = state.captured_module.?.getImportMeta(ctx);
+    defer meta.deinit(ctx);
+
+    try testing.expect(meta.isObject());
+}
+
+test "ModuleDef getNamespace" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const State = struct { captured_module: ?*ModuleDef = null };
+
+    const loader = struct {
+        fn load(
+            state: ?*State,
+            load_ctx: *Context,
+            name: [:0]const u8,
+        ) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "ns_test")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "foo");
+            _ = m.addExport(load_ctx, "bar");
+
+            state.?.captured_module = m;
+
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "foo", Value.initInt32(10))) return false;
+            if (!m.setExport(init_ctx, "bar", Value.initInt32(20))) return false;
+            return true;
+        }
+    };
+
+    var state: State = .{};
+    rt.setModuleLoaderFunc(State, &state, null, loader.load);
+
+    const result = ctx.eval(
+        \\import * as ns from "ns_test";
+        \\globalThis.nsResult = ns.foo + ns.bar;
+    , "<test>", .{ .type = .module });
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    const ns_result = global.getPropertyStr(ctx, "nsResult");
+    defer ns_result.deinit(ctx);
+    try testing.expectEqual(@as(i32, 30), try ns_result.toInt32(ctx));
+
+    const ns = state.captured_module.?.getNamespace(ctx);
+    defer ns.deinit(ctx);
+
+    try testing.expect(ns.isObject());
+
+    const foo = ns.getPropertyStr(ctx, "foo");
+    defer foo.deinit(ctx);
+    try testing.expectEqual(@as(i32, 10), try foo.toInt32(ctx));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/opaque.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/opaque.zig
@@ -1,0 +1,22 @@
+// Helpers for userdata handling.
+
+/// Given an opaque type T, returns the expected type T that the user
+/// should pass in. This is necessary because if the user provides `void`,
+/// then we don't want a `void` pointer, we just want void.
+pub fn Opaque(comptime T: type) type {
+    // Void as-is so the function signature is cleaner.
+    if (T == void) return void;
+
+    // Optional pointer to the type.
+    return ?*T;
+}
+
+pub fn toC(comptime T: type, value: Opaque(T)) ?*anyopaque {
+    if (T == void) return null;
+    return @ptrCast(value);
+}
+
+pub fn fromC(comptime T: type, ud: ?*anyopaque) Opaque(T) {
+    if (T == void) return;
+    return @alignCast(@ptrCast(ud));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/runtime.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/runtime.zig
@@ -1,0 +1,1099 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const c = @import("quickjs_c");
+const Context = @import("context.zig").Context;
+const ModuleDef = @import("module.zig").ModuleDef;
+const typed_array = @import("typed_array.zig");
+const Value = @import("value.zig").Value;
+const class = @import("class.zig");
+const Atom = @import("atom.zig").Atom;
+const opaquepkg = @import("opaque.zig");
+const Opaque = opaquepkg.Opaque;
+
+/// Custom malloc functions for runtime memory allocation.
+///
+/// Note: A Zig `std.mem.Allocator` cannot be directly wrapped because
+/// Zig allocators require the original allocation size for `free` and
+/// `realloc`, but this C-style interface does not provide it. Use
+/// allocators that internally track sizes (e.g., libc malloc via
+/// `std.c.malloc`/`std.c.free`).
+///
+/// C: `JSMallocFunctions`
+pub const MallocFunctions = extern struct {
+    calloc: *const fn (?*anyopaque, usize, usize) callconv(.c) ?*anyopaque,
+    malloc: *const fn (?*anyopaque, usize) callconv(.c) ?*anyopaque,
+    free: *const fn (?*anyopaque, ?*anyopaque) callconv(.c) void,
+    realloc: *const fn (?*anyopaque, ?*anyopaque, usize) callconv(.c) ?*anyopaque,
+    malloc_usable_size: ?*const fn (?*const anyopaque) callconv(.c) usize = null,
+
+    comptime {
+        if (@sizeOf(MallocFunctions) != @sizeOf(c.JSMallocFunctions))
+            @compileError("MallocFunctions size mismatch");
+        if (@alignOf(MallocFunctions) != @alignOf(c.JSMallocFunctions))
+            @compileError("MallocFunctions alignment mismatch");
+    }
+};
+
+/// Wrapper for the QuickJS `JSRuntime`.
+///
+/// The runtime represents a JavaScript execution environment. It manages
+/// memory allocation, garbage collection, and atom (interned string) tables
+/// shared by all contexts created from it.
+pub const Runtime = opaque {
+    /// Creates a new JavaScript runtime.
+    ///
+    /// The runtime must be freed with `deinit` when no longer needed.
+    /// All contexts created from this runtime must be freed before
+    /// freeing the runtime itself.
+    ///
+    /// C: `JS_NewRuntime`
+    pub fn init() Allocator.Error!*Runtime {
+        const rt = c.JS_NewRuntime();
+        if (rt == null) return error.OutOfMemory;
+        return @ptrCast(rt);
+    }
+
+    /// Creates a new JavaScript runtime with custom malloc functions.
+    ///
+    /// This allows using a custom allocator for all runtime memory operations.
+    /// The opaque pointer is passed to all malloc function callbacks.
+    ///
+    /// C: `JS_NewRuntime2`
+    pub fn initWithMallocFunctions(mf: *const MallocFunctions, opaque_ptr: ?*anyopaque) Allocator.Error!*Runtime {
+        const rt = c.JS_NewRuntime2(@ptrCast(mf), opaque_ptr);
+        if (rt == null) return error.OutOfMemory;
+        return @ptrCast(rt);
+    }
+
+    /// Frees the JavaScript runtime and all associated resources.
+    ///
+    /// All contexts created from this runtime must be freed before
+    /// calling this function. If `JS_DUMP_LEAKS` or similar dump flags
+    /// were set, this will output diagnostic information about leaked
+    /// objects, strings, atoms, or memory.
+    ///
+    /// C: `JS_FreeRuntime`
+    pub fn deinit(self: *Runtime) void {
+        c.JS_FreeRuntime(self.cval());
+    }
+
+    /// Creates a new JavaScript context within this runtime.
+    ///
+    /// The context must be freed with `Context.deinit` when no longer needed.
+    /// Contexts must be freed before freeing the runtime they belong to.
+    ///
+    /// C: `JS_NewContext`
+    pub fn newContext(self: *Runtime) Allocator.Error!*Context {
+        return Context.init(self);
+    }
+
+    /// Creates a raw JavaScript context without any intrinsic objects.
+    ///
+    /// Use this to create a minimal context, then add only the intrinsics
+    /// you need with `addIntrinsic*` methods.
+    ///
+    /// C: `JS_NewContextRaw`
+    pub fn newContextRaw(self: *Runtime) Allocator.Error!*Context {
+        return Context.initRaw(self);
+    }
+
+    // =========================================================================
+    // Runtime Configuration
+    // =========================================================================
+
+    /// Sets runtime description for debugging purposes.
+    ///
+    /// The info string lifetime must exceed that of the runtime.
+    ///
+    /// C: `JS_SetRuntimeInfo`
+    pub fn setInfo(self: *Runtime, info: [:0]const u8) void {
+        c.JS_SetRuntimeInfo(self.cval(), info.ptr);
+    }
+
+    /// Sets the memory limit for the runtime.
+    ///
+    /// Use 0 to disable the memory limit.
+    ///
+    /// C: `JS_SetMemoryLimit`
+    pub fn setMemoryLimit(self: *Runtime, limit: usize) void {
+        c.JS_SetMemoryLimit(self.cval(), limit);
+    }
+
+    /// Sets the maximum stack size for the runtime.
+    ///
+    /// Use 0 to disable the stack size check.
+    ///
+    /// C: `JS_SetMaxStackSize`
+    pub fn setMaxStackSize(self: *Runtime, size: usize) void {
+        c.JS_SetMaxStackSize(self.cval(), size);
+    }
+
+    /// Updates the stack top value used to check stack overflow.
+    ///
+    /// Should be called when changing threads.
+    ///
+    /// C: `JS_UpdateStackTop`
+    pub fn updateStackTop(self: *Runtime) void {
+        c.JS_UpdateStackTop(self.cval());
+    }
+
+    // =========================================================================
+    // Garbage Collection
+    // =========================================================================
+
+    /// Sets the GC threshold.
+    ///
+    /// The threshold determines when automatic garbage collection is triggered.
+    ///
+    /// C: `JS_SetGCThreshold`
+    pub fn setGCThreshold(self: *Runtime, threshold: usize) void {
+        c.JS_SetGCThreshold(self.cval(), threshold);
+    }
+
+    /// Gets the current GC threshold.
+    ///
+    /// C: `JS_GetGCThreshold`
+    pub fn getGCThreshold(self: *Runtime) usize {
+        return c.JS_GetGCThreshold(self.cval());
+    }
+
+    /// Runs the garbage collector.
+    ///
+    /// C: `JS_RunGC`
+    pub fn runGC(self: *Runtime) void {
+        c.JS_RunGC(self.cval());
+    }
+
+    /// Checks if a value is a live object in this runtime.
+    ///
+    /// C: `JS_IsLiveObject`
+    pub fn isLiveObject(self: *Runtime, obj: Value) bool {
+        return c.JS_IsLiveObject(self.cval(), obj.cval());
+    }
+
+    // =========================================================================
+    // Opaque Data
+    // =========================================================================
+
+    /// Gets the opaque pointer associated with this runtime.
+    ///
+    /// C: `JS_GetRuntimeOpaque`
+    pub fn getOpaque(self: *Runtime, comptime T: type) ?*T {
+        return @ptrCast(@alignCast(c.JS_GetRuntimeOpaque(self.cval())));
+    }
+
+    /// Sets the opaque pointer for this runtime.
+    ///
+    /// C: `JS_SetRuntimeOpaque`
+    pub fn setOpaque(self: *Runtime, comptime T: type, ptr: ?*T) void {
+        c.JS_SetRuntimeOpaque(self.cval(), ptr);
+    }
+
+    // =========================================================================
+    // Dump Flags (Debugging)
+    // =========================================================================
+
+    /// Sets the dump flags for debugging output.
+    ///
+    /// C: `JS_SetDumpFlags`
+    pub fn setDumpFlags(self: *Runtime, flags: DumpFlags) void {
+        c.JS_SetDumpFlags(self.cval(), @bitCast(flags));
+    }
+
+    /// Gets the current dump flags.
+    ///
+    /// C: `JS_GetDumpFlags`
+    pub fn getDumpFlags(self: *Runtime) DumpFlags {
+        return @bitCast(c.JS_GetDumpFlags(self.cval()));
+    }
+
+    // =========================================================================
+    // Interrupt Handler
+    // =========================================================================
+
+    /// Interrupt handler callback type.
+    ///
+    /// Called periodically during JavaScript execution.
+    /// - userdata: The opaque pointer passed to setInterruptHandler
+    /// - runtime: The runtime
+    /// Return true to interrupt execution, false to continue.
+    pub fn InterruptHandler(comptime T: type) type {
+        return *const fn (Opaque(T), *Runtime) bool;
+    }
+
+    /// Sets the interrupt handler for this runtime.
+    ///
+    /// The interrupt handler is called periodically during JavaScript execution
+    /// and can be used to implement timeouts or cancellation.
+    ///
+    /// C: `JS_SetInterruptHandler`
+    pub fn setInterruptHandler(
+        self: *Runtime,
+        comptime T: type,
+        userdata: Opaque(T),
+        comptime handler: ?InterruptHandler(T),
+    ) void {
+        const h = handler orelse {
+            c.JS_SetInterruptHandler(self.cval(), null, null);
+            return;
+        };
+
+        const Wrapper = struct {
+            fn callback(
+                runtime: *Runtime,
+                inner_userdata: ?*anyopaque,
+            ) callconv(.c) c_int {
+                const should_interrupt = @call(.always_inline, h, .{
+                    opaquepkg.fromC(T, inner_userdata),
+                    runtime,
+                });
+                return if (should_interrupt) 1 else 0;
+            }
+        };
+
+        c.JS_SetInterruptHandler(
+            self.cval(),
+            @ptrCast(&Wrapper.callback),
+            opaquepkg.toC(T, userdata),
+        );
+    }
+
+    // =========================================================================
+    // Atomics Support
+    // =========================================================================
+
+    /// Sets whether Atomics.wait() can be used.
+    ///
+    /// If can_block is true, Atomics.wait() can be used.
+    ///
+    /// C: `JS_SetCanBlock`
+    pub fn setCanBlock(self: *Runtime, can_block: bool) void {
+        c.JS_SetCanBlock(self.cval(), can_block);
+    }
+
+    /// Sets the SharedArrayBuffer functions for this runtime.
+    ///
+    /// These functions are used to allocate, free, and duplicate SharedArrayBuffer memory.
+    ///
+    /// C: `JS_SetSharedArrayBufferFunctions`
+    pub fn setSharedArrayBufferFunctions(self: *Runtime, sf: typed_array.SharedBufferFunctions) void {
+        var c_sf = sf.toCStruct();
+        c.JS_SetSharedArrayBufferFunctions(self.cval(), &c_sf);
+    }
+
+    // =========================================================================
+    // Module Loader
+    // =========================================================================
+
+    /// Module name normalization function type.
+    ///
+    /// Called to normalize a module specifier.
+    /// - userdata: The opaque pointer passed to setModuleLoaderFunc
+    /// - ctx: The context
+    /// - module_base_name: The base name (requester) of the module
+    /// - module_name: The specifier being requested
+    ///
+    /// Returns the normalized module specifier (allocated with js_malloc) or null on exception.
+    pub fn ModuleNormalizeFunc(comptime T: type) type {
+        return *const fn (Opaque(T), *Context, [:0]const u8, [:0]const u8) ?[*:0]u8;
+    }
+
+    /// Module loader function type.
+    ///
+    /// Called to load a module.
+    /// - userdata: The opaque pointer passed to setModuleLoaderFunc
+    /// - ctx: The context
+    /// - module_name: The normalized module specifier
+    ///
+    /// Returns the module definition or null on error.
+    pub fn ModuleLoaderFunc(comptime T: type) type {
+        return *const fn (Opaque(T), *Context, [:0]const u8) ?*ModuleDef;
+    }
+
+    /// Sets the module loader functions.
+    ///
+    /// module_normalize can be null to use the default normalizer.
+    /// module_loader can be null to disable module loading.
+    ///
+    /// C: `JS_SetModuleLoaderFunc`
+    pub fn setModuleLoaderFunc(
+        self: *Runtime,
+        comptime T: type,
+        userdata: Opaque(T),
+        comptime module_normalize: ?ModuleNormalizeFunc(T),
+        comptime module_loader: ?ModuleLoaderFunc(T),
+    ) void {
+        const Wrapper = struct {
+            fn normCallback(
+                ctx: *Context,
+                module_base_name: [*:0]const u8,
+                module_name: [*:0]const u8,
+                inner_userdata: ?*anyopaque,
+            ) callconv(.c) ?[*:0]u8 {
+                const norm = module_normalize orelse return null;
+                return @call(.always_inline, norm, .{
+                    opaquepkg.fromC(T, inner_userdata),
+                    ctx,
+                    std.mem.span(module_base_name),
+                    std.mem.span(module_name),
+                });
+            }
+
+            fn loadCallback(
+                ctx: *Context,
+                module_name: [*:0]const u8,
+                inner_userdata: ?*anyopaque,
+            ) callconv(.c) ?*ModuleDef {
+                const loader = module_loader orelse return null;
+                return @call(.always_inline, loader, .{
+                    opaquepkg.fromC(T, inner_userdata),
+                    ctx,
+                    std.mem.span(module_name),
+                });
+            }
+        };
+
+        c.JS_SetModuleLoaderFunc(
+            self.cval(),
+            if (module_normalize != null) @ptrCast(&Wrapper.normCallback) else null,
+            if (module_loader != null) @ptrCast(&Wrapper.loadCallback) else null,
+            opaquepkg.toC(T, userdata),
+        );
+    }
+
+    // =========================================================================
+    // Class Definition
+    // =========================================================================
+
+    /// Registers a new class with this runtime.
+    ///
+    /// The class ID must be obtained from `class.Id.new`. Once registered,
+    /// objects of this class can be created with `Value.initObjectClass`.
+    ///
+    /// C: `JS_NewClass`
+    pub fn newClass(self: *Runtime, class_id: class.Id, def: *const class.Def) !void {
+        const result = c.JS_NewClass(self.cval(), @intFromEnum(class_id), @ptrCast(def));
+        if (result < 0) return error.ClassRegistrationFailed;
+    }
+
+    /// Checks if a class ID is registered with this runtime.
+    ///
+    /// C: `JS_IsRegisteredClass`
+    pub fn isRegisteredClass(self: *Runtime, class_id: class.Id) bool {
+        return c.JS_IsRegisteredClass(self.cval(), @intFromEnum(class_id));
+    }
+
+    /// Gets the name of a registered class.
+    ///
+    /// Returns the class name as an atom, or `Atom.null` if the class is not registered.
+    /// The returned atom must be freed with `Atom.deinit`.
+    ///
+    /// C: `JS_GetClassName`
+    pub fn getClassName(self: *Runtime, class_id: class.Id) Atom {
+        return @enumFromInt(c.JS_GetClassName(self.cval(), @intFromEnum(class_id)));
+    }
+
+    // =========================================================================
+    // Job Queue (Microtasks)
+    // =========================================================================
+
+    /// Checks if there are pending jobs in the job queue.
+    ///
+    /// C: `JS_IsJobPending`
+    pub fn isJobPending(self: *Runtime) bool {
+        return c.JS_IsJobPending(self.cval());
+    }
+
+    /// Executes a pending job from the job queue.
+    ///
+    /// Returns the context in which the job was executed, or null if no job was pending.
+    /// Returns error.Exception if the job threw an exception.
+    ///
+    /// C: `JS_ExecutePendingJob`
+    pub fn executePendingJob(self: *Runtime) !?*Context {
+        var ctx: ?*c.JSContext = null;
+        const result = c.JS_ExecutePendingJob(self.cval(), &ctx);
+        if (result < 0) return error.Exception;
+        if (result == 0) return null;
+        return @ptrCast(ctx);
+    }
+
+    // =========================================================================
+    // Memory Usage
+    // =========================================================================
+
+    /// Computes memory usage statistics for this runtime.
+    ///
+    /// C: `JS_ComputeMemoryUsage`
+    pub fn computeMemoryUsage(self: *Runtime) c.JSMemoryUsage {
+        var usage: c.JSMemoryUsage = undefined;
+        c.JS_ComputeMemoryUsage(self.cval(), &usage);
+        return usage;
+    }
+
+    // =========================================================================
+    // Runtime Finalizers
+    // =========================================================================
+
+    /// Adds a finalizer to be called when the runtime is freed.
+    ///
+    /// Multiple finalizers can be added and will be called in reverse order
+    /// of registration when `deinit` is called.
+    ///
+    /// C: `JS_AddRuntimeFinalizer`
+    pub fn addFinalizer(
+        self: *Runtime,
+        comptime T: type,
+        userdata: Opaque(T),
+        comptime finalizer: *const fn (
+            Opaque(T),
+            *Runtime,
+        ) void,
+    ) Allocator.Error!void {
+        const result = c.JS_AddRuntimeFinalizer(
+            self.cval(),
+            @ptrCast(&(struct {
+                fn callback(
+                    runtime: *Runtime,
+                    inner_userdata: ?*anyopaque,
+                ) callconv(.c) void {
+                    @call(.always_inline, finalizer, .{
+                        opaquepkg.fromC(T, inner_userdata),
+                        runtime,
+                    });
+                }
+            }).callback),
+            opaquepkg.toC(T, userdata),
+        );
+        if (result < 0) return error.OutOfMemory;
+    }
+
+    // =========================================================================
+    // Promise Hooks
+    // =========================================================================
+
+    /// Promise hook type for tracking promise lifecycle.
+    pub const PromiseHookType = enum(c_uint) {
+        /// Promise was created
+        init = c.JS_PROMISE_HOOK_INIT,
+        /// About to execute promise reaction
+        before = c.JS_PROMISE_HOOK_BEFORE,
+        /// Finished executing promise reaction
+        after = c.JS_PROMISE_HOOK_AFTER,
+        /// Promise was resolved or rejected
+        resolve = c.JS_PROMISE_HOOK_RESOLVE,
+    };
+
+    /// Promise hook callback type.
+    ///
+    /// Called at various points in a promise's lifecycle.
+    /// - userdata: The opaque pointer passed to setPromiseHook
+    /// - ctx: The context
+    /// - hook_type: The type of hook event
+    /// - promise: The promise object
+    /// - parent_or_value: For init, the parent promise; for resolve, the resolution value
+    pub fn PromiseHook(comptime T: type) type {
+        return *const fn (Opaque(T), *Context, PromiseHookType, Value, Value) void;
+    }
+
+    /// Sets the promise hook for debugging/tracing promise lifecycle.
+    ///
+    /// The hook is called when promises are created, before/after reactions,
+    /// and when resolved/rejected.
+    ///
+    /// C: `JS_SetPromiseHook`
+    pub fn setPromiseHook(
+        self: *Runtime,
+        comptime T: type,
+        userdata: Opaque(T),
+        comptime hook: ?PromiseHook(T),
+    ) void {
+        const h = hook orelse {
+            c.JS_SetPromiseHook(self.cval(), null, null);
+            return;
+        };
+
+        const Wrapper = struct {
+            fn callback(
+                ctx: ?*c.JSContext,
+                hook_type: c.JSPromiseHookType,
+                promise: c.JSValue,
+                parent_or_value: c.JSValue,
+                inner_userdata: ?*anyopaque,
+            ) callconv(.c) void {
+                @call(.always_inline, h, .{
+                    opaquepkg.fromC(T, inner_userdata),
+                    @as(*Context, @ptrCast(ctx)),
+                    @as(PromiseHookType, @enumFromInt(hook_type)),
+                    @as(Value, @bitCast(promise)),
+                    @as(Value, @bitCast(parent_or_value)),
+                });
+            }
+        };
+        c.JS_SetPromiseHook(self.cval(), &Wrapper.callback, opaquepkg.toC(T, userdata));
+    }
+
+    /// Promise rejection tracker callback type.
+    ///
+    /// Called when a promise is rejected without a handler, or when a handler
+    /// is added to a previously unhandled rejection.
+    /// - userdata: The opaque pointer passed to setHostPromiseRejectionTracker
+    /// - ctx: The context
+    /// - promise: The promise object
+    /// - reason: The rejection reason
+    /// - is_handled: true if the rejection now has a handler, false if unhandled
+    pub fn HostPromiseRejectionTracker(comptime T: type) type {
+        return *const fn (Opaque(T), *Context, Value, Value, bool) void;
+    }
+
+    /// Sets the host promise rejection tracker.
+    ///
+    /// This is called when a promise rejection is unhandled, allowing the host
+    /// to log or report the unhandled rejection.
+    ///
+    /// C: `JS_SetHostPromiseRejectionTracker`
+    pub fn setHostPromiseRejectionTracker(
+        self: *Runtime,
+        comptime T: type,
+        userdata: Opaque(T),
+        comptime tracker: ?HostPromiseRejectionTracker(T),
+    ) void {
+        const t = tracker orelse {
+            c.JS_SetHostPromiseRejectionTracker(self.cval(), null, null);
+            return;
+        };
+
+        const Wrapper = struct {
+            fn callback(
+                ctx: ?*c.JSContext,
+                promise: c.JSValue,
+                reason: c.JSValue,
+                is_handled: bool,
+                inner_userdata: ?*anyopaque,
+            ) callconv(.c) void {
+                @call(.always_inline, t, .{
+                    opaquepkg.fromC(T, inner_userdata),
+                    @as(*Context, @ptrCast(ctx)),
+                    @as(Value, @bitCast(promise)),
+                    @as(Value, @bitCast(reason)),
+                    is_handled,
+                });
+            }
+        };
+        c.JS_SetHostPromiseRejectionTracker(self.cval(), &Wrapper.callback, opaquepkg.toC(T, userdata));
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    pub inline fn cval(self: *Runtime) *c.JSRuntime {
+        return @ptrCast(self);
+    }
+};
+
+/// Debug dump flags for runtime diagnostics.
+///
+/// C: `JS_DUMP_*`
+pub const DumpFlags = packed struct(u64) {
+    bytecode_final: bool = false,
+    bytecode_pass2: bool = false,
+    bytecode_pass1: bool = false,
+    _reserved1: bool = false,
+    bytecode_hex: bool = false,
+    bytecode_pc2line: bool = false,
+    bytecode_stack: bool = false,
+    bytecode_step: bool = false,
+    read_object: bool = false,
+    free: bool = false,
+    gc: bool = false,
+    gc_free: bool = false,
+    module_resolve: bool = false,
+    promise: bool = false,
+    leaks: bool = false,
+    atom_leaks: bool = false,
+    mem: bool = false,
+    objects: bool = false,
+    atoms: bool = false,
+    shapes: bool = false,
+    _padding: u44 = 0,
+};
+
+test "Runtime init and deinit" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+}
+
+test "Runtime newContext" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Verify the context is properly linked to the runtime
+    try std.testing.expectEqual(rt, ctx.getRuntime());
+}
+
+test "Runtime setMemoryLimit" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Set a memory limit
+    rt.setMemoryLimit(1024 * 1024);
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Allocate something very large that exceeds the limit
+    const result = ctx.eval(
+        \\let arr = [];
+        \\for (let i = 0; i < 1000000; i++) arr.push(new Array(1000));
+        \\arr.length
+    , "<test>", .{});
+    defer result.deinit(ctx);
+
+    // Should fail with out of memory
+    try std.testing.expect(result.isException());
+
+    // Disable limit
+    rt.setMemoryLimit(0);
+}
+
+test "Runtime setMaxStackSize" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Set a small stack size
+    rt.setMaxStackSize(32 * 1024);
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Deep recursion should hit stack limit
+    const result = ctx.eval(
+        \\function recurse(n) { return recurse(n + 1); }
+        \\recurse(0);
+    , "<test>", .{});
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+}
+
+test "Runtime GC threshold" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Get default threshold
+    const default_threshold = rt.getGCThreshold();
+    try std.testing.expect(default_threshold > 0);
+
+    // Set a new threshold
+    rt.setGCThreshold(1024);
+    try std.testing.expectEqual(@as(usize, 1024), rt.getGCThreshold());
+
+    // Restore
+    rt.setGCThreshold(default_threshold);
+    try std.testing.expectEqual(default_threshold, rt.getGCThreshold());
+}
+
+test "Runtime runGC" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Create some garbage
+    const result = ctx.eval(
+        \\for (let i = 0; i < 1000; i++) { let x = {a: i, b: [1,2,3]}; }
+        \\true
+    , "<test>", .{});
+    defer result.deinit(ctx);
+
+    // Run GC - should not crash
+    rt.runGC();
+
+    try std.testing.expect(!result.isException());
+}
+
+test "Runtime opaque data" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const TestData = struct {
+        value: i32,
+    };
+
+    var data: TestData = .{ .value = 42 };
+
+    // Initially null
+    try std.testing.expectEqual(@as(?*TestData, null), rt.getOpaque(TestData));
+
+    // Set opaque
+    rt.setOpaque(TestData, &data);
+
+    // Get opaque
+    const retrieved = rt.getOpaque(TestData);
+    try std.testing.expect(retrieved != null);
+    try std.testing.expectEqual(@as(i32, 42), retrieved.?.value);
+
+    // Modify through pointer
+    retrieved.?.value = 100;
+    try std.testing.expectEqual(@as(i32, 100), data.value);
+
+    // Clear
+    rt.setOpaque(TestData, null);
+    try std.testing.expectEqual(@as(?*TestData, null), rt.getOpaque(TestData));
+}
+
+test "Runtime dump flags" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Get default flags
+    const default_flags = rt.getDumpFlags();
+
+    // Set some flags
+    rt.setDumpFlags(.{ .leaks = true, .gc = true });
+    const new_flags = rt.getDumpFlags();
+    try std.testing.expect(new_flags.leaks);
+    try std.testing.expect(new_flags.gc);
+    try std.testing.expect(!new_flags.promise);
+
+    // Restore defaults
+    rt.setDumpFlags(default_flags);
+}
+
+test "Runtime setInterruptHandler" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    const State = struct {
+        call_count: i32 = 0,
+
+        fn handler(self: ?*@This(), _: *Runtime) bool {
+            self.?.call_count += 1;
+            // Interrupt after 100 calls
+            return self.?.call_count > 100;
+        }
+    };
+
+    var state: State = .{};
+
+    rt.setInterruptHandler(State, &state, State.handler);
+
+    // Run an infinite loop - should be interrupted
+    const result = ctx.eval("while(true) {}", "<test>", .{});
+    defer result.deinit(ctx);
+
+    try std.testing.expect(result.isException());
+    try std.testing.expect(state.call_count > 100);
+
+    // Clear handler
+    rt.setInterruptHandler(State, null, null);
+}
+
+test "Runtime isJobPending with promises" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // No jobs initially
+    try std.testing.expect(!rt.isJobPending());
+
+    // Create a resolved promise - this schedules a job
+    const result = ctx.eval("Promise.resolve(42).then(x => x * 2)", "<test>", .{});
+    defer result.deinit(ctx);
+    try std.testing.expect(!result.isException());
+
+    // Now there should be a pending job
+    try std.testing.expect(rt.isJobPending());
+}
+
+test "Runtime executePendingJob" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Track promise resolution through a global
+    _ = ctx.eval("globalThis.result = 0", "<test>", .{});
+
+    // Create a promise that modifies global state
+    const promise_result = ctx.eval(
+        \\Promise.resolve(42).then(x => { globalThis.result = x * 2; });
+    , "<test>", .{});
+    defer promise_result.deinit(ctx);
+
+    // Execute the pending job
+    while (rt.isJobPending()) {
+        const job_ctx = try rt.executePendingJob();
+        try std.testing.expect(job_ctx != null);
+    }
+
+    // Check that the promise callback ran
+    const check = ctx.eval("globalThis.result", "<test>", .{});
+    defer check.deinit(ctx);
+
+    try std.testing.expectEqual(@as(i32, 84), try check.toInt32(ctx));
+}
+
+test "Runtime computeMemoryUsage" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Create some objects
+    const result = ctx.eval(
+        \\let obj = {a: 1, b: 2, c: [1,2,3]};
+        \\let str = "hello world";
+        \\true
+    , "<test>", .{});
+    defer result.deinit(ctx);
+
+    const usage = rt.computeMemoryUsage();
+
+    // Basic sanity checks
+    try std.testing.expect(usage.malloc_size > 0);
+    try std.testing.expect(usage.memory_used_size > 0);
+    try std.testing.expect(usage.atom_count > 0);
+    try std.testing.expect(usage.obj_count > 0);
+}
+
+test "Runtime isLiveObject" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Create an object
+    const obj = ctx.eval("({a: 1})", "<test>", .{});
+    defer obj.deinit(ctx);
+
+    // Object should be live
+    try std.testing.expect(rt.isLiveObject(obj));
+
+    // Primitives are not "live objects" in QuickJS sense
+    const num = Value.initInt32(42);
+    try std.testing.expect(!rt.isLiveObject(num));
+}
+
+test "Runtime setCanBlock" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Just test that it doesn't crash
+    rt.setCanBlock(true);
+    rt.setCanBlock(false);
+}
+
+test "Runtime updateStackTop" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Just test that it doesn't crash
+    rt.updateStackTop();
+}
+
+test "Runtime setInfo" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    // Just test that it doesn't crash
+    rt.setInfo("test runtime");
+}
+
+test "DumpFlags bit layout matches C header" {
+    const testing = std.testing;
+
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_FINAL, @as(u64, @bitCast(DumpFlags{ .bytecode_final = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_PASS2, @as(u64, @bitCast(DumpFlags{ .bytecode_pass2 = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_PASS1, @as(u64, @bitCast(DumpFlags{ .bytecode_pass1 = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_HEX, @as(u64, @bitCast(DumpFlags{ .bytecode_hex = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_PC2LINE, @as(u64, @bitCast(DumpFlags{ .bytecode_pc2line = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_STACK, @as(u64, @bitCast(DumpFlags{ .bytecode_stack = true })));
+    try testing.expectEqual(c.JS_DUMP_BYTECODE_STEP, @as(u64, @bitCast(DumpFlags{ .bytecode_step = true })));
+    try testing.expectEqual(c.JS_DUMP_READ_OBJECT, @as(u64, @bitCast(DumpFlags{ .read_object = true })));
+    try testing.expectEqual(c.JS_DUMP_FREE, @as(u64, @bitCast(DumpFlags{ .free = true })));
+    try testing.expectEqual(c.JS_DUMP_GC, @as(u64, @bitCast(DumpFlags{ .gc = true })));
+    try testing.expectEqual(c.JS_DUMP_GC_FREE, @as(u64, @bitCast(DumpFlags{ .gc_free = true })));
+    try testing.expectEqual(c.JS_DUMP_MODULE_RESOLVE, @as(u64, @bitCast(DumpFlags{ .module_resolve = true })));
+    try testing.expectEqual(c.JS_DUMP_PROMISE, @as(u64, @bitCast(DumpFlags{ .promise = true })));
+    try testing.expectEqual(c.JS_DUMP_LEAKS, @as(u64, @bitCast(DumpFlags{ .leaks = true })));
+    try testing.expectEqual(c.JS_DUMP_ATOM_LEAKS, @as(u64, @bitCast(DumpFlags{ .atom_leaks = true })));
+    try testing.expectEqual(c.JS_DUMP_MEM, @as(u64, @bitCast(DumpFlags{ .mem = true })));
+    try testing.expectEqual(c.JS_DUMP_OBJECTS, @as(u64, @bitCast(DumpFlags{ .objects = true })));
+    try testing.expectEqual(c.JS_DUMP_ATOMS, @as(u64, @bitCast(DumpFlags{ .atoms = true })));
+    try testing.expectEqual(c.JS_DUMP_SHAPES, @as(u64, @bitCast(DumpFlags{ .shapes = true })));
+
+    // Combined flags
+    try testing.expectEqual(
+        c.JS_DUMP_LEAKS | c.JS_DUMP_GC,
+        @as(u64, @bitCast(DumpFlags{ .leaks = true, .gc = true })),
+    );
+}
+
+test "Runtime initWithMallocFunctions" {
+    const State = struct {
+        var malloc_count: usize = 0;
+        var free_count: usize = 0;
+
+        fn jsMalloc(_: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
+            malloc_count += 1;
+            return std.c.malloc(size);
+        }
+
+        fn jsCalloc(_: ?*anyopaque, count: usize, size: usize) callconv(.c) ?*anyopaque {
+            malloc_count += 1;
+            return std.c.calloc(count, size);
+        }
+
+        fn jsFree(_: ?*anyopaque, ptr: ?*anyopaque) callconv(.c) void {
+            if (ptr != null) free_count += 1;
+            std.c.free(ptr);
+        }
+
+        fn jsRealloc(_: ?*anyopaque, ptr: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque {
+            return std.c.realloc(ptr, size);
+        }
+
+        fn jsMallocUsableSize(_: ?*const anyopaque) callconv(.c) usize {
+            return 0;
+        }
+    };
+
+    const mf = MallocFunctions{
+        .malloc = State.jsMalloc,
+        .calloc = State.jsCalloc,
+        .free = State.jsFree,
+        .realloc = State.jsRealloc,
+        .malloc_usable_size = State.jsMallocUsableSize,
+    };
+
+    State.malloc_count = 0;
+    State.free_count = 0;
+
+    const rt = try Runtime.initWithMallocFunctions(&mf, null);
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    // Verify custom allocator was used
+    try std.testing.expect(State.malloc_count > 0);
+}
+
+test "Runtime addFinalizer" {
+    const State = struct {
+        called: bool = false,
+
+        fn finalizer(self: ?*@This(), _: *Runtime) void {
+            self.?.called = true;
+        }
+    };
+
+    var state: State = .{};
+    const rt: *Runtime = try .init();
+    try rt.addFinalizer(State, &state, State.finalizer);
+    rt.deinit();
+
+    // Finalizer should have been called during deinit
+    try std.testing.expect(state.called);
+}
+
+test "Runtime setPromiseHook" {
+    const State = struct {
+        hook_calls: usize = 0,
+        last_hook_type: ?Runtime.PromiseHookType = null,
+
+        fn hook(
+            self: ?*@This(),
+            _: *Context,
+            hook_type: Runtime.PromiseHookType,
+            _: Value,
+            _: Value,
+        ) void {
+            self.?.hook_calls += 1;
+            self.?.last_hook_type = hook_type;
+        }
+    };
+
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    var state: State = .{};
+
+    rt.setPromiseHook(State, &state, State.hook);
+
+    // Create a promise - should trigger the hook
+    const result = ctx.eval("Promise.resolve(42)", "<test>", .{});
+    defer result.deinit(ctx);
+
+    try std.testing.expect(state.hook_calls > 0);
+    try std.testing.expect(state.last_hook_type != null);
+
+    // Clear the hook
+    rt.setPromiseHook(State, null, null);
+}
+
+test "Runtime setHostPromiseRejectionTracker" {
+    const State = struct {
+        tracker_calls: usize = 0,
+        was_handled: bool = false,
+
+        fn tracker(
+            self: ?*@This(),
+            _: *Context,
+            _: Value,
+            _: Value,
+            is_handled: bool,
+        ) void {
+            self.?.tracker_calls += 1;
+            self.?.was_handled = is_handled;
+        }
+    };
+
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx = try rt.newContext();
+    defer ctx.deinit();
+
+    var state: State = .{};
+
+    rt.setHostPromiseRejectionTracker(State, &state, State.tracker);
+
+    // Create an unhandled rejection
+    const result = ctx.eval("Promise.reject(new Error('test'))", "<test>", .{});
+    defer result.deinit(ctx);
+
+    // Execute pending jobs to trigger rejection tracking
+    while (rt.isJobPending()) {
+        _ = rt.executePendingJob() catch break;
+    }
+
+    try std.testing.expect(state.tracker_calls > 0);
+
+    // Clear the tracker
+    rt.setHostPromiseRejectionTracker(State, null, null);
+}
+
+test "PromiseHookType matches C constants" {
+    try std.testing.expectEqual(@as(c_uint, c.JS_PROMISE_HOOK_INIT), @intFromEnum(Runtime.PromiseHookType.init));
+    try std.testing.expectEqual(@as(c_uint, c.JS_PROMISE_HOOK_BEFORE), @intFromEnum(Runtime.PromiseHookType.before));
+    try std.testing.expectEqual(@as(c_uint, c.JS_PROMISE_HOOK_AFTER), @intFromEnum(Runtime.PromiseHookType.after));
+    try std.testing.expectEqual(@as(c_uint, c.JS_PROMISE_HOOK_RESOLVE), @intFromEnum(Runtime.PromiseHookType.resolve));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/typed_array.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/typed_array.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Context = @import("context.zig").Context;
+const Runtime = @import("runtime.zig").Runtime;
+const Value = @import("value.zig").Value;
+const opaquepkg = @import("opaque.zig");
+const Opaque = opaquepkg.Opaque;
+
+/// TypedArray element type.
+///
+/// C: `JSTypedArrayEnum`
+pub const Type = enum(c_uint) {
+    uint8_clamped = c.JS_TYPED_ARRAY_UINT8C,
+    int8 = c.JS_TYPED_ARRAY_INT8,
+    uint8 = c.JS_TYPED_ARRAY_UINT8,
+    int16 = c.JS_TYPED_ARRAY_INT16,
+    uint16 = c.JS_TYPED_ARRAY_UINT16,
+    int32 = c.JS_TYPED_ARRAY_INT32,
+    uint32 = c.JS_TYPED_ARRAY_UINT32,
+    big_int64 = c.JS_TYPED_ARRAY_BIG_INT64,
+    big_uint64 = c.JS_TYPED_ARRAY_BIG_UINT64,
+    float16 = c.JS_TYPED_ARRAY_FLOAT16,
+    float32 = c.JS_TYPED_ARRAY_FLOAT32,
+    float64 = c.JS_TYPED_ARRAY_FLOAT64,
+};
+
+/// Information about a typed array's underlying buffer.
+pub const Buffer = struct {
+    value: Value,
+    byte_offset: usize,
+    byte_length: usize,
+    bytes_per_element: usize,
+};
+
+/// Callback for freeing ArrayBuffer data.
+///
+/// C: `JSFreeArrayBufferDataFunc`
+pub fn FreeBufferDataFunc(comptime T: type) type {
+    return *const fn (
+        rt: *Runtime,
+        userdata: Opaque(T),
+        ptr: ?*anyopaque,
+    ) void;
+}
+
+/// Wraps a Zig-friendly FreeBufferDataFunc into a C-callable function.
+pub fn wrapFreeBufferDataFunc(comptime T: type, comptime func: FreeBufferDataFunc(T)) c.JSFreeArrayBufferDataFunc {
+    return struct {
+        fn callback(
+            rt: ?*c.JSRuntime,
+            opaque_ptr: ?*anyopaque,
+            ptr: ?*anyopaque,
+        ) callconv(.c) void {
+            @call(.always_inline, func, .{
+                @as(*Runtime, @ptrCast(rt)),
+                opaquepkg.fromC(T, opaque_ptr),
+                ptr,
+            });
+        }
+    }.callback;
+}
+
+/// Functions for SharedArrayBuffer support.
+///
+/// C: `JSSharedArrayBufferFunctions`
+pub const SharedBufferFunctions = struct {
+    alloc: ?*const fn (userdata: ?*anyopaque, size: usize) callconv(.c) ?*anyopaque = null,
+    free: ?*const fn (userdata: ?*anyopaque, ptr: ?*anyopaque) callconv(.c) void = null,
+    dup: ?*const fn (userdata: ?*anyopaque, ptr: ?*anyopaque) callconv(.c) void = null,
+    userdata: ?*anyopaque = null,
+
+    fn toCStruct(self: SharedBufferFunctions) c.JSSharedArrayBufferFunctions {
+        return .{
+            .sab_alloc = self.alloc,
+            .sab_free = self.free,
+            .sab_dup = self.dup,
+            .sab_opaque = self.userdata,
+        };
+    }
+};
+
+test "Type matches C constants" {
+    try testing.expectEqual(@as(c_uint, 0), @intFromEnum(Type.uint8_clamped));
+    try testing.expectEqual(@as(c_uint, 1), @intFromEnum(Type.int8));
+    try testing.expectEqual(@as(c_uint, 2), @intFromEnum(Type.uint8));
+    try testing.expectEqual(@as(c_uint, 3), @intFromEnum(Type.int16));
+    try testing.expectEqual(@as(c_uint, 4), @intFromEnum(Type.uint16));
+    try testing.expectEqual(@as(c_uint, 5), @intFromEnum(Type.int32));
+    try testing.expectEqual(@as(c_uint, 6), @intFromEnum(Type.uint32));
+    try testing.expectEqual(@as(c_uint, 7), @intFromEnum(Type.big_int64));
+    try testing.expectEqual(@as(c_uint, 8), @intFromEnum(Type.big_uint64));
+    try testing.expectEqual(@as(c_uint, 9), @intFromEnum(Type.float16));
+    try testing.expectEqual(@as(c_uint, 10), @intFromEnum(Type.float32));
+    try testing.expectEqual(@as(c_uint, 11), @intFromEnum(Type.float64));
+}

--- a/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/value.zig
+++ b/zig-pkg/quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS/src/value.zig
@@ -1,0 +1,3567 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const assert = std.debug.assert;
+const testing = std.testing;
+const c = @import("quickjs_c");
+const Atom = @import("atom.zig").Atom;
+const cfunc = @import("cfunc.zig");
+const Context = @import("context.zig").Context;
+const ModuleDef = @import("module.zig").ModuleDef;
+const Runtime = @import("runtime.zig").Runtime;
+const typed_array = @import("typed_array.zig");
+const class = @import("class.zig");
+const opaquepkg = @import("opaque.zig");
+const Opaque = opaquepkg.Opaque;
+
+/// Wrapper for the QuickJS `JSValue`.
+///
+/// A value represents any JavaScript value (number, string, object, etc.).
+/// Values are reference-counted and must be freed with `deinit` when no
+/// longer needed.
+///
+/// C: `JSValue`
+pub const Value = extern struct {
+    // If this is true then we are in nan-boxing mode which changes
+    // our Value representation.
+    pub const is_nan_boxed = builtin.target.ptrBitWidth() < 64;
+
+    // Non-nan-boxed layout
+    u: if (!is_nan_boxed) c.JSValueUnion else void = if (!is_nan_boxed) .{ .int32 = 0 } else {},
+    tag: if (!is_nan_boxed) Tag else void = if (!is_nan_boxed) .undefined else {},
+
+    // NaN-boxed layout
+    val: if (is_nan_boxed) u64 else void = if (is_nan_boxed) mkval(.undefined, 0) else {},
+
+    /// JavaScript value type tag.
+    ///
+    /// C: anonymous enum in quickjs.h
+    pub const Tag = enum(i64) {
+        big_int = c.JS_TAG_BIG_INT,
+        symbol = c.JS_TAG_SYMBOL,
+        string = c.JS_TAG_STRING,
+        module = c.JS_TAG_MODULE,
+        function_bytecode = c.JS_TAG_FUNCTION_BYTECODE,
+        object = c.JS_TAG_OBJECT,
+        int = c.JS_TAG_INT,
+        bool = c.JS_TAG_BOOL,
+        null = c.JS_TAG_NULL,
+        undefined = c.JS_TAG_UNDEFINED,
+        uninitialized = c.JS_TAG_UNINITIALIZED,
+        catch_offset = c.JS_TAG_CATCH_OFFSET,
+        exception = c.JS_TAG_EXCEPTION,
+        short_big_int = c.JS_TAG_SHORT_BIG_INT,
+        float64 = c.JS_TAG_FLOAT64,
+        _,
+    };
+
+    pub const @"null": Value = if (is_nan_boxed)
+        .{ .val = mkval(.null, 0) }
+    else
+        .{ .u = .{ .int32 = 0 }, .tag = .null };
+
+    pub const @"undefined": Value = if (is_nan_boxed)
+        .{ .val = mkval(.undefined, 0) }
+    else
+        .{ .u = .{ .int32 = 0 }, .tag = .undefined };
+
+    pub const @"false": Value = if (is_nan_boxed)
+        .{ .val = mkval(.bool, 0) }
+    else
+        .{ .u = .{ .int32 = 0 }, .tag = .bool };
+
+    pub const @"true": Value = if (is_nan_boxed)
+        .{ .val = mkval(.bool, 1) }
+    else
+        .{ .u = .{ .int32 = 1 }, .tag = .bool };
+
+    pub const exception: Value = if (is_nan_boxed)
+        .{ .val = mkval(.exception, 0) }
+    else
+        .{ .u = .{ .int32 = 0 }, .tag = .exception };
+
+    pub const uninitialized: Value = if (is_nan_boxed)
+        .{ .val = mkval(.uninitialized, 0) }
+    else
+        .{ .u = .{ .int32 = 0 }, .tag = .uninitialized };
+
+    /// Initialize a Value from a Zig type.
+    ///
+    /// If the value is already a `Value`, it is returned directly.
+    /// Otherwise, this function attempts to convert the Zig value to a
+    /// JavaScript Value. If conversion fails, an exception is thrown and
+    /// the exception Value is returned.
+    ///
+    /// Supported types:
+    /// - `Value` (returned as-is)
+    /// - `bool` → JavaScript boolean
+    /// - `void` → JavaScript null
+    /// - `@TypeOf(null)` → JavaScript null
+    /// - Optional types → unwrapped value or null
+    /// - Integers (≤32 bits) → JavaScript int32/uint32
+    /// - Integers (≤64 bits) → JavaScript int64 (may become float64)
+    /// - `comptime_int` → JavaScript int64
+    /// - Floats (≤64 bits) → JavaScript float64
+    /// - `comptime_float` → JavaScript float64
+    /// - `[]const u8` slices → JavaScript string
+    /// - `*const [N]u8` → JavaScript string
+    pub fn init(ctx: *Context, val: anytype) Value {
+        return switch (@TypeOf(val)) {
+            Value => val,
+            bool => initBool(val),
+            void => @"null",
+
+            else => |T| switch (@typeInfo(T)) {
+                .null => @"null",
+                .optional => if (val) |v| init(ctx, v) else @"null",
+
+                .int => |info| if (info.bits <= 32) switch (info.signedness) {
+                    .signed => initInt32(@intCast(val)),
+                    .unsigned => initUint32(@intCast(val)),
+                } else if (info.bits <= 63 or
+                    (val >= std.math.minInt(i63) and val <= std.math.maxInt(i63)))
+                    initInt64(@intCast(val))
+                else if (info.bits == 64)
+                    initFloat64(@floatFromInt(val))
+                else
+                    initConversionError(ctx),
+
+                .comptime_int => initInt64(val),
+
+                .float => |info| if (info.bits <= 64)
+                    initFloat64(@floatCast(val))
+                else
+                    initConversionError(ctx),
+                .comptime_float => initFloat64(val),
+
+                .pointer => |ptr| switch (ptr.size) {
+                    .slice => if (ptr.child == u8)
+                        initStringLen(ctx, val)
+                    else
+                        initConversionError(ctx),
+
+                    .one => if (@typeInfo(ptr.child) == .array and
+                        @typeInfo(ptr.child).array.child == u8)
+                        initStringLen(ctx, val)
+                    else
+                        initConversionError(ctx),
+
+                    else => initConversionError(ctx),
+                },
+
+                else => initConversionError(ctx),
+            },
+        };
+    }
+
+    fn initConversionError(ctx: *Context) Value {
+        return initString(ctx, "failed to convert Zig value to JS Value").throw(ctx);
+    }
+
+    /// Creates a JavaScript boolean value.
+    ///
+    /// C: `JS_NewBool`
+    pub fn initBool(val: bool) Value {
+        return if (is_nan_boxed)
+            .{ .val = mkval(.bool, @intFromBool(val)) }
+        else
+            .{ .u = .{ .int32 = @intFromBool(val) }, .tag = .bool };
+    }
+
+    /// Creates a JavaScript 32-bit integer value.
+    ///
+    /// C: `JS_NewInt32`
+    pub fn initInt32(val: i32) Value {
+        return if (is_nan_boxed)
+            .{ .val = mkval(.int, val) }
+        else
+            .{ .u = .{ .int32 = val }, .tag = .int };
+    }
+
+    /// Creates a JavaScript 64-bit integer value.
+    ///
+    /// If the value fits in an i32, creates an int value. Otherwise creates a float64.
+    ///
+    /// C: `JS_NewInt64`
+    pub fn initInt64(val: i64) Value {
+        return if (val >= std.math.minInt(i32) and val <= std.math.maxInt(i32))
+            initInt32(@intCast(val))
+        else
+            initFloat64(@floatFromInt(val));
+    }
+
+    /// Creates a JavaScript unsigned 32-bit integer value.
+    ///
+    /// If the value fits in an i32, creates an int value. Otherwise creates a float64.
+    ///
+    /// C: `JS_NewUint32`
+    pub fn initUint32(val: u32) Value {
+        return if (val <= std.math.maxInt(i32))
+            initInt32(@intCast(val))
+        else
+            initFloat64(@floatFromInt(val));
+    }
+
+    /// Creates a JavaScript floating-point number value.
+    ///
+    /// C: `JS_NewFloat64`
+    pub fn initFloat64(val: f64) Value {
+        return if (is_nan_boxed)
+            .{ .val = mkfloat64(val) }
+        else
+            .{ .u = .{ .float64 = val }, .tag = .float64 };
+    }
+
+    /// Creates a JavaScript number value from a double.
+    ///
+    /// May return an integer if the value is a whole number that fits in i32.
+    ///
+    /// C: `JS_NewNumber`
+    pub fn initNumber(ctx: *Context, val: f64) Value {
+        return fromCVal(c.JS_NewNumber(ctx.cval(), val));
+    }
+
+    /// Creates a JavaScript BigInt value from a signed 64-bit integer.
+    ///
+    /// C: `JS_NewBigInt64`
+    pub fn initBigInt64(ctx: *Context, val: i64) Value {
+        return fromCVal(c.JS_NewBigInt64(ctx.cval(), val));
+    }
+
+    /// Creates a JavaScript BigInt value from an unsigned 64-bit integer.
+    ///
+    /// C: `JS_NewBigUint64`
+    pub fn initBigUint64(ctx: *Context, val: u64) Value {
+        return fromCVal(c.JS_NewBigUint64(ctx.cval(), val));
+    }
+
+    /// Creates a JavaScript string value from a null-terminated string.
+    ///
+    /// C: `JS_NewString`
+    pub fn initString(ctx: *Context, str: [*:0]const u8) Value {
+        return fromCVal(c.JS_NewString(ctx.cval(), str));
+    }
+
+    /// Creates a JavaScript string value from a byte slice.
+    ///
+    /// C: `JS_NewStringLen`
+    pub fn initStringLen(ctx: *Context, str: []const u8) Value {
+        return fromCVal(c.JS_NewStringLen(ctx.cval(), str.ptr, str.len));
+    }
+
+    /// Creates an empty JavaScript object.
+    ///
+    /// C: `JS_NewObject`
+    pub fn initObject(ctx: *Context) Value {
+        return fromCVal(c.JS_NewObject(ctx.cval()));
+    }
+
+    /// Creates a JavaScript object with a specific prototype.
+    ///
+    /// C: `JS_NewObjectProto`
+    pub fn initObjectProto(ctx: *Context, proto: Value) Value {
+        return fromCVal(c.JS_NewObjectProto(ctx.cval(), proto.cval()));
+    }
+
+    /// Creates a JavaScript object with a specific class ID.
+    ///
+    /// The object will have the prototype associated with the class (set via
+    /// Context.setClassProto) and can store opaque data via setOpaque.
+    ///
+    /// C: `JS_NewObjectClass`
+    pub fn initObjectClass(ctx: *Context, class_id: class.Id) Value {
+        return fromCVal(c.JS_NewObjectClass(ctx.cval(), @intFromEnum(class_id)));
+    }
+
+    /// Creates an empty JavaScript array.
+    ///
+    /// C: `JS_NewArray`
+    pub fn initArray(ctx: *Context) Value {
+        return fromCVal(c.JS_NewArray(ctx.cval()));
+    }
+
+    /// Creates a JavaScript array from a slice of values.
+    ///
+    /// Takes ownership of the values.
+    ///
+    /// C: `JS_NewArrayFrom`
+    pub fn initArrayFrom(ctx: *Context, values: []const Value) Value {
+        return fromCVal(c.JS_NewArrayFrom(
+            ctx.cval(),
+            @intCast(values.len),
+            @ptrCast(values.ptr),
+        ));
+    }
+
+    /// Creates a JavaScript Date object from epoch milliseconds.
+    ///
+    /// C: `JS_NewDate`
+    pub fn initDate(ctx: *Context, epoch_ms: f64) Value {
+        return fromCVal(c.JS_NewDate(ctx.cval(), epoch_ms));
+    }
+
+    /// Creates a JavaScript Symbol.
+    ///
+    /// C: `JS_NewSymbol`
+    pub fn initSymbol(ctx: *Context, description: [*:0]const u8, is_global: bool) Value {
+        return fromCVal(c.JS_NewSymbol(ctx.cval(), description, is_global));
+    }
+
+    /// Creates a JavaScript Error object.
+    ///
+    /// C: `JS_NewError`
+    pub fn initError(ctx: *Context) Value {
+        return fromCVal(c.JS_NewError(ctx.cval()));
+    }
+
+    // -----------------------------------------------------------------------
+    // C Function Constructors
+    // -----------------------------------------------------------------------
+
+    /// Creates a JavaScript function from a C function.
+    ///
+    /// C: `JS_NewCFunction`
+    pub fn initCFunction(
+        ctx: *Context,
+        comptime func: cfunc.Func,
+        name: [:0]const u8,
+        length: i32,
+    ) Value {
+        return fromCVal(c.JS_NewCFunction(
+            ctx.cval(),
+            cfunc.wrapFunc(func),
+            name.ptr,
+            length,
+        ));
+    }
+
+    /// Creates a JavaScript function from a C function with prototype and magic.
+    ///
+    /// C: `JS_NewCFunction2`
+    pub fn initCFunction2(
+        ctx: *Context,
+        comptime func: cfunc.Func,
+        name: [:0]const u8,
+        length: i32,
+        cproto: cfunc.Proto,
+        magic: i32,
+    ) Value {
+        return fromCVal(c.JS_NewCFunction2(
+            ctx.cval(),
+            cfunc.wrapFunc(func),
+            name.ptr,
+            length,
+            @intFromEnum(cproto),
+            magic,
+        ));
+    }
+
+    /// Creates a JavaScript function from a C function with prototype, magic and custom prototype object.
+    ///
+    /// C: `JS_NewCFunction3`
+    pub fn initCFunction3(
+        ctx: *Context,
+        comptime func: cfunc.Func,
+        name: [:0]const u8,
+        length: i32,
+        cproto: cfunc.Proto,
+        magic: i32,
+        proto_val: Value,
+    ) Value {
+        return fromCVal(c.JS_NewCFunction3(
+            ctx.cval(),
+            cfunc.wrapFunc(func),
+            name.ptr,
+            length,
+            @intFromEnum(cproto),
+            magic,
+            proto_val.cval(),
+        ));
+    }
+
+    /// Creates a JavaScript function from a C function with closure data.
+    ///
+    /// The data values are copied and can be accessed in the function via func_data parameter.
+    ///
+    /// C: `JS_NewCFunctionData`
+    pub fn initCFunctionData(
+        ctx: *Context,
+        comptime func: cfunc.FuncData,
+        length: i32,
+        magic: i32,
+        data: []const Value,
+    ) Value {
+        return fromCVal(c.JS_NewCFunctionData(
+            ctx.cval(),
+            cfunc.wrapFuncData(func),
+            length,
+            magic,
+            @intCast(data.len),
+            @ptrCast(@constCast(data.ptr)),
+        ));
+    }
+
+    /// Creates a named JavaScript function from a C function with closure data.
+    ///
+    /// C: `JS_NewCFunctionData2`
+    pub fn initCFunctionData2(
+        ctx: *Context,
+        comptime func: cfunc.FuncData,
+        name: [:0]const u8,
+        length: i32,
+        magic: i32,
+        data: []const Value,
+    ) Value {
+        return fromCVal(c.JS_NewCFunctionData2(
+            ctx.cval(),
+            cfunc.wrapFuncData(func),
+            name.ptr,
+            length,
+            magic,
+            @intCast(data.len),
+            @ptrCast(@constCast(data.ptr)),
+        ));
+    }
+
+    /// Creates a JavaScript function from a C closure with opaque data.
+    ///
+    /// The opaque pointer is passed directly to the function and finalizer.
+    ///
+    /// C: `JS_NewCClosure`
+    pub fn initCClosure(
+        ctx: *Context,
+        comptime T: type,
+        comptime func: cfunc.Closure(T),
+        name: [:0]const u8,
+        comptime finalizer: ?cfunc.ClosureFinalizer(T),
+        length: i32,
+        magic: i32,
+        userdata: Opaque(T),
+    ) Value {
+        return fromCVal(c.JS_NewCClosure(
+            ctx.cval(),
+            cfunc.wrapClosure(T, func),
+            name.ptr,
+            if (finalizer) |f| cfunc.wrapClosureFinalizer(T, f) else null,
+            length,
+            magic,
+            opaquepkg.toC(T, userdata),
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // ArrayBuffer & TypedArray Constructors
+    // -----------------------------------------------------------------------
+
+    /// Creates an ArrayBuffer with the given data.
+    ///
+    /// The buffer takes ownership of the data. When the buffer is garbage
+    /// collected, free_func will be called (if provided) to free the data.
+    ///
+    /// C: `JS_NewArrayBuffer`
+    pub fn initArrayBuffer(
+        ctx: *Context,
+        comptime T: type,
+        buf: []u8,
+        comptime free_func: ?typed_array.FreeBufferDataFunc(T),
+        userdata: Opaque(T),
+        is_shared: bool,
+    ) Value {
+        return fromCVal(c.JS_NewArrayBuffer(
+            ctx.cval(),
+            buf.ptr,
+            buf.len,
+            if (free_func) |f| typed_array.wrapFreeBufferDataFunc(T, f) else null,
+            opaquepkg.toC(T, userdata),
+            is_shared,
+        ));
+    }
+
+    /// Creates an ArrayBuffer by copying the given data.
+    ///
+    /// C: `JS_NewArrayBufferCopy`
+    pub fn initArrayBufferCopy(ctx: *Context, buf: []const u8) Value {
+        return fromCVal(c.JS_NewArrayBufferCopy(ctx.cval(), buf.ptr, buf.len));
+    }
+
+    /// Creates a typed array of the specified type.
+    ///
+    /// The args should contain constructor arguments (e.g., length or ArrayBuffer).
+    ///
+    /// C: `JS_NewTypedArray`
+    pub fn initTypedArray(
+        ctx: *Context,
+        args: []const Value,
+        array_type: typed_array.Type,
+    ) Value {
+        return fromCVal(c.JS_NewTypedArray(
+            ctx.cval(),
+            @intCast(args.len),
+            @ptrCast(@constCast(args.ptr)),
+            @intFromEnum(array_type),
+        ));
+    }
+
+    /// Creates a Uint8Array with the given data.
+    ///
+    /// The buffer takes ownership of the data. When the array is garbage
+    /// collected, free_func will be called (if provided) to free the data.
+    ///
+    /// C: `JS_NewUint8Array`
+    pub fn initUint8Array(
+        ctx: *Context,
+        buf: []u8,
+        free_func: ?typed_array.FreeBufferDataFunc,
+        opaque_ptr: ?*anyopaque,
+        is_shared: bool,
+    ) Value {
+        return fromCVal(c.JS_NewUint8Array(
+            ctx.cval(),
+            buf.ptr,
+            buf.len,
+            @ptrCast(free_func),
+            opaque_ptr,
+            is_shared,
+        ));
+    }
+
+    /// Creates a Uint8Array by copying the given data.
+    ///
+    /// C: `JS_NewUint8ArrayCopy`
+    pub fn initUint8ArrayCopy(ctx: *Context, buf: []const u8) Value {
+        return fromCVal(c.JS_NewUint8ArrayCopy(ctx.cval(), buf.ptr, buf.len));
+    }
+
+    // -----------------------------------------------------------------------
+    // Reference Counting
+    // -----------------------------------------------------------------------
+
+    /// Duplicates the value, incrementing its reference count.
+    ///
+    /// The returned value must also be freed with `deinit`.
+    ///
+    /// C: `JS_DupValue`
+    pub fn dup(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_DupValue(ctx.cval(), self.cval()));
+    }
+
+    /// Duplicates the value using the runtime, incrementing its reference count.
+    ///
+    /// The returned value must also be freed with `deinitRT`.
+    ///
+    /// C: `JS_DupValueRT`
+    pub fn dupRT(self: Value, rt: *Runtime) Value {
+        return fromCVal(c.JS_DupValueRT(rt.cval(), self.cval()));
+    }
+
+    /// Frees the JavaScript value.
+    ///
+    /// This decrements the reference count and frees the value if it
+    /// reaches zero. Must be called for values returned from `eval`,
+    /// property getters, and other functions that return owned values.
+    ///
+    /// C: `JS_FreeValue`
+    pub fn deinit(self: Value, ctx: *Context) void {
+        c.JS_FreeValue(ctx.cval(), self.cval());
+    }
+
+    /// Frees the JavaScript value using the runtime.
+    ///
+    /// C: `JS_FreeValueRT`
+    pub fn deinitRT(self: Value, rt: *Runtime) void {
+        c.JS_FreeValueRT(rt.cval(), self.cval());
+    }
+
+    // -----------------------------------------------------------------------
+    // Type Predicates - Check JavaScript value types
+    // -----------------------------------------------------------------------
+
+    /// Checks if the value is `null`.
+    ///
+    /// C: `JS_IsNull`
+    pub fn isNull(self: Value) bool {
+        return c.JS_IsNull(self.cval());
+    }
+
+    /// Checks if the value is `undefined`.
+    ///
+    /// C: `JS_IsUndefined`
+    pub fn isUndefined(self: Value) bool {
+        return c.JS_IsUndefined(self.cval());
+    }
+
+    /// Checks if the value is a boolean.
+    ///
+    /// C: `JS_IsBool`
+    pub fn isBool(self: Value) bool {
+        return c.JS_IsBool(self.cval());
+    }
+
+    /// Checks if the value is a number (integer or float).
+    ///
+    /// C: `JS_IsNumber`
+    pub fn isNumber(self: Value) bool {
+        return c.JS_IsNumber(self.cval());
+    }
+
+    /// Checks if the value is a BigInt.
+    ///
+    /// C: `JS_IsBigInt`
+    pub fn isBigInt(self: Value) bool {
+        return c.JS_IsBigInt(self.cval());
+    }
+
+    /// Checks if the value is a string.
+    ///
+    /// C: `JS_IsString`
+    pub fn isString(self: Value) bool {
+        return c.JS_IsString(self.cval());
+    }
+
+    /// Checks if the value is a symbol.
+    ///
+    /// C: `JS_IsSymbol`
+    pub fn isSymbol(self: Value) bool {
+        return c.JS_IsSymbol(self.cval());
+    }
+
+    /// Checks if the value is an object.
+    ///
+    /// C: `JS_IsObject`
+    pub fn isObject(self: Value) bool {
+        return c.JS_IsObject(self.cval());
+    }
+
+    /// Checks if the value is an exception.
+    ///
+    /// C: `JS_IsException`
+    pub fn isException(self: Value) bool {
+        return c.JS_IsException(self.cval());
+    }
+
+    /// Checks if the value is uninitialized.
+    ///
+    /// C: `JS_IsUninitialized`
+    pub fn isUninitialized(self: Value) bool {
+        return c.JS_IsUninitialized(self.cval());
+    }
+
+    /// Checks if the value is a module.
+    ///
+    /// C: `JS_IsModule`
+    pub fn isModule(self: Value) bool {
+        return c.JS_IsModule(self.cval());
+    }
+
+    /// Resolves module dependencies.
+    ///
+    /// Call this after reading a module with `JS_ReadObject` to load its
+    /// dependencies before evaluation.
+    ///
+    /// Returns error if resolution fails.
+    ///
+    /// C: `JS_ResolveModule`
+    pub fn resolveModule(self: Value, ctx: *Context) !void {
+        if (c.JS_ResolveModule(ctx.cval(), self.cval()) < 0) {
+            return error.ModuleResolutionFailed;
+        }
+    }
+
+    /// Checks if the value is an array.
+    ///
+    /// C: `JS_IsArray`
+    pub fn isArray(self: Value) bool {
+        return c.JS_IsArray(self.cval());
+    }
+
+    /// Checks if the value is a Proxy.
+    ///
+    /// C: `JS_IsProxy`
+    pub fn isProxy(self: Value) bool {
+        return c.JS_IsProxy(self.cval());
+    }
+
+    /// Checks if the value is a Date.
+    ///
+    /// C: `JS_IsDate`
+    pub fn isDate(self: Value) bool {
+        return c.JS_IsDate(self.cval());
+    }
+
+    /// Checks if the value is a Promise.
+    ///
+    /// C: `JS_IsPromise`
+    pub fn isPromise(self: Value) bool {
+        return c.JS_IsPromise(self.cval());
+    }
+
+    /// Checks if the value is an Error object.
+    ///
+    /// C: `JS_IsError`
+    pub fn isError(self: Value) bool {
+        return c.JS_IsError(self.cval());
+    }
+
+    /// Checks if the value is an uncatchable error.
+    ///
+    /// C: `JS_IsUncatchableError`
+    pub fn isUncatchableError(self: Value) bool {
+        return c.JS_IsUncatchableError(self.cval());
+    }
+
+    /// Checks if the value is an ArrayBuffer.
+    ///
+    /// C: `JS_IsArrayBuffer`
+    pub fn isArrayBuffer(self: Value) bool {
+        return c.JS_IsArrayBuffer(self.cval());
+    }
+
+    /// Checks if the value is a RegExp.
+    ///
+    /// C: `JS_IsRegExp`
+    pub fn isRegExp(self: Value) bool {
+        return c.JS_IsRegExp(self.cval());
+    }
+
+    /// Checks if the value is a Map.
+    ///
+    /// C: `JS_IsMap`
+    pub fn isMap(self: Value) bool {
+        return c.JS_IsMap(self.cval());
+    }
+
+    /// Checks if the value is a Set.
+    ///
+    /// C: `JS_IsSet`
+    pub fn isSet(self: Value) bool {
+        return c.JS_IsSet(self.cval());
+    }
+
+    /// Checks if the value is a WeakRef.
+    ///
+    /// C: `JS_IsWeakRef`
+    pub fn isWeakRef(self: Value) bool {
+        return c.JS_IsWeakRef(self.cval());
+    }
+
+    /// Checks if the value is a WeakSet.
+    ///
+    /// C: `JS_IsWeakSet`
+    pub fn isWeakSet(self: Value) bool {
+        return c.JS_IsWeakSet(self.cval());
+    }
+
+    /// Checks if the value is a WeakMap.
+    ///
+    /// C: `JS_IsWeakMap`
+    pub fn isWeakMap(self: Value) bool {
+        return c.JS_IsWeakMap(self.cval());
+    }
+
+    /// Checks if the value is a DataView.
+    ///
+    /// C: `JS_IsDataView`
+    pub fn isDataView(self: Value) bool {
+        return c.JS_IsDataView(self.cval());
+    }
+
+    /// Checks if the value is a function.
+    ///
+    /// Requires context because this checks internal object state.
+    ///
+    /// C: `JS_IsFunction`
+    pub fn isFunction(self: Value, ctx: *Context) bool {
+        return c.JS_IsFunction(ctx.cval(), self.cval());
+    }
+
+    /// Checks if the value is a constructor.
+    ///
+    /// Requires context because this checks internal object state.
+    ///
+    /// C: `JS_IsConstructor`
+    pub fn isConstructor(self: Value, ctx: *Context) bool {
+        return c.JS_IsConstructor(ctx.cval(), self.cval());
+    }
+
+    // -----------------------------------------------------------------------
+    // ArrayBuffer & TypedArray Operations
+    // -----------------------------------------------------------------------
+
+    /// Detaches the ArrayBuffer, making it unusable.
+    ///
+    /// After detaching, the buffer's byteLength becomes 0 and any views
+    /// on it become unusable.
+    ///
+    /// C: `JS_DetachArrayBuffer`
+    pub fn detachArrayBuffer(self: Value, ctx: *Context) void {
+        c.JS_DetachArrayBuffer(ctx.cval(), self.cval());
+    }
+
+    /// Gets the underlying data of an ArrayBuffer.
+    ///
+    /// Returns null if the value is not an ArrayBuffer or is detached.
+    ///
+    /// C: `JS_GetArrayBuffer`
+    pub fn getArrayBuffer(self: Value, ctx: *Context) ?[]u8 {
+        var size: usize = 0;
+        const ptr = c.JS_GetArrayBuffer(ctx.cval(), &size, self.cval());
+        if (ptr == null) return null;
+        return ptr[0..size];
+    }
+
+    /// Gets the underlying data of a Uint8Array.
+    ///
+    /// Returns null if the value is not a Uint8Array or its buffer is detached.
+    ///
+    /// C: `JS_GetUint8Array`
+    pub fn getUint8Array(self: Value, ctx: *Context) ?[]u8 {
+        var size: usize = 0;
+        const ptr = c.JS_GetUint8Array(ctx.cval(), &size, self.cval());
+        if (ptr == null) return null;
+        return ptr[0..size];
+    }
+
+    /// Gets the underlying ArrayBuffer of a typed array.
+    ///
+    /// Returns the buffer value along with offset, length, and element size info.
+    /// The returned buffer value must be freed with deinit.
+    ///
+    /// C: `JS_GetTypedArrayBuffer`
+    pub fn getTypedArrayBuffer(self: Value, ctx: *Context) ?typed_array.Buffer {
+        var byte_offset: usize = 0;
+        var byte_length: usize = 0;
+        var bytes_per_element: usize = 0;
+        const buffer = fromCVal(c.JS_GetTypedArrayBuffer(
+            ctx.cval(),
+            self.cval(),
+            &byte_offset,
+            &byte_length,
+            &bytes_per_element,
+        ));
+        if (buffer.isException()) return null;
+        return .{
+            .value = buffer,
+            .byte_offset = byte_offset,
+            .byte_length = byte_length,
+            .bytes_per_element = bytes_per_element,
+        };
+    }
+
+    /// Gets the type of a typed array.
+    ///
+    /// Returns null if the value is not a typed array.
+    ///
+    /// C: `JS_GetTypedArrayType`
+    pub fn getTypedArrayType(self: Value) ?typed_array.Type {
+        const result = c.JS_GetTypedArrayType(self.cval());
+        if (result < 0) return null;
+        return @enumFromInt(@as(c_uint, @intCast(result)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Type Conversions - Convert JavaScript values to native types
+    // -----------------------------------------------------------------------
+
+    /// Converts the value to a boolean.
+    ///
+    /// C: `JS_ToBool`
+    pub fn toBool(self: Value, ctx: *Context) error{JSError}!bool {
+        const result = c.JS_ToBool(ctx.cval(), self.cval());
+        if (result < 0) return error.JSError;
+        return result != 0;
+    }
+
+    /// Converts the value to a 32-bit integer.
+    ///
+    /// Returns an error if the value cannot be converted to an integer.
+    ///
+    /// C: `JS_ToInt32`
+    pub fn toInt32(self: Value, ctx: *Context) error{JSError}!i32 {
+        var result: i32 = undefined;
+        const ret = c.JS_ToInt32(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to an unsigned 32-bit integer.
+    ///
+    /// Returns an error if the value cannot be converted.
+    ///
+    /// C: `JS_ToUint32`
+    pub fn toUint32(self: Value, ctx: *Context) error{JSError}!u32 {
+        var result: u32 = undefined;
+        const ret = c.JS_ToUint32(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to a 64-bit integer.
+    ///
+    /// C: `JS_ToInt64`
+    pub fn toInt64(self: Value, ctx: *Context) error{JSError}!i64 {
+        var result: i64 = undefined;
+        const ret = c.JS_ToInt64(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to an array/string index.
+    ///
+    /// C: `JS_ToIndex`
+    pub fn toIndex(self: Value, ctx: *Context) error{JSError}!u64 {
+        var result: u64 = undefined;
+        const ret = c.JS_ToIndex(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to a 64-bit float.
+    ///
+    /// C: `JS_ToFloat64`
+    pub fn toFloat64(self: Value, ctx: *Context) error{JSError}!f64 {
+        var result: f64 = undefined;
+        const ret = c.JS_ToFloat64(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to a BigInt as i64.
+    ///
+    /// Returns an error if the value is not a BigInt.
+    ///
+    /// C: `JS_ToBigInt64`
+    pub fn toBigInt64(self: Value, ctx: *Context) error{JSError}!i64 {
+        var result: i64 = undefined;
+        const ret = c.JS_ToBigInt64(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to a BigInt as u64.
+    ///
+    /// Returns an error if the value is not a BigInt.
+    ///
+    /// C: `JS_ToBigUint64`
+    pub fn toBigUint64(self: Value, ctx: *Context) error{JSError}!u64 {
+        var result: u64 = undefined;
+        const ret = c.JS_ToBigUint64(ctx.cval(), &result, self.cval());
+        if (ret != 0) return error.JSError;
+        return result;
+    }
+
+    /// Converts the value to a JavaScript Number.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_ToNumber`
+    pub fn toNumber(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_ToNumber(ctx.cval(), self.cval()));
+    }
+
+    /// Converts the value to a JavaScript String.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_ToString`
+    pub fn toStringValue(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_ToString(ctx.cval(), self.cval()));
+    }
+
+    /// Converts the value to a JavaScript Object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_ToObject`
+    pub fn toObject(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_ToObject(ctx.cval(), self.cval()));
+    }
+
+    /// Converts the value to a property key.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_ToPropertyKey`
+    pub fn toPropertyKey(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_ToPropertyKey(ctx.cval(), self.cval()));
+    }
+
+    /// Converts the value to a Zig string slice.
+    ///
+    /// Returns null if the conversion fails. The returned slice must be
+    /// freed by passing the pointer to `Context.freeCString`.
+    ///
+    /// C: `JS_ToCStringLen`
+    pub fn toZigSlice(self: Value, ctx: *Context) ?[:0]const u8 {
+        const result = self.toCStringLen(ctx) orelse return null;
+        return result.ptr[0..result.len :0];
+    }
+
+    /// Converts the value to a C string with length.
+    ///
+    /// Returns null if the conversion fails. The returned pointer must be
+    /// freed with `Context.freeCString`.
+    ///
+    /// C: `JS_ToCStringLen`
+    pub fn toCStringLen(self: Value, ctx: *Context) ?struct { ptr: [*:0]const u8, len: usize } {
+        var len: usize = 0;
+        const ptr = c.JS_ToCStringLen(ctx.cval(), &len, self.cval());
+        if (ptr == null) return null;
+        return .{ .ptr = ptr, .len = len };
+    }
+
+    /// Converts the value to a null-terminated C string.
+    ///
+    /// Returns null if the conversion fails. The returned pointer must be
+    /// freed with `Context.freeCString`.
+    ///
+    /// C: `JS_ToCString`
+    pub fn toCString(self: Value, ctx: *Context) ?[*:0]const u8 {
+        return c.JS_ToCString(ctx.cval(), self.cval());
+    }
+
+    // -----------------------------------------------------------------------
+    // Property Access
+    // -----------------------------------------------------------------------
+
+    /// Gets a property by atom.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetProperty`
+    pub fn getProperty(self: Value, ctx: *Context, prop: Atom) Value {
+        return fromCVal(c.JS_GetProperty(ctx.cval(), self.cval(), @intFromEnum(prop)));
+    }
+
+    /// Gets a property by string name.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetPropertyStr`
+    pub fn getPropertyStr(self: Value, ctx: *Context, name: [*:0]const u8) Value {
+        return fromCVal(c.JS_GetPropertyStr(ctx.cval(), self.cval(), name));
+    }
+
+    /// Gets a property by integer index.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetPropertyUint32`
+    pub fn getPropertyUint32(self: Value, ctx: *Context, idx: u32) Value {
+        return fromCVal(c.JS_GetPropertyUint32(ctx.cval(), self.cval(), idx));
+    }
+
+    /// Gets a property by 64-bit integer index.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetPropertyInt64`
+    pub fn getPropertyInt64(self: Value, ctx: *Context, idx: i64) Value {
+        return fromCVal(c.JS_GetPropertyInt64(ctx.cval(), self.cval(), idx));
+    }
+
+    /// Sets a property by atom.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_SetProperty`
+    pub fn setProperty(self: Value, ctx: *Context, prop: Atom, val: Value) error{JSError}!void {
+        const ret = c.JS_SetProperty(ctx.cval(), self.cval(), @intFromEnum(prop), val.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Sets a property by string name.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_SetPropertyStr`
+    pub fn setPropertyStr(self: Value, ctx: *Context, name: [*:0]const u8, val: Value) error{JSError}!void {
+        const ret = c.JS_SetPropertyStr(ctx.cval(), self.cval(), name, val.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Sets a property by integer index.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_SetPropertyUint32`
+    pub fn setPropertyUint32(self: Value, ctx: *Context, idx: u32, val: Value) error{JSError}!void {
+        const ret = c.JS_SetPropertyUint32(ctx.cval(), self.cval(), idx, val.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Sets a property by 64-bit integer index.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_SetPropertyInt64`
+    pub fn setPropertyInt64(self: Value, ctx: *Context, idx: i64, val: Value) error{JSError}!void {
+        const ret = c.JS_SetPropertyInt64(ctx.cval(), self.cval(), idx, val.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Checks if the object has the specified property.
+    ///
+    /// C: `JS_HasProperty` (via string)
+    pub fn hasPropertyStr(self: Value, ctx: *Context, name: [*:0]const u8) error{JSError}!bool {
+        const atom = c.JS_NewAtom(ctx.cval(), name);
+        defer c.JS_FreeAtom(ctx.cval(), atom);
+        const ret = c.JS_HasProperty(ctx.cval(), self.cval(), atom);
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Deletes a property by string name.
+    ///
+    /// C: `JS_DeleteProperty`
+    pub fn deletePropertyStr(self: Value, ctx: *Context, name: [*:0]const u8) error{JSError}!bool {
+        const atom = c.JS_NewAtom(ctx.cval(), name);
+        defer c.JS_FreeAtom(ctx.cval(), atom);
+        const ret = c.JS_DeleteProperty(ctx.cval(), self.cval(), atom, 0);
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Gets the prototype of an object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetPrototype`
+    pub fn getPrototype(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_GetPrototype(ctx.cval(), self.cval()));
+    }
+
+    /// Sets the prototype of an object.
+    ///
+    /// C: `JS_SetPrototype`
+    pub fn setPrototype(self: Value, ctx: *Context, proto: Value) error{JSError}!void {
+        const ret = c.JS_SetPrototype(ctx.cval(), self.cval(), proto.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Sets the constructor for a function object.
+    ///
+    /// This links a constructor function with its prototype object.
+    /// After calling this, instances created with `new func()` will have
+    /// `proto` as their prototype, and `proto.constructor` will be set to `func`.
+    ///
+    /// C: `JS_SetConstructor`
+    pub fn setConstructor(self: Value, ctx: *Context, proto: Value) void {
+        c.JS_SetConstructor(ctx.cval(), self.cval(), proto.cval());
+    }
+
+    /// Sets the constructor bit on a function object.
+    ///
+    /// This controls whether the function can be used as a constructor with `new`.
+    ///
+    /// C: `JS_SetConstructorBit`
+    pub fn setConstructorBit(self: Value, ctx: *Context, val: bool) bool {
+        return c.JS_SetConstructorBit(ctx.cval(), self.cval(), val);
+    }
+
+    /// Defines multiple properties on an object from a function list.
+    ///
+    /// This is efficient for defining many properties at once (functions, getters/setters, constants).
+    ///
+    /// C: `JS_SetPropertyFunctionList`
+    pub fn setPropertyFunctionList(
+        self: Value,
+        ctx: *Context,
+        list: []const cfunc.FunctionListEntry,
+    ) error{JSError}!void {
+        const ret = c.JS_SetPropertyFunctionList(
+            ctx.cval(),
+            self.cval(),
+            @ptrCast(list.ptr),
+            @intCast(list.len),
+        );
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Gets the length property of an array or array-like object.
+    ///
+    /// C: `JS_GetLength`
+    pub fn getLength(self: Value, ctx: *Context) error{JSError}!i64 {
+        var result: i64 = undefined;
+        const ret = c.JS_GetLength(ctx.cval(), self.cval(), &result);
+        if (ret < 0) return error.JSError;
+        return result;
+    }
+
+    /// Sets the length property of an array or array-like object.
+    ///
+    /// C: `JS_SetLength`
+    pub fn setLength(self: Value, ctx: *Context, len: i64) error{JSError}!void {
+        const ret = c.JS_SetLength(ctx.cval(), self.cval(), len);
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Checks if the object is extensible.
+    ///
+    /// C: `JS_IsExtensible`
+    pub fn isExtensible(self: Value, ctx: *Context) error{JSError}!bool {
+        const ret = c.JS_IsExtensible(ctx.cval(), self.cval());
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Prevents any extensions to the object.
+    ///
+    /// C: `JS_PreventExtensions`
+    pub fn preventExtensions(self: Value, ctx: *Context) error{JSError}!void {
+        const ret = c.JS_PreventExtensions(ctx.cval(), self.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Seals the object (prevents adding new properties and marks existing ones non-configurable).
+    ///
+    /// C: `JS_SealObject`
+    pub fn seal(self: Value, ctx: *Context) error{JSError}!void {
+        const ret = c.JS_SealObject(ctx.cval(), self.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    /// Freezes the object (seals it and makes all properties non-writable).
+    ///
+    /// C: `JS_FreezeObject`
+    pub fn freeze(self: Value, ctx: *Context) error{JSError}!void {
+        const ret = c.JS_FreezeObject(ctx.cval(), self.cval());
+        if (ret < 0) return error.JSError;
+    }
+
+    // -----------------------------------------------------------------------
+    // Property Definition
+    // -----------------------------------------------------------------------
+
+    /// Defines a property with full control over attributes.
+    ///
+    /// This is the most general form of property definition. Use the simpler
+    /// definePropertyValue or definePropertyGetSet for common cases.
+    ///
+    /// C: `JS_DefineProperty`
+    pub fn defineProperty(
+        self: Value,
+        ctx: *Context,
+        prop: Atom,
+        val: Value,
+        getter: Value,
+        setter: Value,
+        flags: PropertyFlags,
+    ) error{JSError}!bool {
+        const ret = c.JS_DefineProperty(
+            ctx.cval(),
+            self.cval(),
+            @intFromEnum(prop),
+            val.cval(),
+            getter.cval(),
+            setter.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Defines a data property with the given value and flags.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_DefinePropertyValue`
+    pub fn definePropertyValue(
+        self: Value,
+        ctx: *Context,
+        prop: Atom,
+        val: Value,
+        flags: PropertyFlags,
+    ) error{JSError}!bool {
+        const ret = c.JS_DefinePropertyValue(
+            ctx.cval(),
+            self.cval(),
+            @intFromEnum(prop),
+            val.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Defines a data property at an integer index with the given value and flags.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_DefinePropertyValueUint32`
+    pub fn definePropertyValueUint32(
+        self: Value,
+        ctx: *Context,
+        idx: u32,
+        val: Value,
+        flags: PropertyFlags,
+    ) error{JSError}!bool {
+        const ret = c.JS_DefinePropertyValueUint32(
+            ctx.cval(),
+            self.cval(),
+            idx,
+            val.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Defines a data property by string name with the given value and flags.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_DefinePropertyValueStr`
+    pub fn definePropertyValueStr(
+        self: Value,
+        ctx: *Context,
+        name: [*:0]const u8,
+        val: Value,
+        flags: PropertyFlags,
+    ) error{JSError}!bool {
+        const ret = c.JS_DefinePropertyValueStr(
+            ctx.cval(),
+            self.cval(),
+            name,
+            val.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Defines an accessor property with getter and/or setter.
+    ///
+    /// Takes ownership of getter and setter values.
+    ///
+    /// C: `JS_DefinePropertyGetSet`
+    pub fn definePropertyGetSet(
+        self: Value,
+        ctx: *Context,
+        prop: Atom,
+        getter: Value,
+        setter: Value,
+        flags: PropertyFlags,
+    ) error{JSError}!bool {
+        const ret = c.JS_DefinePropertyGetSet(
+            ctx.cval(),
+            self.cval(),
+            @intFromEnum(prop),
+            getter.cval(),
+            setter.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Gets the own property names of an object.
+    ///
+    /// Returns an iterator over the property names. The iterator must be
+    /// freed with `freePropertyEnum` when done.
+    ///
+    /// C: `JS_GetOwnPropertyNames`
+    pub fn getOwnPropertyNames(
+        self: Value,
+        ctx: *Context,
+        flags: GetPropertyNamesFlags,
+    ) error{JSError}![]const PropertyEnum {
+        var tab: [*]PropertyEnum = undefined;
+        var len: u32 = 0;
+        const ret = c.JS_GetOwnPropertyNames(
+            ctx.cval(),
+            @ptrCast(&tab),
+            &len,
+            self.cval(),
+            flags.toInt(),
+        );
+        if (ret < 0) return error.JSError;
+        return tab[0..len];
+    }
+
+    /// Frees a property enum slice returned by `getOwnPropertyNames`.
+    ///
+    /// C: `JS_FreePropertyEnum`
+    pub fn freePropertyEnum(ctx: *Context, props: []const PropertyEnum) void {
+        c.JS_FreePropertyEnum(ctx.cval(), @ptrCast(@constCast(props.ptr)), @intCast(props.len));
+    }
+
+    /// Gets the own property descriptor for a property.
+    ///
+    /// Returns null if the property does not exist.
+    /// The returned descriptor's values must be freed with deinit.
+    ///
+    /// C: `JS_GetOwnProperty`
+    pub fn getOwnProperty(
+        self: Value,
+        ctx: *Context,
+        prop: Atom,
+    ) error{JSError}!?PropertyDescriptor {
+        var desc: PropertyDescriptor = undefined;
+        const ret = c.JS_GetOwnProperty(ctx.cval(), @ptrCast(&desc), self.cval(), @intFromEnum(prop));
+        if (ret < 0) return error.JSError;
+        if (ret == 0) return null;
+        return desc;
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparison
+    // -----------------------------------------------------------------------
+
+    /// Checks if two values are equal (using JavaScript `==`).
+    ///
+    /// C: `JS_IsEqual`
+    pub fn isEqual(self: Value, ctx: *Context, other: Value) error{JSError}!bool {
+        const ret = c.JS_IsEqual(ctx.cval(), self.cval(), other.cval());
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    /// Checks if two values are strictly equal (using JavaScript `===`).
+    ///
+    /// C: `JS_IsStrictEqual`
+    pub fn isStrictEqual(self: Value, ctx: *Context, other: Value) bool {
+        return c.JS_IsStrictEqual(ctx.cval(), self.cval(), other.cval());
+    }
+
+    /// Checks if two values are the same value (Object.is semantics).
+    ///
+    /// C: `JS_IsSameValue`
+    pub fn isSameValue(self: Value, ctx: *Context, other: Value) bool {
+        return c.JS_IsSameValue(ctx.cval(), self.cval(), other.cval());
+    }
+
+    /// Checks if two values are the same value, treating +0 and -0 as equal.
+    ///
+    /// C: `JS_IsSameValueZero`
+    pub fn isSameValueZero(self: Value, ctx: *Context, other: Value) bool {
+        return c.JS_IsSameValueZero(ctx.cval(), self.cval(), other.cval());
+    }
+
+    /// Checks if this value is an instance of a constructor.
+    ///
+    /// C: `JS_IsInstanceOf`
+    pub fn isInstanceOf(self: Value, ctx: *Context, obj: Value) error{JSError}!bool {
+        const ret = c.JS_IsInstanceOf(ctx.cval(), self.cval(), obj.cval());
+        if (ret < 0) return error.JSError;
+        return ret != 0;
+    }
+
+    // -----------------------------------------------------------------------
+    // Function Calls
+    // -----------------------------------------------------------------------
+
+    /// Calls a function with the given this value and arguments.
+    ///
+    /// Returns a new Value that must be freed. Check `isException` for errors.
+    ///
+    /// C: `JS_Call`
+    pub fn call(self: Value, ctx: *Context, this: Value, args: []const Value) Value {
+        return fromCVal(c.JS_Call(
+            ctx.cval(),
+            self.cval(),
+            this.cval(),
+            @intCast(args.len),
+            @ptrCast(@constCast(args.ptr)),
+        ));
+    }
+
+    /// Calls a constructor function with the given arguments.
+    ///
+    /// Returns a new Value that must be freed. Check `isException` for errors.
+    ///
+    /// C: `JS_CallConstructor`
+    pub fn callConstructor(self: Value, ctx: *Context, args: []const Value) Value {
+        return fromCVal(c.JS_CallConstructor(
+            ctx.cval(),
+            self.cval(),
+            @intCast(args.len),
+            @ptrCast(args.ptr),
+        ));
+    }
+
+    /// Calls a constructor function with a custom `new.target`.
+    ///
+    /// This allows specifying a different `new.target` value than the
+    /// constructor function itself.
+    ///
+    /// Returns a new Value that must be freed. Check `isException` for errors.
+    ///
+    /// C: `JS_CallConstructor2`
+    pub fn callConstructor2(self: Value, ctx: *Context, new_target: Value, args: []const Value) Value {
+        return fromCVal(c.JS_CallConstructor2(
+            ctx.cval(),
+            self.cval(),
+            new_target.cval(),
+            @intCast(args.len),
+            @ptrCast(@constCast(args.ptr)),
+        ));
+    }
+
+    /// Invokes a method on this value by atom.
+    ///
+    /// This is equivalent to `this[method_name](...args)` in JavaScript.
+    ///
+    /// Returns a new Value that must be freed. Check `isException` for errors.
+    ///
+    /// C: `JS_Invoke`
+    pub fn invoke(self: Value, ctx: *Context, method: Atom, args: []const Value) Value {
+        return fromCVal(c.JS_Invoke(
+            ctx.cval(),
+            self.cval(),
+            @intFromEnum(method),
+            @intCast(args.len),
+            @ptrCast(@constCast(args.ptr)),
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // JSON
+    // -----------------------------------------------------------------------
+
+    /// Parses a JSON string into a JavaScript value.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_ParseJSON`
+    pub fn parseJSON(ctx: *Context, buf: []const u8, filename: [*:0]const u8) Value {
+        return fromCVal(c.JS_ParseJSON(ctx.cval(), buf.ptr, buf.len, filename));
+    }
+
+    /// Converts a JavaScript value to a JSON string.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_JSONStringify`
+    pub fn jsonStringify(self: Value, ctx: *Context, replacer: Value, space: Value) Value {
+        return fromCVal(c.JS_JSONStringify(ctx.cval(), self.cval(), replacer.cval(), space.cval()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Proxy
+    // -----------------------------------------------------------------------
+
+    /// Creates a new Proxy object.
+    ///
+    /// C: `JS_NewProxy`
+    pub fn initProxy(ctx: *Context, target: Value, handler: Value) Value {
+        return fromCVal(c.JS_NewProxy(ctx.cval(), target.cval(), handler.cval()));
+    }
+
+    /// Gets the target of a Proxy object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetProxyTarget`
+    pub fn getProxyTarget(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_GetProxyTarget(ctx.cval(), self.cval()));
+    }
+
+    /// Gets the handler of a Proxy object.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_GetProxyHandler`
+    pub fn getProxyHandler(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_GetProxyHandler(ctx.cval(), self.cval()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Exceptions
+    // -----------------------------------------------------------------------
+
+    /// Throws this value as an exception.
+    ///
+    /// Takes ownership of the value.
+    ///
+    /// C: `JS_Throw`
+    pub fn throw(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_Throw(ctx.cval(), self.cval()));
+    }
+
+    /// Marks this error as uncatchable.
+    ///
+    /// C: `JS_SetUncatchableError`
+    pub fn setUncatchableError(self: Value, ctx: *Context) void {
+        c.JS_SetUncatchableError(ctx.cval(), self.cval());
+    }
+
+    /// Clears the uncatchable flag on this error.
+    ///
+    /// C: `JS_ClearUncatchableError`
+    pub fn clearUncatchableError(self: Value, ctx: *Context) void {
+        c.JS_ClearUncatchableError(ctx.cval(), self.cval());
+    }
+
+    // -----------------------------------------------------------------------
+    // Promise
+    // -----------------------------------------------------------------------
+
+    /// Gets the state of a promise.
+    ///
+    /// C: `JS_PromiseState`
+    pub fn promiseState(self: Value, ctx: *Context) PromiseState {
+        return @enumFromInt(c.JS_PromiseState(ctx.cval(), self.cval()));
+    }
+
+    /// Gets the result of a fulfilled or rejected promise.
+    ///
+    /// Returns a new Value that must be freed.
+    ///
+    /// C: `JS_PromiseResult`
+    pub fn promiseResult(self: Value, ctx: *Context) Value {
+        return fromCVal(c.JS_PromiseResult(ctx.cval(), self.cval()));
+    }
+
+    /// A promise with its resolve/reject capability functions.
+    pub const Promise = struct {
+        value: Value,
+        resolve: Value,
+        reject: Value,
+
+        /// Deinitializes all three values.
+        pub fn deinit(self: Promise, ctx: *Context) void {
+            self.value.deinit(ctx);
+            self.resolve.deinit(ctx);
+            self.reject.deinit(ctx);
+        }
+    };
+
+    /// Creates a new Promise with its resolve/reject functions.
+    ///
+    /// Returns a Promise struct containing the promise value and its
+    /// resolve/reject functions. All three values must be freed when
+    /// no longer needed (or call `Promise.deinit` to free all at once).
+    ///
+    /// C: `JS_NewPromiseCapability`
+    pub fn initPromiseCapability(ctx: *Context) Promise {
+        var resolving_funcs: [2]Value = undefined;
+        const promise = fromCVal(c.JS_NewPromiseCapability(ctx.cval(), @ptrCast(&resolving_funcs)));
+        return .{
+            .value = promise,
+            .resolve = resolving_funcs[0],
+            .reject = resolving_funcs[1],
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Class / Opaque data
+    // -----------------------------------------------------------------------
+
+    /// Gets the class ID of an object.
+    ///
+    /// Returns `class.Id.invalid` if not an object.
+    ///
+    /// C: `JS_GetClassID`
+    pub fn getClassId(self: Value) class.Id {
+        return @enumFromInt(c.JS_GetClassID(self.cval()));
+    }
+
+    /// Sets opaque data on an object.
+    ///
+    /// Only works for custom class objects. Returns true on success.
+    ///
+    /// C: `JS_SetOpaque`
+    pub fn setOpaque(self: Value, opaque_ptr: ?*anyopaque) bool {
+        return c.JS_SetOpaque(self.cval(), opaque_ptr) == 0;
+    }
+
+    /// Gets opaque data from an object.
+    ///
+    /// Returns null if the object is not of the expected class or has no opaque data.
+    ///
+    /// C: `JS_GetOpaque`
+    pub fn getOpaque(self: Value, comptime T: type, class_id: class.Id) ?*T {
+        return @ptrCast(@alignCast(c.JS_GetOpaque(self.cval(), @intFromEnum(class_id))));
+    }
+
+    /// Gets opaque data from an object with context validation.
+    ///
+    /// Throws a JavaScript exception if the object is not of the expected class.
+    ///
+    /// C: `JS_GetOpaque2`
+    pub fn getOpaque2(self: Value, ctx: *Context, comptime T: type, class_id: class.Id) ?*T {
+        return @ptrCast(@alignCast(c.JS_GetOpaque2(ctx.cval(), self.cval(), @intFromEnum(class_id))));
+    }
+
+    /// Gets opaque data from an object without knowing the class ID.
+    ///
+    /// Returns both the opaque pointer and the class ID of the object.
+    ///
+    /// C: `JS_GetAnyOpaque`
+    pub fn getAnyOpaque(self: Value, comptime T: type) struct { ptr: ?*T, class_id: class.Id } {
+        var raw_class_id: u32 = 0;
+        const ptr = c.JS_GetAnyOpaque(self.cval(), &raw_class_id);
+        return .{
+            .ptr = @ptrCast(@alignCast(ptr)),
+            .class_id = @enumFromInt(raw_class_id),
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // C Interop
+    // -----------------------------------------------------------------------
+
+    /// Initialize a Value from a C JSValue.
+    pub inline fn fromCVal(val: c.JSValue) Value {
+        return @bitCast(val);
+    }
+
+    /// Get the underlying C JSValue representation.
+    pub inline fn cval(self: Value) c.JSValue {
+        return @bitCast(self);
+    }
+
+    // -----------------------------------------------------------------------
+    // NaN-boxing helpers (implementation details)
+    //
+    // On 32-bit platforms, QuickJS uses NaN-boxing to pack values into a u64:
+    // - Upper 32 bits: tag
+    // - Lower 32 bits: int32/bool value or pointer
+    // - Floats use a special encoding with JS_FLOAT64_TAG_ADDEND
+    //
+    // See quickjs.h under `#if defined(JS_NAN_BOXING)` for the C implementation.
+    // -----------------------------------------------------------------------
+
+    /// Constructs a nan-boxed value from a tag and 32-bit payload.
+    ///
+    /// C: `JS_MKVAL(tag, val)` macro in quickjs.h
+    fn mkval(t: Tag, val: i32) u64 {
+        const tag: u64 = @bitCast(@as(i64, @intFromEnum(t)));
+        return (tag << 32) | @as(u32, @bitCast(val));
+    }
+
+    /// Addend used for encoding floats in nan-boxed representation.
+    /// Floats are stored with their bits adjusted by this value to avoid
+    /// colliding with the tag space.
+    ///
+    /// C: `JS_FLOAT64_TAG_ADDEND` macro in quickjs.h
+    const float64_tag_addend: u64 = 0x7ff80000 -% @as(u64, @bitCast(@as(i64, c.JS_TAG_FIRST))) +% 1;
+
+    /// Constructs a nan-boxed float64 value, normalizing NaN to a canonical form.
+    ///
+    /// C: `__JS_NewFloat64(double d)` function in quickjs.h
+    fn mkfloat64(val: f64) u64 {
+        const u: u64 = @bitCast(val);
+        const nan_val = 0x7ff8000000000000 -% (float64_tag_addend << 32);
+        if ((u & 0x7fffffffffffffff) > 0x7ff0000000000000) {
+            return nan_val;
+        }
+        return u -% (float64_tag_addend << 32);
+    }
+};
+
+/// Promise state enumeration.
+pub const PromiseState = enum(c_int) {
+    not_a_promise = -1,
+    pending = 0,
+    fulfilled = 1,
+    rejected = 2,
+};
+
+/// Property type, encoded in the `tmask` field of `PropertyFlags`.
+///
+/// C: `JS_PROP_NORMAL`, `JS_PROP_GETSET`, `JS_PROP_VARREF`, `JS_PROP_AUTOINIT`
+pub const PropertyType = enum(u2) {
+    /// Regular data property with a value.
+    normal = 0,
+    /// Accessor property with getter and/or setter functions.
+    getset = 1,
+    /// Internal: references a closure variable.
+    varref = 2,
+    /// Internal: lazy-initialized property.
+    autoinit = 3,
+};
+
+/// Property attribute flags for defining and querying object properties.
+///
+/// These flags correspond to the `JS_PROP_*` C constants in QuickJS.
+/// Used with defineProperty* methods to control property attributes.
+///
+/// ## Attribute Flags vs. HAS Flags
+///
+/// The `has_*` flags indicate **whether an attribute is being specified**, while the base
+/// flags contain the **actual value**. This mirrors `Object.defineProperty` behavior where
+/// omitting an attribute leaves the existing value intact. For example, without
+/// `has_configurable`, the engine doesn't know if you want `configurable: false` or if you
+/// simply didn't specify it.
+pub const PropertyFlags = packed struct(c_int) {
+    /// Property can be deleted and its attributes can be changed.
+    configurable: bool = false,
+    /// Property value can be modified (data properties only).
+    writable: bool = false,
+    /// Property appears in `for...in` loops and `Object.keys()`.
+    enumerable: bool = false,
+    /// Internal flag for Array `length` property (special setter behavior).
+    length: bool = false,
+    /// The property type (normal, getset, varref, or autoinit).
+    property_type: PropertyType = .normal,
+    _reserved1: u2 = 0,
+    /// When set, the `configurable` field value should be applied.
+    has_configurable: bool = false,
+    /// When set, the `writable` field value should be applied.
+    has_writable: bool = false,
+    /// When set, the `enumerable` field value should be applied.
+    has_enumerable: bool = false,
+    /// When set, a getter function is being provided.
+    has_get: bool = false,
+    /// When set, a setter function is being provided.
+    has_set: bool = false,
+    /// When set, a value is being provided.
+    has_value: bool = false,
+    /// Throw an exception instead of returning false on failure.
+    throw_flag: bool = false,
+    /// Throw an exception on failure only in strict mode.
+    throw_strict: bool = false,
+    /// Internal: don't add the property if it doesn't exist.
+    no_add: bool = false,
+    /// Internal: skip exotic object behavior.
+    no_exotic: bool = false,
+    /// Internal: called from `Object.defineProperty`.
+    define_property: bool = false,
+    /// Internal: called from `Reflect.defineProperty`.
+    reflect_define_property: bool = false,
+    _reserved2: u12 = 0,
+
+    /// Standard data property flags (configurable, writable, enumerable).
+    ///
+    /// C: `JS_PROP_C_W_E`
+    pub const default: PropertyFlags = .{
+        .configurable = true,
+        .writable = true,
+        .enumerable = true,
+    };
+
+    pub fn toInt(self: PropertyFlags) c_int {
+        return @bitCast(self);
+    }
+};
+
+/// Flags for `getOwnPropertyNames` to control which property keys are returned.
+///
+/// These flags correspond to the `JS_GPN_*` C constants in QuickJS.
+///
+/// ## Common Patterns
+///
+/// - `Object.keys()`: `.enum_strings` (enumerable string keys only)
+/// - `Object.getOwnPropertyNames()`: `.strings` (all string keys)
+/// - `Object.getOwnPropertySymbols()`: `.symbols` (all symbol keys)
+/// - `Reflect.ownKeys()`: `.all` (all keys: strings + symbols)
+pub const GetPropertyNamesFlags = packed struct(c_int) {
+    /// Include string-keyed properties (normal property names).
+    string_mask: bool = false,
+    /// Include symbol-keyed properties.
+    symbol_mask: bool = false,
+    /// Include private class fields (internal use).
+    private_mask: bool = false,
+    _reserved1: u1 = 0,
+    /// Only include enumerable properties.
+    enum_only: bool = false,
+    /// Populate the `is_enumerable` field in returned `PropertyEnum` structs.
+    set_enum: bool = false,
+    _reserved2: u26 = 0,
+
+    /// All string property keys. Equivalent to `Object.getOwnPropertyNames()`.
+    pub const strings: GetPropertyNamesFlags = .{ .string_mask = true };
+
+    /// All symbol property keys. Equivalent to `Object.getOwnPropertySymbols()`.
+    pub const symbols: GetPropertyNamesFlags = .{ .symbol_mask = true };
+
+    /// All property keys (strings and symbols). Equivalent to `Reflect.ownKeys()`.
+    pub const all: GetPropertyNamesFlags = .{ .string_mask = true, .symbol_mask = true };
+
+    /// Enumerable string keys only. Equivalent to `Object.keys()`.
+    pub const enum_strings: GetPropertyNamesFlags = .{ .string_mask = true, .enum_only = true };
+
+    pub fn toInt(self: GetPropertyNamesFlags) c_int {
+        return @bitCast(self);
+    }
+};
+
+/// Property descriptor returned by getOwnProperty.
+///
+/// C: `JSPropertyDescriptor`
+pub const PropertyDescriptor = extern struct {
+    flags: PropertyFlags,
+    value: Value,
+    getter: Value,
+    setter: Value,
+
+    /// Frees all values in the descriptor.
+    pub fn deinit(self: *PropertyDescriptor, ctx: *Context) void {
+        self.value.deinit(ctx);
+        self.getter.deinit(ctx);
+        self.setter.deinit(ctx);
+    }
+};
+
+/// Property name entry returned by getOwnPropertyNames.
+///
+/// C: `JSPropertyEnum`
+pub const PropertyEnum = extern struct {
+    is_enumerable: bool,
+    atom: Atom,
+};
+
+comptime {
+    assert(@sizeOf(Value) == @sizeOf(c.JSValue));
+    assert(@alignOf(Value) == @alignOf(c.JSValue));
+    assert(@sizeOf(PropertyDescriptor) == @sizeOf(c.JSPropertyDescriptor));
+    assert(@alignOf(PropertyDescriptor) == @alignOf(c.JSPropertyDescriptor));
+    assert(@sizeOf(PropertyEnum) == @sizeOf(c.JSPropertyEnum));
+    assert(@alignOf(PropertyEnum) == @alignOf(c.JSPropertyEnum));
+}
+
+test "constants match JavaScript values" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Test null
+    const js_null = ctx.eval("null", "<test>", .{});
+    defer js_null.deinit(ctx);
+    try testing.expect(js_null.isNull());
+    try testing.expect(Value.@"null".isNull());
+    try testing.expect(js_null.isStrictEqual(ctx, Value.@"null"));
+
+    // Test undefined
+    const js_undefined = ctx.eval("undefined", "<test>", .{});
+    defer js_undefined.deinit(ctx);
+    try testing.expect(js_undefined.isUndefined());
+    try testing.expect(Value.undefined.isUndefined());
+    try testing.expect(js_undefined.isStrictEqual(ctx, Value.undefined));
+
+    // Test true
+    const js_true = ctx.eval("true", "<test>", .{});
+    defer js_true.deinit(ctx);
+    try testing.expect(js_true.isBool());
+    try testing.expect(try js_true.toBool(ctx));
+    try testing.expect(try Value.true.toBool(ctx));
+    try testing.expect(js_true.isStrictEqual(ctx, Value.true));
+
+    // Test false
+    const js_false = ctx.eval("false", "<test>", .{});
+    defer js_false.deinit(ctx);
+    try testing.expect(js_false.isBool());
+    try testing.expect(!try js_false.toBool(ctx));
+    try testing.expect(!try Value.false.toBool(ctx));
+    try testing.expect(js_false.isStrictEqual(ctx, Value.false));
+}
+
+test "type predicates with JavaScript values" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // isNumber
+    const num = ctx.eval("42", "<test>", .{});
+    defer num.deinit(ctx);
+    try testing.expect(num.isNumber());
+
+    const float = ctx.eval("3.14", "<test>", .{});
+    defer float.deinit(ctx);
+    try testing.expect(float.isNumber());
+
+    // isString
+    const str = ctx.eval("'hello'", "<test>", .{});
+    defer str.deinit(ctx);
+    try testing.expect(str.isString());
+
+    // isArray
+    const arr = ctx.eval("[1, 2, 3]", "<test>", .{});
+    defer arr.deinit(ctx);
+    try testing.expect(arr.isArray());
+
+    // isObject (but not array)
+    const obj = ctx.eval("({a: 1})", "<test>", .{});
+    defer obj.deinit(ctx);
+    try testing.expect(obj.isObject());
+    try testing.expect(!obj.isArray());
+
+    // isFunction
+    const func = ctx.eval("(function() {})", "<test>", .{});
+    defer func.deinit(ctx);
+    try testing.expect(func.isFunction(ctx));
+
+    // isBool
+    const boolean = ctx.eval("true", "<test>", .{});
+    defer boolean.deinit(ctx);
+    try testing.expect(boolean.isBool());
+
+    // isNull
+    const null_val = ctx.eval("null", "<test>", .{});
+    defer null_val.deinit(ctx);
+    try testing.expect(null_val.isNull());
+
+    // isUndefined
+    const undef = ctx.eval("undefined", "<test>", .{});
+    defer undef.deinit(ctx);
+    try testing.expect(undef.isUndefined());
+
+    // isDate
+    const date = ctx.eval("new Date()", "<test>", .{});
+    defer date.deinit(ctx);
+    try testing.expect(date.isDate());
+
+    // isRegExp
+    const regex = ctx.eval("/test/g", "<test>", .{});
+    defer regex.deinit(ctx);
+    try testing.expect(regex.isRegExp());
+
+    // isMap
+    const map = ctx.eval("new Map()", "<test>", .{});
+    defer map.deinit(ctx);
+    try testing.expect(map.isMap());
+
+    // isSet
+    const set = ctx.eval("new Set()", "<test>", .{});
+    defer set.deinit(ctx);
+    try testing.expect(set.isSet());
+
+    // isPromise
+    const promise = ctx.eval("new Promise(() => {})", "<test>", .{});
+    defer promise.deinit(ctx);
+    try testing.expect(promise.isPromise());
+
+    // isSymbol
+    const symbol = ctx.eval("Symbol('test')", "<test>", .{});
+    defer symbol.deinit(ctx);
+    try testing.expect(symbol.isSymbol());
+
+    // isBigInt
+    const bigint = ctx.eval("BigInt(9007199254740991)", "<test>", .{});
+    defer bigint.deinit(ctx);
+    try testing.expect(bigint.isBigInt());
+
+    // isError
+    const err = ctx.eval("new Error('test')", "<test>", .{});
+    defer err.deinit(ctx);
+    try testing.expect(err.isError());
+}
+
+test "constructors create valid JavaScript values" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+
+    // initBool
+    const bool_val = Value.initBool(true);
+    try testing.expect(bool_val.isBool());
+    try testing.expect(try bool_val.toBool(ctx));
+
+    // initInt32
+    const int32_val = Value.initInt32(42);
+    try testing.expect(int32_val.isNumber());
+    try testing.expectEqual(@as(i32, 42), try int32_val.toInt32(ctx));
+
+    // initFloat64
+    const float_val = Value.initFloat64(3.14);
+    try testing.expect(float_val.isNumber());
+    try testing.expectApproxEqAbs(@as(f64, 3.14), try float_val.toFloat64(ctx), 0.001);
+
+    // initInt64 - fits in i32
+    const int64_small = Value.initInt64(100);
+    try testing.expect(int64_small.isNumber());
+    try testing.expectEqual(@as(i32, 100), try int64_small.toInt32(ctx));
+
+    // initInt64 - too large for i32, becomes float
+    const int64_large = Value.initInt64(std.math.maxInt(i32) + 1);
+    try testing.expect(int64_large.isNumber());
+
+    // initUint32 - fits in i32
+    const uint32_small = Value.initUint32(100);
+    try testing.expect(uint32_small.isNumber());
+    try testing.expectEqual(@as(i32, 100), try uint32_small.toInt32(ctx));
+
+    // initUint32 - too large for i32, becomes float
+    const uint32_large = Value.initUint32(std.math.maxInt(i32) + 1);
+    try testing.expect(uint32_large.isNumber());
+
+    // initString
+    const str_val = Value.initString(ctx, "hello");
+    defer str_val.deinit(ctx);
+    try testing.expect(str_val.isString());
+    const cstr = str_val.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("hello", std.mem.span(cstr));
+
+    // initStringLen
+    const str_len_val = Value.initStringLen(ctx, "hello world");
+    defer str_len_val.deinit(ctx);
+    try testing.expect(str_len_val.isString());
+
+    // initObject
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+    try testing.expect(obj.isObject());
+    try testing.expect(!obj.isArray());
+
+    // initArray
+    const arr = Value.initArray(ctx);
+    defer arr.deinit(ctx);
+    try testing.expect(arr.isArray());
+
+    // Verify values work in JavaScript by setting as global and reading back
+    try global.setPropertyStr(ctx, "testInt", Value.initInt32(123));
+    const read_back = ctx.eval("testInt", "<test>", .{});
+    defer read_back.deinit(ctx);
+    try testing.expectEqual(@as(i32, 123), try read_back.toInt32(ctx));
+}
+
+test "conversions" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // toInt32
+    const int_val = ctx.eval("42", "<test>", .{});
+    defer int_val.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try int_val.toInt32(ctx));
+
+    // toInt32 from float truncates
+    const float_to_int = ctx.eval("3.7", "<test>", .{});
+    defer float_to_int.deinit(ctx);
+    try testing.expectEqual(@as(i32, 3), try float_to_int.toInt32(ctx));
+
+    // toInt64
+    const int64_val = ctx.eval("9007199254740991", "<test>", .{});
+    defer int64_val.deinit(ctx);
+    try testing.expectEqual(@as(i64, 9007199254740991), try int64_val.toInt64(ctx));
+
+    // toFloat64
+    const float_val = ctx.eval("3.14159", "<test>", .{});
+    defer float_val.deinit(ctx);
+    try testing.expectApproxEqAbs(@as(f64, 3.14159), try float_val.toFloat64(ctx), 0.00001);
+
+    // toBool
+    const true_val = ctx.eval("true", "<test>", .{});
+    defer true_val.deinit(ctx);
+    try testing.expect(try true_val.toBool(ctx));
+
+    const false_val = ctx.eval("false", "<test>", .{});
+    defer false_val.deinit(ctx);
+    try testing.expect(!try false_val.toBool(ctx));
+
+    // toCString
+    const str_val = ctx.eval("'test string'", "<test>", .{});
+    defer str_val.deinit(ctx);
+    const cstr = str_val.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("test string", std.mem.span(cstr));
+
+    // toCStringLen
+    const str_with_null = Value.initStringLen(ctx, "hello\x00world");
+    defer str_with_null.deinit(ctx);
+    const cstr_result = str_with_null.toCStringLen(ctx).?;
+    defer ctx.freeCString(cstr_result.ptr);
+    try testing.expectEqual(@as(usize, 11), cstr_result.len);
+
+    // toZigSlice
+    const str_val2 = ctx.eval("'zig slice test'", "<test>", .{});
+    defer str_val2.deinit(ctx);
+    const slice = str_val2.toZigSlice(ctx).?;
+    defer ctx.freeCString(slice.ptr);
+    try testing.expectEqualStrings("zig slice test", slice);
+
+    // toZigSlice with embedded null
+    const str_with_null2 = Value.initStringLen(ctx, "foo\x00bar");
+    defer str_with_null2.deinit(ctx);
+    const slice2 = str_with_null2.toZigSlice(ctx).?;
+    defer ctx.freeCString(slice2.ptr);
+    try testing.expectEqual(@as(usize, 7), slice2.len);
+    try testing.expectEqualStrings("foo\x00bar", slice2);
+}
+
+test "property access" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create an object and set properties
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    // setPropertyStr and getPropertyStr
+    try obj.setPropertyStr(ctx, "foo", Value.initInt32(42));
+    const foo = obj.getPropertyStr(ctx, "foo");
+    defer foo.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try foo.toInt32(ctx));
+
+    // hasPropertyStr
+    try testing.expect(try obj.hasPropertyStr(ctx, "foo"));
+    try testing.expect(!try obj.hasPropertyStr(ctx, "bar"));
+
+    // deletePropertyStr
+    try testing.expect(try obj.deletePropertyStr(ctx, "foo"));
+    try testing.expect(!try obj.hasPropertyStr(ctx, "foo"));
+
+    // getLength on arrays
+    const arr = ctx.eval("[1, 2, 3, 4, 5]", "<test>", .{});
+    defer arr.deinit(ctx);
+    try testing.expectEqual(@as(i64, 5), try arr.getLength(ctx));
+
+    // Property access via JavaScript
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+
+    const test_obj = Value.initObject(ctx);
+    try test_obj.setPropertyStr(ctx, "x", Value.initInt32(100));
+    try test_obj.setPropertyStr(ctx, "y", Value.initInt32(200));
+    try global.setPropertyStr(ctx, "testObj", test_obj);
+
+    const sum = ctx.eval("testObj.x + testObj.y", "<test>", .{});
+    defer sum.deinit(ctx);
+    try testing.expectEqual(@as(i32, 300), try sum.toInt32(ctx));
+}
+
+test "comparison functions" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // isEqual vs isStrictEqual: 1 == "1" is true, 1 === "1" is false
+    const num_one = ctx.eval("1", "<test>", .{});
+    defer num_one.deinit(ctx);
+    const str_one = ctx.eval("'1'", "<test>", .{});
+    defer str_one.deinit(ctx);
+
+    try testing.expect(try num_one.isEqual(ctx, str_one)); // 1 == "1"
+    try testing.expect(!num_one.isStrictEqual(ctx, str_one)); // 1 !== "1"
+
+    // Same value comparison
+    const num_a = ctx.eval("42", "<test>", .{});
+    defer num_a.deinit(ctx);
+    const num_b = ctx.eval("42", "<test>", .{});
+    defer num_b.deinit(ctx);
+
+    try testing.expect(try num_a.isEqual(ctx, num_b));
+    try testing.expect(num_a.isStrictEqual(ctx, num_b));
+    try testing.expect(num_a.isSameValue(ctx, num_b));
+
+    // isSameValue: NaN === NaN is false, but Object.is(NaN, NaN) is true
+    const nan_a = ctx.eval("NaN", "<test>", .{});
+    defer nan_a.deinit(ctx);
+    const nan_b = ctx.eval("NaN", "<test>", .{});
+    defer nan_b.deinit(ctx);
+
+    try testing.expect(!nan_a.isStrictEqual(ctx, nan_b)); // NaN !== NaN
+    try testing.expect(nan_a.isSameValue(ctx, nan_b)); // Object.is(NaN, NaN) === true
+
+    // isSameValueZero: +0 and -0
+    const pos_zero = ctx.eval("+0", "<test>", .{});
+    defer pos_zero.deinit(ctx);
+    const neg_zero = ctx.eval("-0", "<test>", .{});
+    defer neg_zero.deinit(ctx);
+
+    try testing.expect(pos_zero.isStrictEqual(ctx, neg_zero)); // +0 === -0
+    try testing.expect(!pos_zero.isSameValue(ctx, neg_zero)); // Object.is(+0, -0) === false
+    try testing.expect(pos_zero.isSameValueZero(ctx, neg_zero)); // SameValueZero(+0, -0) === true
+}
+
+test "function calls" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+
+    // Create a function via eval
+    const add_func = ctx.eval("(function(a, b) { return a + b; })", "<test>", .{});
+    defer add_func.deinit(ctx);
+    try testing.expect(add_func.isFunction(ctx));
+
+    // Call the function with arguments
+    const arg1 = Value.initInt32(10);
+    const arg2 = Value.initInt32(32);
+    const result = add_func.call(ctx, Value.undefined, &.{ arg1, arg2 });
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+    try testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+
+    // Function with string concatenation
+    const concat_func = ctx.eval("(function(s1, s2) { return s1 + s2; })", "<test>", .{});
+    defer concat_func.deinit(ctx);
+
+    const s1 = Value.initString(ctx, "Hello, ");
+    defer s1.deinit(ctx);
+    const s2 = Value.initString(ctx, "World!");
+    defer s2.deinit(ctx);
+    const concat_result = concat_func.call(ctx, Value.undefined, &.{ s1.dup(ctx), s2.dup(ctx) });
+    defer concat_result.deinit(ctx);
+
+    const cstr = concat_result.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("Hello, World!", std.mem.span(cstr));
+
+    // Function that uses 'this'
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+    try obj.setPropertyStr(ctx, "value", Value.initInt32(100));
+
+    const method = ctx.eval("(function() { return this.value * 2; })", "<test>", .{});
+    defer method.deinit(ctx);
+
+    const method_result = method.call(ctx, obj, &.{});
+    defer method_result.deinit(ctx);
+    try testing.expectEqual(@as(i32, 200), try method_result.toInt32(ctx));
+}
+
+test "array operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create array and add elements via setPropertyUint32
+    const arr = Value.initArray(ctx);
+    defer arr.deinit(ctx);
+
+    try arr.setPropertyUint32(ctx, 0, Value.initInt32(10));
+    try arr.setPropertyUint32(ctx, 1, Value.initInt32(20));
+    try arr.setPropertyUint32(ctx, 2, Value.initInt32(30));
+
+    try testing.expectEqual(@as(i64, 3), try arr.getLength(ctx));
+
+    // Read elements back via getPropertyUint32
+    const elem0 = arr.getPropertyUint32(ctx, 0);
+    defer elem0.deinit(ctx);
+    try testing.expectEqual(@as(i32, 10), try elem0.toInt32(ctx));
+
+    const elem2 = arr.getPropertyUint32(ctx, 2);
+    defer elem2.deinit(ctx);
+    try testing.expectEqual(@as(i32, 30), try elem2.toInt32(ctx));
+
+    // initArrayFrom
+    const values = [_]Value{
+        Value.initInt32(1),
+        Value.initInt32(2),
+        Value.initInt32(3),
+    };
+    const arr2 = Value.initArrayFrom(ctx, &values);
+    defer arr2.deinit(ctx);
+
+    try testing.expect(arr2.isArray());
+    try testing.expectEqual(@as(i64, 3), try arr2.getLength(ctx));
+}
+
+test "JSON operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // parseJSON
+    const parsed = Value.parseJSON(ctx, "{\"a\": 1, \"b\": 2}", "<json>");
+    defer parsed.deinit(ctx);
+
+    try testing.expect(parsed.isObject());
+    const a = parsed.getPropertyStr(ctx, "a");
+    defer a.deinit(ctx);
+    try testing.expectEqual(@as(i32, 1), try a.toInt32(ctx));
+
+    // jsonStringify
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+    try obj.setPropertyStr(ctx, "x", Value.initInt32(42));
+
+    const json_str = obj.jsonStringify(ctx, Value.undefined, Value.undefined);
+    defer json_str.deinit(ctx);
+
+    const cstr = json_str.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("{\"x\":42}", std.mem.span(cstr));
+}
+
+test "BigInt operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initBigInt64
+    const big1 = Value.initBigInt64(ctx, 9007199254740993);
+    defer big1.deinit(ctx);
+    try testing.expect(big1.isBigInt());
+
+    // initBigUint64
+    const big2 = Value.initBigUint64(ctx, 18446744073709551615);
+    defer big2.deinit(ctx);
+    try testing.expect(big2.isBigInt());
+
+    // toBigInt64
+    const big_val = ctx.eval("BigInt(12345)", "<test>", .{});
+    defer big_val.deinit(ctx);
+    try testing.expectEqual(@as(i64, 12345), try big_val.toBigInt64(ctx));
+}
+
+test "Date operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initDate
+    const epoch_ms: f64 = 1609459200000; // 2021-01-01 00:00:00 UTC
+    const date = Value.initDate(ctx, epoch_ms);
+    defer date.deinit(ctx);
+
+    try testing.expect(date.isDate());
+
+    // Verify via JavaScript
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "testDate", date.dup(ctx));
+
+    const year = ctx.eval("testDate.getUTCFullYear()", "<test>", .{});
+    defer year.deinit(ctx);
+    try testing.expectEqual(@as(i32, 2021), try year.toInt32(ctx));
+}
+
+test "Symbol operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initSymbol (local)
+    const sym_local = Value.initSymbol(ctx, "mySymbol", false);
+    defer sym_local.deinit(ctx);
+    try testing.expect(sym_local.isSymbol());
+
+    // initSymbol (global)
+    const sym_global = Value.initSymbol(ctx, "globalSymbol", true);
+    defer sym_global.deinit(ctx);
+    try testing.expect(sym_global.isSymbol());
+
+    // Two global symbols with same name should be equal
+    const sym_global2 = Value.initSymbol(ctx, "globalSymbol", true);
+    defer sym_global2.deinit(ctx);
+    try testing.expect(sym_global.isStrictEqual(ctx, sym_global2));
+
+    // Two local symbols with same name should NOT be equal
+    const sym_local2 = Value.initSymbol(ctx, "mySymbol", false);
+    defer sym_local2.deinit(ctx);
+    try testing.expect(!sym_local.isStrictEqual(ctx, sym_local2));
+}
+
+test "Error operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initError
+    const err = Value.initError(ctx);
+    defer err.deinit(ctx);
+    try testing.expect(err.isError());
+
+    // Exception handling via eval
+    const result = ctx.eval("throw new Error('test error')", "<test>", .{});
+    defer result.deinit(ctx);
+    try testing.expect(result.isException());
+
+    const exc = ctx.getException();
+    defer exc.deinit(ctx);
+    try testing.expect(exc.isError());
+}
+
+test "Promise state" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Pending promise
+    const pending = ctx.eval("new Promise(() => {})", "<test>", .{});
+    defer pending.deinit(ctx);
+    try testing.expect(pending.isPromise());
+    try testing.expectEqual(PromiseState.pending, pending.promiseState(ctx));
+
+    // Fulfilled promise
+    const fulfilled = ctx.eval("Promise.resolve(42)", "<test>", .{});
+    defer fulfilled.deinit(ctx);
+    try testing.expectEqual(PromiseState.fulfilled, fulfilled.promiseState(ctx));
+
+    const result = fulfilled.promiseResult(ctx);
+    defer result.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+
+    // Non-promise value
+    const num = ctx.eval("42", "<test>", .{});
+    defer num.deinit(ctx);
+    try testing.expectEqual(PromiseState.not_a_promise, num.promiseState(ctx));
+}
+
+test "initPromiseCapability" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const promise: Value.Promise = Value.initPromiseCapability(ctx);
+    defer promise.resolve.deinit(ctx);
+    defer promise.reject.deinit(ctx);
+    defer promise.value.deinit(ctx);
+
+    try testing.expect(promise.value.isPromise());
+    try testing.expectEqual(PromiseState.pending, promise.value.promiseState(ctx));
+
+    // Resolve the promise
+    const val: Value = .initInt32(42);
+    const resolve_result = promise.resolve.call(ctx, .undefined, &.{val});
+    defer resolve_result.deinit(ctx);
+
+    try testing.expectEqual(PromiseState.fulfilled, promise.value.promiseState(ctx));
+
+    const result = promise.value.promiseResult(ctx);
+    defer result.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+}
+
+test "instanceof" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const arr = ctx.eval("[1, 2, 3]", "<test>", .{});
+    defer arr.deinit(ctx);
+
+    const array_ctor = ctx.eval("Array", "<test>", .{});
+    defer array_ctor.deinit(ctx);
+
+    const object_ctor = ctx.eval("Object", "<test>", .{});
+    defer object_ctor.deinit(ctx);
+
+    const map_ctor = ctx.eval("Map", "<test>", .{});
+    defer map_ctor.deinit(ctx);
+
+    try testing.expect(try arr.isInstanceOf(ctx, array_ctor));
+    try testing.expect(try arr.isInstanceOf(ctx, object_ctor)); // Arrays are objects
+    try testing.expect(!try arr.isInstanceOf(ctx, map_ctor));
+}
+
+test "init with Value passthrough" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const original = Value.initInt32(42);
+    const result = Value.init(ctx, original);
+
+    if (Value.is_nan_boxed) {
+        try testing.expectEqual(original.val, result.val);
+    } else {
+        try testing.expectEqual(original.tag, result.tag);
+        try testing.expectEqual(original.u.int32, result.u.int32);
+    }
+}
+
+test "init with bool" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const true_val = Value.init(ctx, true);
+    try testing.expect(true_val.isBool());
+    try testing.expect(try true_val.toBool(ctx));
+
+    const false_val = Value.init(ctx, false);
+    try testing.expect(false_val.isBool());
+    try testing.expect(!try false_val.toBool(ctx));
+}
+
+test "init with void" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = Value.init(ctx, {});
+    try testing.expect(result.isNull());
+}
+
+test "init with null" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = Value.init(ctx, null);
+    try testing.expect(result.isNull());
+}
+
+test "init with optional" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const some_val: ?i32 = 42;
+    const result = Value.init(ctx, some_val);
+    try testing.expect(!result.isNull());
+    try testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+
+    const none_val: ?i32 = null;
+    const result_null = Value.init(ctx, none_val);
+    try testing.expect(result_null.isNull());
+}
+
+test "init with signed integers" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // i8
+    const i8_val: i8 = -42;
+    const result_i8 = Value.init(ctx, i8_val);
+    try testing.expectEqual(@as(i32, -42), try result_i8.toInt32(ctx));
+
+    // i16
+    const i16_val: i16 = -1000;
+    const result_i16 = Value.init(ctx, i16_val);
+    try testing.expectEqual(@as(i32, -1000), try result_i16.toInt32(ctx));
+
+    // i32
+    const i32_val: i32 = -100000;
+    const result_i32 = Value.init(ctx, i32_val);
+    try testing.expectEqual(@as(i32, -100000), try result_i32.toInt32(ctx));
+
+    // i64 that fits in i32
+    const i64_small: i64 = -50000;
+    const result_i64_small = Value.init(ctx, i64_small);
+    try testing.expectEqual(@as(i32, -50000), try result_i64_small.toInt32(ctx));
+
+    // i64 that exceeds i32 range
+    const i64_large: i64 = 9007199254740992;
+    const result_i64_large = Value.init(ctx, i64_large);
+    try testing.expectEqual(@as(f64, 9007199254740992), try result_i64_large.toFloat64(ctx));
+}
+
+test "init with unsigned integers" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // u8
+    const u8_val: u8 = 200;
+    const result_u8 = Value.init(ctx, u8_val);
+    try testing.expectEqual(@as(u32, 200), try result_u8.toUint32(ctx));
+
+    // u16
+    const u16_val: u16 = 60000;
+    const result_u16 = Value.init(ctx, u16_val);
+    try testing.expectEqual(@as(u32, 60000), try result_u16.toUint32(ctx));
+
+    // u32 within i32 range
+    const u32_small: u32 = 1000000;
+    const result_u32_small = Value.init(ctx, u32_small);
+    try testing.expectEqual(@as(u32, 1000000), try result_u32_small.toUint32(ctx));
+
+    // u32 exceeding i32 max (becomes float)
+    const u32_large: u32 = 3000000000;
+    const result_u32_large = Value.init(ctx, u32_large);
+    try testing.expectEqual(@as(f64, 3000000000), try result_u32_large.toFloat64(ctx));
+}
+
+test "init with comptime_int" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = Value.init(ctx, 42);
+    try testing.expectEqual(@as(i32, 42), try result.toInt32(ctx));
+
+    const result_neg = Value.init(ctx, -100);
+    try testing.expectEqual(@as(i32, -100), try result_neg.toInt32(ctx));
+}
+
+test "init with floats" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // f32
+    const f32_val: f32 = 3.14;
+    const result_f32 = Value.init(ctx, f32_val);
+    try testing.expect(result_f32.isNumber());
+    try testing.expectApproxEqAbs(@as(f64, 3.14), try result_f32.toFloat64(ctx), 0.001);
+
+    // f64
+    const f64_val: f64 = 2.71828;
+    const result_f64 = Value.init(ctx, f64_val);
+    try testing.expectApproxEqAbs(@as(f64, 2.71828), try result_f64.toFloat64(ctx), 0.00001);
+}
+
+test "init with comptime_float" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = Value.init(ctx, 3.14159);
+    try testing.expectApproxEqAbs(@as(f64, 3.14159), try result.toFloat64(ctx), 0.00001);
+}
+
+test "init with string slice" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const str: []const u8 = "hello world";
+    const result = Value.init(ctx, str);
+    defer result.deinit(ctx);
+
+    try testing.expect(result.isString());
+    const cstr = result.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("hello world", std.mem.span(cstr));
+}
+
+test "init with string pointer to array" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const str: *const [5]u8 = "hello";
+    const result = Value.init(ctx, str);
+    defer result.deinit(ctx);
+
+    try testing.expect(result.isString());
+    const cstr = result.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("hello", std.mem.span(cstr));
+}
+
+test "init with string literal" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const result = Value.init(ctx, "test string");
+    defer result.deinit(ctx);
+
+    try testing.expect(result.isString());
+    const cstr = result.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("test string", std.mem.span(cstr));
+}
+
+test "init with nested optional" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const optional_str: ?[]const u8 = "nested";
+    const result = Value.init(ctx, optional_str);
+    defer result.deinit(ctx);
+
+    try testing.expect(result.isString());
+    const cstr = result.toCString(ctx).?;
+    defer ctx.freeCString(cstr);
+    try testing.expectEqualStrings("nested", std.mem.span(cstr));
+}
+
+test "Value isModule" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const loader = struct {
+        fn load(
+            _: void,
+            load_ctx: *Context,
+            name: [:0]const u8,
+        ) ?*ModuleDef {
+            if (!std.mem.eql(u8, name, "mod_test")) return null;
+
+            const m = ModuleDef.init(load_ctx, name, initFn) orelse return null;
+            _ = m.addExport(load_ctx, "x");
+            return m;
+        }
+
+        fn initFn(init_ctx: *Context, m: *ModuleDef) bool {
+            if (!m.setExport(init_ctx, "x", Value.initInt32(1))) return false;
+            return true;
+        }
+    };
+
+    ctx.getRuntime().setModuleLoaderFunc(void, {}, null, loader.load);
+
+    const result = ctx.eval(
+        \\import { x } from "mod_test"; x
+    , "<test>", .{ .type = .module });
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+
+    const num = Value.initInt32(42);
+    try testing.expect(!num.isModule());
+}
+
+test "ArrayBuffer operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initArrayBufferCopy - creates a copy of the data
+    const data = [_]u8{ 1, 2, 3, 4, 5 };
+    const ab = Value.initArrayBufferCopy(ctx, &data);
+    defer ab.deinit(ctx);
+
+    try testing.expect(ab.isArrayBuffer());
+    try testing.expect(!ab.isException());
+
+    // getArrayBuffer - get the underlying data
+    const buf = ab.getArrayBuffer(ctx);
+    try testing.expect(buf != null);
+    try testing.expectEqual(@as(usize, 5), buf.?.len);
+    try testing.expectEqualSlices(u8, &data, buf.?);
+
+    // Modify the buffer and verify it's the same underlying data
+    buf.?[0] = 42;
+    const buf2 = ab.getArrayBuffer(ctx);
+    try testing.expectEqual(@as(u8, 42), buf2.?[0]);
+}
+
+test "ArrayBuffer from JavaScript" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create ArrayBuffer in JS
+    const ab = ctx.eval("new ArrayBuffer(8)", "<test>", .{});
+    defer ab.deinit(ctx);
+
+    try testing.expect(!ab.isException());
+    try testing.expect(ab.isArrayBuffer());
+
+    const buf = ab.getArrayBuffer(ctx);
+    try testing.expect(buf != null);
+    try testing.expectEqual(@as(usize, 8), buf.?.len);
+}
+
+test "ArrayBuffer detach" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const data = [_]u8{ 1, 2, 3, 4 };
+    const ab = Value.initArrayBufferCopy(ctx, &data);
+    defer ab.deinit(ctx);
+
+    // Should have data before detach
+    try testing.expect(ab.getArrayBuffer(ctx) != null);
+
+    // Detach the buffer
+    ab.detachArrayBuffer(ctx);
+
+    // After detach, getArrayBuffer returns null
+    try testing.expect(ab.getArrayBuffer(ctx) == null);
+}
+
+test "Uint8Array operations" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // initUint8ArrayCopy - creates a Uint8Array with copied data
+    const data = [_]u8{ 10, 20, 30, 40, 50 };
+    const arr = Value.initUint8ArrayCopy(ctx, &data);
+    defer arr.deinit(ctx);
+
+    try testing.expect(!arr.isException());
+
+    // getUint8Array - get the underlying data
+    const buf = arr.getUint8Array(ctx);
+    try testing.expect(buf != null);
+    try testing.expectEqual(@as(usize, 5), buf.?.len);
+    try testing.expectEqualSlices(u8, &data, buf.?);
+
+    // getTypedArrayType
+    const arr_type = arr.getTypedArrayType();
+    try testing.expect(arr_type != null);
+    try testing.expectEqual(typed_array.Type.uint8, arr_type.?);
+}
+
+test "Uint8Array from JavaScript" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create Uint8Array in JS
+    const arr = ctx.eval("new Uint8Array([1, 2, 3, 4])", "<test>", .{});
+    defer arr.deinit(ctx);
+
+    try testing.expect(!arr.isException());
+
+    const buf = arr.getUint8Array(ctx);
+    try testing.expect(buf != null);
+    try testing.expectEqual(@as(usize, 4), buf.?.len);
+    try testing.expectEqualSlices(u8, &[_]u8{ 1, 2, 3, 4 }, buf.?);
+
+    // Verify type
+    const arr_type = arr.getTypedArrayType();
+    try testing.expectEqual(typed_array.Type.uint8, arr_type.?);
+}
+
+test "TypedArray types" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const TestCase = struct {
+        js_code: [:0]const u8,
+        expected_type: typed_array.Type,
+    };
+
+    const test_cases = [_]TestCase{
+        .{ .js_code = "new Int8Array(4)", .expected_type = .int8 },
+        .{ .js_code = "new Uint8Array(4)", .expected_type = .uint8 },
+        .{ .js_code = "new Uint8ClampedArray(4)", .expected_type = .uint8_clamped },
+        .{ .js_code = "new Int16Array(4)", .expected_type = .int16 },
+        .{ .js_code = "new Uint16Array(4)", .expected_type = .uint16 },
+        .{ .js_code = "new Int32Array(4)", .expected_type = .int32 },
+        .{ .js_code = "new Uint32Array(4)", .expected_type = .uint32 },
+        .{ .js_code = "new Float32Array(4)", .expected_type = .float32 },
+        .{ .js_code = "new Float64Array(4)", .expected_type = .float64 },
+        .{ .js_code = "new BigInt64Array(4)", .expected_type = .big_int64 },
+        .{ .js_code = "new BigUint64Array(4)", .expected_type = .big_uint64 },
+    };
+
+    for (test_cases) |tc| {
+        const arr = ctx.eval(tc.js_code, "<test>", .{});
+        defer arr.deinit(ctx);
+
+        try testing.expect(!arr.isException());
+        const arr_type = arr.getTypedArrayType();
+        try testing.expect(arr_type != null);
+        try testing.expectEqual(tc.expected_type, arr_type.?);
+    }
+}
+
+test "getTypedArrayType returns null for non-typed-arrays" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Regular array
+    const arr = ctx.eval("[1, 2, 3]", "<test>", .{});
+    defer arr.deinit(ctx);
+    try testing.expect(arr.getTypedArrayType() == null);
+
+    // Number
+    const num = Value.initInt32(42);
+    try testing.expect(num.getTypedArrayType() == null);
+
+    // ArrayBuffer (not a TypedArray)
+    const ab = ctx.eval("new ArrayBuffer(8)", "<test>", .{});
+    defer ab.deinit(ctx);
+    try testing.expect(ab.getTypedArrayType() == null);
+}
+
+test "getTypedArrayBuffer" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create a typed array with an offset and different element size
+    const arr = ctx.eval(
+        \\const buf = new ArrayBuffer(16);
+        \\new Int32Array(buf, 4, 2);
+    , "<test>", .{});
+    defer arr.deinit(ctx);
+
+    try testing.expect(!arr.isException());
+
+    const info = arr.getTypedArrayBuffer(ctx);
+    try testing.expect(info != null);
+    defer info.?.value.deinit(ctx);
+
+    try testing.expect(info.?.value.isArrayBuffer());
+    try testing.expectEqual(@as(usize, 4), info.?.byte_offset);
+    try testing.expectEqual(@as(usize, 8), info.?.byte_length); // 2 Int32s = 8 bytes
+    try testing.expectEqual(@as(usize, 4), info.?.bytes_per_element);
+}
+
+test "initTypedArray with length" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create typed array with length argument
+    const len = Value.initInt32(10);
+    const args = [_]Value{len};
+    const arr = Value.initTypedArray(ctx, &args, .float64);
+    defer arr.deinit(ctx);
+
+    try testing.expect(!arr.isException());
+    try testing.expectEqual(typed_array.Type.float64, arr.getTypedArrayType().?);
+
+    const info = arr.getTypedArrayBuffer(ctx);
+    try testing.expect(info != null);
+    defer info.?.value.deinit(ctx);
+
+    try testing.expectEqual(@as(usize, 80), info.?.byte_length); // 10 Float64s = 80 bytes
+    try testing.expectEqual(@as(usize, 8), info.?.bytes_per_element);
+}
+
+test "initCFunction basic" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const addFunc = Value.initCFunction(ctx, &testAddFunc, "add", 2);
+    defer addFunc.deinit(ctx);
+
+    try testing.expect(!addFunc.isException());
+    try testing.expect(addFunc.isFunction(ctx));
+
+    // Register as global and call from JS
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "add", addFunc.dup(ctx));
+
+    const result = ctx.eval("add(3, 4)", "<test>", .{});
+    defer result.deinit(ctx);
+    try testing.expect(!result.isException());
+    try testing.expectEqual(@as(i32, 7), try result.toInt32(ctx));
+}
+
+fn testAddFunc(
+    ctx_opt: ?*Context,
+    _: Value,
+    args: []const c.JSValue,
+) Value {
+    if (args.len < 2) return Value.undefined;
+    const ctx = ctx_opt.?;
+    const a = Value.fromCVal(args[0]).toInt32(ctx) catch return Value.exception;
+    const b = Value.fromCVal(args[1]).toInt32(ctx) catch return Value.exception;
+    return Value.initInt32(a + b);
+}
+
+test "initCFunctionData with closure data" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create a function with closure data (a multiplier)
+    const multiplier = Value.initInt32(10);
+    const data = [_]Value{multiplier};
+    const multiplyFunc = Value.initCFunctionData(ctx, &testMultiplyFunc, 1, 0, &data);
+    defer multiplyFunc.deinit(ctx);
+
+    try testing.expect(!multiplyFunc.isException());
+    try testing.expect(multiplyFunc.isFunction(ctx));
+
+    // Register as global and call from JS
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "multiplyByTen", multiplyFunc.dup(ctx));
+
+    const result = ctx.eval("multiplyByTen(5)", "<test>", .{});
+    defer result.deinit(ctx);
+    try testing.expect(!result.isException());
+    try testing.expectEqual(@as(i32, 50), try result.toInt32(ctx));
+}
+
+fn testMultiplyFunc(ctx_opt: ?*Context, _: Value, args: []const c.JSValue, _: c_int, func_data: [*c]c.JSValue) Value {
+    if (args.len < 1) return Value.undefined;
+    const ctx = ctx_opt.?;
+    const val = Value.fromCVal(args[0]).toInt32(ctx) catch return Value.exception;
+    const multiplier = Value.fromCVal(func_data[0]).toInt32(ctx) catch return Value.exception;
+    return Value.initInt32(val * multiplier);
+}
+
+test "setPropertyFunctionList" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    const list = [_]cfunc.FunctionListEntry{
+        cfunc.FunctionListEntryHelpers.func("square", 1, &testSquareFunc),
+        cfunc.FunctionListEntryHelpers.propInt32("VERSION", 42, .{ .configurable = true }),
+    };
+
+    try obj.setPropertyFunctionList(ctx, &list);
+
+    // Register object as global
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "myObj", obj.dup(ctx));
+
+    // Test function
+    const result1 = ctx.eval("myObj.square(7)", "<test>", .{});
+    defer result1.deinit(ctx);
+    try testing.expect(!result1.isException());
+    try testing.expectEqual(@as(i32, 49), try result1.toInt32(ctx));
+
+    // Test constant
+    const result2 = ctx.eval("myObj.VERSION", "<test>", .{});
+    defer result2.deinit(ctx);
+    try testing.expect(!result2.isException());
+    try testing.expectEqual(@as(i32, 42), try result2.toInt32(ctx));
+}
+
+fn testSquareFunc(ctx_opt: ?*Context, _: Value, args: []const c.JSValue) Value {
+    if (args.len < 1) return Value.undefined;
+    const ctx = ctx_opt.?;
+    const val = Value.fromCVal(args[0]).toInt32(ctx) catch return Value.exception;
+    return Value.initInt32(val * val);
+}
+
+test "getset property accessors" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj: Value = .initObject(ctx);
+    defer obj.deinit(ctx);
+
+    const list = [_]cfunc.FunctionListEntry{
+        cfunc.FunctionListEntryHelpers.getset("readOnly", &testGetter, null),
+        cfunc.FunctionListEntryHelpers.getset("readWrite", &testGetter, &testSetter),
+        cfunc.FunctionListEntryHelpers.getsetMagic("magicProp", &testGetterMagic, &testSetterMagic, 42),
+    };
+
+    try obj.setPropertyFunctionList(ctx, &list);
+
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "testObj", obj.dup(ctx));
+
+    // Test read-only getter
+    const result1 = ctx.eval("testObj.readOnly", "<test>", .{});
+    defer result1.deinit(ctx);
+    try testing.expect(!result1.isException());
+    try testing.expectEqual(@as(i32, 123), try result1.toInt32(ctx));
+
+    // Test read-write getter
+    const result2 = ctx.eval("testObj.readWrite", "<test>", .{});
+    defer result2.deinit(ctx);
+    try testing.expect(!result2.isException());
+    try testing.expectEqual(@as(i32, 123), try result2.toInt32(ctx));
+
+    // Test setter returns value
+    const result3 = ctx.eval("testObj.readWrite = 999", "<test>", .{});
+    defer result3.deinit(ctx);
+    try testing.expect(!result3.isException());
+
+    // Test magic getter (returns the magic value)
+    const result4 = ctx.eval("testObj.magicProp", "<test>", .{});
+    defer result4.deinit(ctx);
+    try testing.expect(!result4.isException());
+    try testing.expectEqual(@as(i32, 42), try result4.toInt32(ctx));
+
+    // Test magic setter
+    const result5 = ctx.eval("testObj.magicProp = 100", "<test>", .{});
+    defer result5.deinit(ctx);
+    try testing.expect(!result5.isException());
+}
+
+fn testGetter(_: ?*Context, _: Value) Value {
+    return .initInt32(123);
+}
+
+fn testSetter(_: ?*Context, _: Value, _: Value) Value {
+    return .undefined;
+}
+
+fn testGetterMagic(_: ?*Context, _: Value, magic: c_int) Value {
+    return .initInt32(magic);
+}
+
+fn testSetterMagic(_: ?*Context, _: Value, _: Value, _: c_int) Value {
+    return .undefined;
+}
+
+test "setConstructor" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create a constructor function using generic (constructor_or_func allows both new and call)
+    const ctor = Value.initCFunction2(ctx, &testConstructor, "Point", 2, .constructor_or_func, 0);
+    defer ctor.deinit(ctx);
+
+    // Create prototype with method
+    const proto = Value.initObject(ctx);
+    defer proto.deinit(ctx);
+
+    const protoList = [_]cfunc.FunctionListEntry{
+        cfunc.FunctionListEntryHelpers.func("toString", 0, &testPointToString),
+    };
+    try proto.setPropertyFunctionList(ctx, &protoList);
+
+    // Link constructor and prototype
+    ctor.setConstructor(ctx, proto);
+
+    // Register as global
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "Point", ctor.dup(ctx));
+
+    // Test that function was registered and constructor link exists
+    const protoCheck = ctx.eval("Point.prototype.toString !== undefined", "<test>", .{});
+    defer protoCheck.deinit(ctx);
+    try testing.expect(!protoCheck.isException());
+    try testing.expect(try protoCheck.toBool(ctx));
+
+    // Test that prototype.constructor points back to Point
+    const ctorCheck = ctx.eval("Point.prototype.constructor === Point", "<test>", .{});
+    defer ctorCheck.deinit(ctx);
+    try testing.expect(!ctorCheck.isException());
+    try testing.expect(try ctorCheck.toBool(ctx));
+}
+
+fn testConstructor(ctx_opt: ?*Context, this_val: Value, args: []const c.JSValue) Value {
+    const ctx = ctx_opt.?;
+    var this = this_val;
+
+    if (args.len >= 1) {
+        this.setPropertyStr(ctx, "x", Value.fromCVal(args[0]).dup(ctx)) catch return Value.exception;
+    }
+    if (args.len >= 2) {
+        this.setPropertyStr(ctx, "y", Value.fromCVal(args[1]).dup(ctx)) catch return Value.exception;
+    }
+
+    return Value.undefined;
+}
+
+fn testPointToString(_: ?*Context, _: Value, _: []const c.JSValue) Value {
+    return Value.initInt32(42);
+}
+
+test "PropertyFlags constants match C" {
+    // Verify the packed struct matches C constants
+    try testing.expectEqual(@as(c_int, 0x1), (PropertyFlags{ .configurable = true }).toInt());
+    try testing.expectEqual(@as(c_int, 0x2), (PropertyFlags{ .writable = true }).toInt());
+    try testing.expectEqual(@as(c_int, 0x4), (PropertyFlags{ .enumerable = true }).toInt());
+    try testing.expectEqual(@as(c_int, 0x7), PropertyFlags.default.toInt());
+
+    try testing.expectEqual(@as(c_int, c.JS_PROP_CONFIGURABLE), (PropertyFlags{ .configurable = true }).toInt());
+    try testing.expectEqual(@as(c_int, c.JS_PROP_WRITABLE), (PropertyFlags{ .writable = true }).toInt());
+    try testing.expectEqual(@as(c_int, c.JS_PROP_ENUMERABLE), (PropertyFlags{ .enumerable = true }).toInt());
+    try testing.expectEqual(@as(c_int, c.JS_PROP_C_W_E), PropertyFlags.default.toInt());
+}
+
+test "GetPropertyNamesFlags constants match C" {
+    try testing.expectEqual(@as(c_int, c.JS_GPN_STRING_MASK), GetPropertyNamesFlags.strings.toInt());
+    try testing.expectEqual(@as(c_int, c.JS_GPN_SYMBOL_MASK), (GetPropertyNamesFlags{ .symbol_mask = true }).toInt());
+    try testing.expectEqual(@as(c_int, c.JS_GPN_ENUM_ONLY), (GetPropertyNamesFlags{ .enum_only = true }).toInt());
+}
+
+test "definePropertyValueStr" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    // Define a non-writable property
+    _ = try obj.definePropertyValueStr(ctx, "readOnly", Value.initInt32(42), .{
+        .configurable = true,
+        .enumerable = true,
+        .writable = false,
+    });
+
+    // Read the value
+    const val = obj.getPropertyStr(ctx, "readOnly");
+    defer val.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try val.toInt32(ctx));
+
+    // Verify via JavaScript that it's not writable
+    const global = ctx.getGlobalObject();
+    defer global.deinit(ctx);
+    try global.setPropertyStr(ctx, "testObj", obj.dup(ctx));
+
+    // Attempt to write should fail silently (not in strict mode)
+    const write_result = ctx.eval("testObj.readOnly = 100; testObj.readOnly", "<test>", .{});
+    defer write_result.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try write_result.toInt32(ctx));
+}
+
+test "definePropertyValueUint32" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const arr = Value.initArray(ctx);
+    defer arr.deinit(ctx);
+
+    // Define array elements with specific flags
+    _ = try arr.definePropertyValueUint32(ctx, 0, Value.initInt32(10), PropertyFlags.default);
+    _ = try arr.definePropertyValueUint32(ctx, 1, Value.initInt32(20), PropertyFlags.default);
+    _ = try arr.definePropertyValueUint32(ctx, 2, Value.initInt32(30), PropertyFlags.default);
+
+    try testing.expectEqual(@as(i64, 3), try arr.getLength(ctx));
+
+    const elem = arr.getPropertyUint32(ctx, 1);
+    defer elem.deinit(ctx);
+    try testing.expectEqual(@as(i32, 20), try elem.toInt32(ctx));
+}
+
+test "definePropertyGetSet" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Create an object with a getter/setter via eval for simplicity
+    const obj = ctx.eval(
+        \\(function() {
+        \\  var obj = { _value: 0 };
+        \\  Object.defineProperty(obj, 'value', {
+        \\    get: function() { return this._value * 2; },
+        \\    set: function(v) { this._value = v; },
+        \\    configurable: true,
+        \\    enumerable: true
+        \\  });
+        \\  return obj;
+        \\})()
+    , "<test>", .{});
+    defer obj.deinit(ctx);
+
+    try testing.expect(!obj.isException());
+    try testing.expect(obj.isObject());
+
+    // Test setter
+    try obj.setPropertyStr(ctx, "value", Value.initInt32(21));
+
+    // Test getter (should return 42 = 21 * 2)
+    const val = obj.getPropertyStr(ctx, "value");
+    defer val.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try val.toInt32(ctx));
+}
+
+test "getOwnPropertyNames" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    try obj.setPropertyStr(ctx, "a", Value.initInt32(1));
+    try obj.setPropertyStr(ctx, "b", Value.initInt32(2));
+    try obj.setPropertyStr(ctx, "c", Value.initInt32(3));
+
+    const props = try obj.getOwnPropertyNames(ctx, GetPropertyNamesFlags.strings);
+    defer Value.freePropertyEnum(ctx, props);
+
+    try testing.expectEqual(@as(usize, 3), props.len);
+}
+
+test "getOwnProperty" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = ctx.eval(
+        \\(function() {
+        \\  var obj = {};
+        \\  Object.defineProperty(obj, 'prop', {
+        \\    value: 42,
+        \\    writable: false,
+        \\    enumerable: true,
+        \\    configurable: true
+        \\  });
+        \\  return obj;
+        \\})()
+    , "<test>", .{});
+    defer obj.deinit(ctx);
+
+    const atom = Atom.init(ctx, "prop");
+    defer atom.deinit(ctx);
+
+    var desc = (try obj.getOwnProperty(ctx, atom)).?;
+    defer desc.deinit(ctx);
+
+    try testing.expect(desc.flags.configurable);
+    try testing.expect(desc.flags.enumerable);
+    try testing.expect(!desc.flags.writable);
+    try testing.expectEqual(@as(i32, 42), try desc.value.toInt32(ctx));
+}
+
+test "getOwnProperty nonexistent" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = Value.initObject(ctx);
+    defer obj.deinit(ctx);
+
+    const atom = Atom.init(ctx, "nonexistent");
+    defer atom.deinit(ctx);
+
+    const desc = try obj.getOwnProperty(ctx, atom);
+    try testing.expect(desc == null);
+}
+
+test "initObjectClass" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    // Class ID 1 is JS_CLASS_OBJECT - creates a plain object
+    const obj = Value.initObjectClass(ctx, @enumFromInt(1));
+    defer obj.deinit(ctx);
+
+    // Verify it's an object
+    try testing.expect(obj.isObject());
+
+    // Verify we can set properties on it
+    try obj.setPropertyStr(ctx, "test", Value.initInt32(42));
+    const val = obj.getPropertyStr(ctx, "test");
+    defer val.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try val.toInt32(ctx));
+}
+
+test "invoke method by atom" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const obj = ctx.eval(
+        \\({
+        \\  value: 10,
+        \\  add: function(x) { return this.value + x; }
+        \\})
+    , "<test>", .{});
+    defer obj.deinit(ctx);
+
+    const method_atom = Atom.init(ctx, "add");
+    defer method_atom.deinit(ctx);
+
+    const arg = Value.initInt32(5);
+    const result = obj.invoke(ctx, method_atom, &.{arg});
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+    try testing.expectEqual(@as(i32, 15), try result.toInt32(ctx));
+}
+
+test "callConstructor2 with custom new.target" {
+    const rt: *Runtime = try .init();
+    defer rt.deinit();
+
+    const ctx: *Context = try .init(rt);
+    defer ctx.deinit();
+
+    const ctor = ctx.eval(
+        \\(function MyClass(value) {
+        \\  this.value = value;
+        \\})
+    , "<test>", .{});
+    defer ctor.deinit(ctx);
+
+    const arg = Value.initInt32(42);
+    const result = ctor.callConstructor2(ctx, ctor, &.{arg});
+    defer result.deinit(ctx);
+
+    try testing.expect(!result.isException());
+    try testing.expect(result.isObject());
+
+    const val = result.getPropertyStr(ctx, "value");
+    defer val.deinit(ctx);
+    try testing.expectEqual(@as(i32, 42), try val.toInt32(ctx));
+}


### PR DESCRIPTION
Refs #133

Full migration from Zig 0.15 → 0.16. Build passes clean. **Do not merge until fully tested.**

### Changes
- New `src/compat.zig` — shims for all removed stdlib APIs
- `build.zig` + vendored quickjs `build.zig` — `root_module` API migration
- 28 source files updated

### What was migrated
| Removed | Replacement |
|---|---|
| `std.net.*` | raw C sockets via `compat.TcpStream` |
| `std.time.timestamp()` | `compat.timestampSeconds()` |
| `std.Thread.Mutex/RwLock/sleep` | pthread shims |
| `std.fs.cwd().*` | C `open/read/write/mkdir` wrappers |
| `std.process.Child` | `fork/exec` |
| `ArrayList.writer()` | direct `.appendSlice()/.print()` |
| `GeneralPurposeAllocator` | `DebugAllocator` |
