### PR TITLE
fix: remove duplicate viewport command handler

### DIFF
--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -164,8 +164,6 @@ pub fn main() !void {
         autoSnap(arena, &client, &session);
     } else if (std.mem.eql(u8, cmd, "viewport")) {
         try cmdViewport(arena, &client, rest);
-    } else if (std.mem.eql(u8, cmd, "viewport")) {
-        try cmdViewport(arena, &client, rest);
     } else if (std.mem.eql(u8, cmd, "eval")) {
         if (rest.len < 1) fatal("eval: requires <js>\n", .{});
         try cmdEval(arena, &client, rest[0]);


### PR DESCRIPTION
## Summary
- Remove duplicate viewport command handler in src/agent_main.zig (lines 165-168)
- The second branch was identical dead code that could never execute

## Test plan
- [x] Verified no other viewport references are affected
- [ ] Run zig build to confirm no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)