### PR TITLE
fix: rename package from agentic_browdie to kuri

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .agentic_browdie,
+    .name = .kuri,
     .version = "0.1.0",
     .dependencies = .{
         .quickjs = .{


### PR DESCRIPTION
## Summary
- Rename `.name` in `build.zig.zon` from `agentic_browdie` to `kuri`
- The package was previously named "agentic_browdie" but has been renamed to "kuri" everywhere else (binary names, README, etc.)

## Test plan
- [ ] Run `zig build` to confirm the rename doesn't break the build
- [ ] Verify all binary names still output correctly (`./zig-out/bin/kuri --version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)