### PR TITLE
feat: enrich a11y snapshots for agent loops

### DIFF
--- a/.claude/skills/kuri-server/SKILL.md
+++ b/.claude/skills/kuri-server/SKILL.md
@@ -42,7 +42,7 @@ curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
 # → {"tab_id":"ABC123","url":"https://example.com/","title":"Example Domain",...}
 
 # 3. Snapshot (a11y tree with element refs)
-curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive"
+curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive&format=compact"
 # → [{"ref":"e0","role":"heading","name":"Example Domain"},
 #    {"ref":"e1","role":"link","name":"More information..."}]
 
@@ -52,7 +52,7 @@ curl -s -H "X-Kuri-Session: $SESSION" "$BASE/action?ref=e2&action=fill&value=hel
 
 # 5. Read results
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
-curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive"
+curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive&format=compact"
 ```
 
 If you already know a tab id, set it directly with:
@@ -79,8 +79,8 @@ curl -s -H "X-Kuri-Session: $SESSION" "$BASE/tab/current?tab_id=ABC123"
 ### Reading the page
 | Endpoint | Description |
 |---|---|
-| `GET /snapshot?tab_id=X&format=compact` | A11y tree with refs (best for agents) |
-| `GET /snapshot?tab_id=X&filter=interactive` | Only interactive elements |
+| `GET /snapshot?tab_id=X&filter=interactive&format=compact` | Lowest-token interactive a11y refs (best for agents) |
+| `GET /snapshot?tab_id=X&filter=interactive` | Only interactive elements as JSON |
 | `GET /diff/snapshot?tab_id=X` | Changes since last snapshot |
 | `GET /text?tab_id=X` | Page text content |
 | `GET /evaluate?tab_id=X&expression=JS` | Run JavaScript |
@@ -156,7 +156,7 @@ curl -s 'https://target.com/api/v4/data' \
 
 1. **Prefer session headers** — set `X-Kuri-Session` and let the server remember the current tab.
 2. **Use `/page/info` between steps** — it is the cheapest live state check for URL/title/ready state.
-3. **Use interactive snapshots** — `filter=interactive` gives refs like `e0`, `e1` for low-token loops.
+3. **Use compact interactive snapshots** — `filter=interactive&format=compact` gives refs like `e0`, `e1` plus useful `state` such as `checked=false`, `disabled`, or `expanded=false` at lower token cost.
 4. **Bot detection is automatic** — if navigate returns `{"blocked":true}`, read the `fallback.suggestions`.
 5. **HAR for API discovery** — start HAR before navigating, then use `/har/replay?filter=api` to find the site's API endpoints.
 6. **Cookies transfer** — use `/cookies` to get browser session cookies, then make direct `curl` calls.

--- a/readme.md
+++ b/readme.md
@@ -170,8 +170,8 @@ curl -s -H "X-Kuri-Session: $SESSION" \
   "$BASE/tab/new?url=https%3A%2F%2Fnews.ycombinator.com"
 
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
-SNAP=$(curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive")
-MORE_REF=$(printf '%s' "$SNAP" | python3 -c 'import json,sys; nodes=json.load(sys.stdin); print(next(n["ref"] for n in nodes if n.get("name") == "More"))')
+SNAP=$(curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive&format=compact")
+MORE_REF=$(printf '%s' "$SNAP" | python3 -c 'import re,sys; print(re.search(r"\"More\" @(e\\d+)", sys.stdin.read()).group(1))')
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/action?action=click&ref=$MORE_REF"
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
 ```
@@ -230,7 +230,7 @@ All endpoints return JSON. Optional auth via `KURI_SECRET` env var.
 | `GET /navigate` | `tab_id`, `url` | Navigate tab to URL |
 | `GET /tab/new` | `url`, `activate`, `wait` | Create a new tab and optionally hydrate/set current tab |
 | `GET /window/new` | `url`, `activate`, `wait` | Create a new window/tab target |
-| `GET /snapshot` | `tab_id`, `filter`, `format` | A11y tree snapshot with `eN` refs |
+| `GET /snapshot` | `tab_id`, `filter`, `format` | A11y tree snapshot with `eN` refs, values, descriptions, and control state. Use `filter=interactive&format=compact` for low-token agent loops. |
 | `GET /text` | `tab_id` | Extract page text |
 | `GET /screenshot` | `tab_id`, `format`, `quality` | Capture screenshot (base64) |
 | `GET /action` | `tab_id`, `ref`, `action`, `value` | Click/type/fill/select/scroll by ref |
@@ -293,11 +293,12 @@ The lowest-friction server loop is:
 
 1. `GET /tab/new?url=...`
 2. `GET /page/info`
-3. `GET /snapshot?filter=interactive`
+3. `GET /snapshot?filter=interactive&format=compact`
 4. `GET /action?action=click&ref=eN`
 5. Repeat `page/info` or `snapshot` after state changes
 
 After any navigation or significant interaction, take a fresh snapshot before using refs again.
+Snapshots include `state` when Chrome exposes useful control state, for example `checked=true`, `checked=false`, `disabled`, `readonly`, `expanded=false`, `selected`, or `autocomplete=list`.
 
 ---
 
@@ -721,7 +722,7 @@ For a 50-page monitoring task (from Pinchtab benchmarks):
 | Method | Tokens | Cost ($) | Best For |
 |--------|--------|----------|----------|
 | `/text` | ~40,000 | $0.20 | Read-heavy (13× cheaper than screenshots) |
-| `/snapshot?filter=interactive` | ~180,000 | $0.90 | Element interaction |
+| `/snapshot?filter=interactive&format=compact` | ~40,000 | $0.20 | Low-token element interaction |
 | `/snapshot` (full) | ~525,000 | $2.63 | Full page understanding |
 | `/screenshot` | ~100,000 | $1.00 | Visual verification |
 

--- a/skills/kuri-skill.md
+++ b/skills/kuri-skill.md
@@ -1,6 +1,6 @@
 ---
 name: kuri-skill
-description: Use Kuri's HTTP server as a session-based browser skill. Prefer X-Kuri-Session with /tab/new, /tab/current, /page/info, /snapshot?filter=interactive, and /action for low-token agent loops. Use when an agent needs to browse, read, click, or fill through Kuri without managing raw CDP details.
+description: Use Kuri's HTTP server as a session-based browser skill. Prefer X-Kuri-Session with /tab/new, /tab/current, /page/info, /snapshot?filter=interactive&format=compact, and /action for low-token agent loops. Use when an agent needs to browse, read, click, or fill through Kuri without managing raw CDP details.
 ---
 
 # Kuri Skill
@@ -12,7 +12,7 @@ Use this when driving `kuri` over HTTP as an agent loop.
 1. Start `kuri`.
 2. Create or select a tab for your session.
 3. Read live page state with `/page/info`.
-4. Read actionable refs with `/snapshot?filter=interactive`.
+4. Read actionable refs with `/snapshot?filter=interactive&format=compact`.
 5. Act with `/action`.
 6. After navigation or DOM changes, re-run `/page/info` and take a fresh snapshot.
 
@@ -26,8 +26,8 @@ curl -s -H "X-Kuri-Session: $SESSION" \
   "$BASE/tab/new?url=https%3A%2F%2Fnews.ycombinator.com"
 
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
-SNAP=$(curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive")
-MORE_REF=$(printf '%s' "$SNAP" | python3 -c 'import json,sys; nodes=json.load(sys.stdin); print(next(n["ref"] for n in nodes if n.get("name") == "More"))')
+SNAP=$(curl -s -H "X-Kuri-Session: $SESSION" "$BASE/snapshot?filter=interactive&format=compact")
+MORE_REF=$(printf '%s' "$SNAP" | python3 -c 'import re,sys; print(re.search(r"\"More\" @(e\\d+)", sys.stdin.read()).group(1))')
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/action?action=click&ref=$MORE_REF"
 curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
 ```
@@ -37,7 +37,8 @@ curl -s -H "X-Kuri-Session: $SESSION" "$BASE/page/info"
 - Prefer `X-Kuri-Session` over repeating `tab_id`.
 - Use `/tab/current?tab_id=...` when you already know which tab should become current.
 - Use `/page/info` before assuming the page moved.
-- Use `filter=interactive` snapshots for agent loops.
+- Use `filter=interactive&format=compact` snapshots for agent loops unless you need JSON.
+- Read snapshot `state` before acting on controls. Examples: `checked=false`, `disabled`, `readonly`, `expanded=false`, `selected`.
 - Treat refs as snapshot-local. Refresh them after navigation or major DOM updates.
 - Use HAR only when you need network or API discovery.
 

--- a/src/bridge/bridge.zig
+++ b/src/bridge/bridge.zig
@@ -459,6 +459,8 @@ pub const Bridge = struct {
                 self.allocator.free(node.role);
                 self.allocator.free(node.name);
                 self.allocator.free(node.value);
+                self.allocator.free(node.description);
+                self.allocator.free(node.state);
             }
         }
 
@@ -468,6 +470,8 @@ pub const Bridge = struct {
                 .role = try self.allocator.dupe(u8, node.role),
                 .name = try self.allocator.dupe(u8, node.name),
                 .value = try self.allocator.dupe(u8, node.value),
+                .description = try self.allocator.dupe(u8, node.description),
+                .state = try self.allocator.dupe(u8, node.state),
                 .backend_node_id = node.backend_node_id,
                 .depth = node.depth,
             };
@@ -484,6 +488,8 @@ fn freeSnapshot(allocator: std.mem.Allocator, snapshot: []const A11yNode) void {
         allocator.free(node.role);
         allocator.free(node.name);
         allocator.free(node.value);
+        allocator.free(node.description);
+        allocator.free(node.state);
     }
     allocator.free(snapshot);
 }

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -107,9 +107,9 @@ fn route(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *B
     } else if (std.mem.eql(u8, clean_path, "/har/stop")) {
         handleHarStop(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/har/status")) {
-            handleHarStatus(request, arena, bridge);
-        } else if (std.mem.eql(u8, clean_path, "/har/replay")) {
-            handleHarReplay(request, arena, bridge);
+        handleHarStatus(request, arena, bridge);
+    } else if (std.mem.eql(u8, clean_path, "/har/replay")) {
+        handleHarReplay(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/close")) {
         handleClose(request, arena, bridge);
     } else if (std.mem.eql(u8, clean_path, "/cookies")) {
@@ -397,6 +397,30 @@ fn waitForRegisteredTab(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, 
         if (bridge.getTab(tab_id)) |tab| return tab;
         compat.threadSleep(100 * std.time.ns_per_ms);
     }
+    return bridge.getTab(tab_id);
+}
+
+fn waitForTabPageReady(arena: std.mem.Allocator, bridge: *Bridge, tab_id: []const u8, requested_url: []const u8) ?TabEntry {
+    const client = bridge.getCdpClient(tab_id) orelse return bridge.getTab(tab_id);
+    const wants_blank = requested_url.len == 0 or std.mem.eql(u8, requested_url, "about:blank");
+
+    var attempts: u8 = 0;
+    while (attempts < 50) : (attempts += 1) {
+        const live_url = evalValueString(arena, client, "window.location.href") orelse "";
+        const live_title = evalValueString(arena, client, "document.title") orelse "";
+        const ready_state = evalValueString(arena, client, "document.readyState") orelse "";
+
+        if (live_url.len > 0) {
+            _ = bridge.updateTabMetadata(tab_id, live_url, live_title) catch false;
+        }
+
+        const reached_url = wants_blank or !std.mem.eql(u8, live_url, "about:blank");
+        const ready_enough = std.mem.eql(u8, ready_state, "interactive") or std.mem.eql(u8, ready_state, "complete");
+        if (reached_url and ready_enough) return bridge.getTab(tab_id);
+
+        compat.threadSleep(100 * std.time.ns_per_ms);
+    }
+
     return bridge.getTab(tab_id);
 }
 
@@ -764,9 +788,13 @@ fn handleSnapshot(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 
     const max_depth: ?u16 = if (depth_str) |ds| std.fmt.parseInt(u16, ds, 10) catch null else null;
 
+    const format_text = if (format) |f| std.mem.eql(u8, f, "text") else false;
+    const format_compact = if (format) |f| std.mem.eql(u8, f, "compact") else false;
+
     const opts = a11y.SnapshotOpts{
         .filter_interactive = if (filter) |f| std.mem.eql(u8, f, "interactive") else false,
-        .format_text = if (format) |f| std.mem.eql(u8, f, "text") else false,
+        .format_text = format_text,
+        .compact = format_compact,
         .max_depth = max_depth,
     };
 
@@ -803,7 +831,8 @@ fn handleSnapshot(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         // Clear old refs and repopulate
         ref_cache.clear();
         for (snapshot) |node| {
-            if (node.backend_node_id) |bid| {
+            if (node.ref.len > 0 and node.backend_node_id != null) {
+                const bid = node.backend_node_id.?;
                 const owned_ref = bridge.allocator.dupe(u8, node.ref) catch continue;
                 ref_cache.refs.put(owned_ref, bid) catch continue;
             }
@@ -816,6 +845,16 @@ fn handleSnapshot(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 
 fn sendSnapshotResponse(request: *std.http.Server.Request, arena: std.mem.Allocator, snapshot: []const @import("../snapshot/a11y.zig").A11yNode, opts: @import("../snapshot/a11y.zig").SnapshotOpts) void {
     const a11y_mod = @import("../snapshot/a11y.zig");
+    // Compact format is the lowest-token server response for agent loops.
+    if (opts.compact) {
+        const text = a11y_mod.formatCompact(snapshot, arena) catch {
+            resp.sendError(request, 500, "Failed to format snapshot");
+            return;
+        };
+        resp.sendJson(request, text);
+        return;
+    }
+
     // Text format for LLM-friendly output
     if (opts.format_text) {
         const text = a11y_mod.formatText(snapshot, arena) catch {
@@ -840,6 +879,14 @@ fn sendSnapshotResponse(request: *std.http.Server.Request, arena: std.mem.Alloca
         if (node.value.len > 0) {
             json_buf.appendSlice(arena, ",") catch return;
             writeJsonField(&json_buf, arena, "value", node.value) catch return;
+        }
+        if (node.description.len > 0) {
+            json_buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&json_buf, arena, "description", node.description) catch return;
+        }
+        if (node.state.len > 0) {
+            json_buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&json_buf, arena, "state", node.state) catch return;
         }
         json_buf.appendSlice(arena, "}") catch return;
     }
@@ -1005,7 +1052,7 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
         .check => "function() { if (!this.checked) { this.click(); } return 'checked'; }",
         .uncheck => "function() { if (this.checked) { this.click(); } return 'unchecked'; }",
         .blur => "function() { this.blur(); return 'blurred'; }",
-        .fill, .@"type" => blk: {
+        .fill, .type => blk: {
             const v = value orelse {
                 resp.sendError(request, 400, "Missing value parameter for fill/type");
                 return;
@@ -1052,11 +1099,9 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                 // Type each character via Input.dispatchKeyEvent
                 for (v) |ch| {
                     const char_str = std.fmt.allocPrint(arena, "{c}", .{ch}) catch continue;
-                    const key_params = std.fmt.allocPrint(arena,
-                        "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str }) catch continue;
+                    const key_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str }) catch continue;
                     _ = client.send(arena, protocol.Methods.input_dispatch_key_event, key_params) catch continue;
-                    const up_params = std.fmt.allocPrint(arena,
-                        "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str}) catch continue;
+                    const up_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str}) catch continue;
                     _ = client.send(arena, protocol.Methods.input_dispatch_key_event, up_params) catch continue;
                 }
                 // Dispatch change event on blur
@@ -1114,7 +1159,7 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
 
     // Step 3: Call function on the resolved object
     const call_params = switch (kind) {
-        .fill, .@"type" => blk: {
+        .fill, .type => blk: {
             const v = value orelse {
                 resp.sendError(request, 400, "Missing value parameter for fill/type");
                 return;
@@ -1126,7 +1171,7 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
             break :blk std.fmt.allocPrint(
                 arena,
                 "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}},{{\"value\":{s}}}],\"returnByValue\":true}}",
-                .{ object_id, escaped_js_fn, escaped_v, if (kind == .@"type") "true" else "false" },
+                .{ object_id, escaped_js_fn, escaped_v, if (kind == .type) "true" else "false" },
             );
         },
         .select => blk: {
@@ -1177,14 +1222,11 @@ fn handleText(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
-        break :blk std.fmt.allocPrint(arena,
-            "{{\"expression\":\"(() => {{ const el = document.querySelector(\\\"{s}\\\"); return el ? (el.innerText ?? '') : ''; }})()\",\"returnByValue\":true}}", .{escaped_sel}) catch {
+        break :blk std.fmt.allocPrint(arena, "{{\"expression\":\"(() => {{ const el = document.querySelector(\\\"{s}\\\"); return el ? (el.innerText ?? '') : ''; }})()\",\"returnByValue\":true}}", .{escaped_sel}) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
-    }
-    else
-        @as([]const u8, "{\"expression\":\"document.body ? document.body.innerText : ''\",\"returnByValue\":true}");
+    } else @as([]const u8, "{\"expression\":\"document.body ? document.body.innerText : ''\",\"returnByValue\":true}");
     const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
@@ -1248,8 +1290,7 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -1385,8 +1426,7 @@ fn handleDiscover(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         return;
     };
 
-    const result = std.fmt.allocPrint(arena,
-        "{{\"discovered\":{d},\"total_tabs\":{d}}}", .{ registered, bridge.tabCount() }) catch {
+    const result = std.fmt.allocPrint(arena, "{{\"discovered\":{d},\"total_tabs\":{d}}}", .{ registered, bridge.tabCount() }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -1399,6 +1439,8 @@ fn freeOwnedSnapshot(allocator: std.mem.Allocator, snapshot: []const @import("..
         allocator.free(node.role);
         allocator.free(node.name);
         allocator.free(node.value);
+        allocator.free(node.description);
+        allocator.free(node.state);
     }
     allocator.free(snapshot);
 }
@@ -1484,64 +1526,228 @@ fn extractSimpleJsonInt(json: []const u8, start: usize, field: []const u8) ?u32 
 
 fn parseA11yNodes(arena: std.mem.Allocator, raw_json: []const u8) ![]const @import("../snapshot/a11y.zig").A11yNode {
     const a11y = @import("../snapshot/a11y.zig");
-    // Parse the CDP response to extract node info
-    // The response has { "result": { "nodes": [ ... ] } }
-    // We do a simple scan for role/name/nodeId patterns
     var nodes: std.ArrayList(a11y.A11yNode) = .empty;
 
-    // Find "nodes" array start
     const nodes_start = std.mem.indexOf(u8, raw_json, "\"nodes\"") orelse return nodes.toOwnedSlice(arena);
     const array_start = std.mem.indexOfScalarPos(u8, raw_json, nodes_start, '[') orelse return nodes.toOwnedSlice(arena);
 
-    // Simple state-machine parser for CDP a11y nodes
     var pos = array_start + 1;
     var depth: u16 = 0;
     while (pos < raw_json.len) {
-        // Find next nodeId
         const node_start = std.mem.indexOfPos(u8, raw_json, pos, "\"nodeId\"") orelse break;
-        const role_val = extractJsonStringField(raw_json, node_start, "\"role\"") orelse "";
-        const name_val = extractNestedValue(raw_json, node_start) orelse "";
-        const backend_id = extractSimpleJsonInt(raw_json, node_start, "\"backendDOMNodeId\"");
+        const object_start = findContainingObjectStart(raw_json, node_start);
+        const object_end = findJsonObjectEnd(raw_json, object_start) orelse break;
+        const node_json = raw_json[object_start..object_end];
+
+        const role_val = extractTopLevelA11yValue(node_json, "\"role\"") orelse "";
+        const name_val = extractTopLevelA11yValue(node_json, "\"name\"") orelse "";
+        const value_val = extractTopLevelA11yValue(node_json, "\"value\"") orelse "";
+        const description_val = extractTopLevelA11yValue(node_json, "\"description\"") orelse "";
+        const state_val = buildA11yState(arena, node_json);
+        const backend_id = extractSimpleJsonInt(node_json, 0, "\"backendDOMNodeId\"");
 
         if (role_val.len > 0) {
             try nodes.append(arena, .{
                 .ref = "",
                 .role = role_val,
                 .name = name_val,
-                .value = "",
+                .value = value_val,
+                .description = description_val,
+                .state = state_val,
                 .backend_node_id = backend_id,
                 .depth = depth,
             });
         }
 
-        // Move past this node object
-        const next_node = std.mem.indexOfPos(u8, raw_json, node_start + 10, "\"nodeId\"") orelse raw_json.len;
-        pos = next_node;
+        pos = object_end;
         depth = 0; // flat for now
     }
 
     return nodes.toOwnedSlice(arena);
 }
 
-fn extractJsonStringField(json: []const u8, start: usize, field: []const u8) ?[]const u8 {
-    const field_pos = std.mem.indexOfPos(u8, json, start, field) orelse return null;
-    // Limit search to next 500 chars (within same node object)
-    if (field_pos - start > 500) return null;
-    // Find the value string after ":"
-    const colon = std.mem.indexOfScalarPos(u8, json, field_pos + field.len, ':') orelse return null;
-    // Look for nested "value" field
-    const value_field = std.mem.indexOfPos(u8, json, colon, "\"value\"") orelse return null;
-    if (value_field - colon > 100) return null;
-    const val_colon = std.mem.indexOfScalarPos(u8, json, value_field + 7, ':') orelse return null;
-    const quote_start = std.mem.indexOfScalarPos(u8, json, val_colon + 1, '"') orelse return null;
-    const quote_end = std.mem.indexOfScalarPos(u8, json, quote_start + 1, '"') orelse return null;
-    return json[quote_start + 1 .. quote_end];
+fn findContainingObjectStart(json: []const u8, pos: usize) usize {
+    var i = @min(pos, json.len);
+    while (i > 0) {
+        i -= 1;
+        if (json[i] == '{') return i;
+    }
+    return pos;
 }
 
-fn extractNestedValue(json: []const u8, start: usize) ?[]const u8 {
-    const name_pos = std.mem.indexOfPos(u8, json, start, "\"name\"") orelse return null;
-    if (name_pos - start > 800) return null;
-    return extractJsonStringField(json, name_pos - 1, "\"name\"");
+fn findJsonObjectEnd(json: []const u8, object_start: usize) ?usize {
+    if (object_start >= json.len or json[object_start] != '{') return null;
+    var i = object_start;
+    var depth: usize = 0;
+    while (i < json.len) : (i += 1) {
+        switch (json[i]) {
+            '"' => {
+                i = skipJsonString(json, i) orelse return null;
+                if (i == 0) return null;
+                i -= 1;
+            },
+            '{' => depth += 1,
+            '}' => {
+                if (depth == 0) return null;
+                depth -= 1;
+                if (depth == 0) return i + 1;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn skipWhitespace(json: []const u8, start: usize) usize {
+    var i = start;
+    while (i < json.len and (json[i] == ' ' or json[i] == '\t' or json[i] == '\n' or json[i] == '\r')) : (i += 1) {}
+    return i;
+}
+
+fn skipJsonString(json: []const u8, quote_start: usize) ?usize {
+    if (quote_start >= json.len or json[quote_start] != '"') return null;
+    var i = quote_start + 1;
+    while (i < json.len) : (i += 1) {
+        if (json[i] == '\\') {
+            i += 1;
+            continue;
+        }
+        if (json[i] == '"') return i + 1;
+    }
+    return null;
+}
+
+fn parseJsonStringValue(json: []const u8, quote_start: usize) ?[]const u8 {
+    const end = skipJsonString(json, quote_start) orelse return null;
+    return json[quote_start + 1 .. end - 1];
+}
+
+fn parseJsonScalarValue(json: []const u8, start: usize) ?[]const u8 {
+    const i = skipWhitespace(json, start);
+    if (i >= json.len) return null;
+    if (json[i] == '"') return parseJsonStringValue(json, i);
+
+    var end = i;
+    while (end < json.len and json[end] != ',' and json[end] != '}' and json[end] != ']' and
+        json[end] != ' ' and json[end] != '\t' and json[end] != '\n' and json[end] != '\r') : (end += 1)
+    {}
+    if (end == i) return null;
+    return json[i..end];
+}
+
+fn extractA11yValueAfterColon(json: []const u8, colon: usize) ?[]const u8 {
+    const value_start = skipWhitespace(json, colon + 1);
+    if (value_start >= json.len) return null;
+    if (json[value_start] == '{') {
+        const value_end = findJsonObjectEnd(json, value_start) orelse return null;
+        return extractTopLevelA11yValue(json[value_start..value_end], "\"value\"");
+    }
+    return parseJsonScalarValue(json, value_start);
+}
+
+fn extractTopLevelA11yValue(object: []const u8, field: []const u8) ?[]const u8 {
+    var i: usize = 0;
+    var depth: usize = 0;
+    while (i < object.len) : (i += 1) {
+        switch (object[i]) {
+            '"' => {
+                if (depth == 1 and std.mem.startsWith(u8, object[i..], field)) {
+                    const after_field = i + field.len;
+                    const j = skipWhitespace(object, after_field);
+                    if (j < object.len and object[j] == ':') {
+                        return extractA11yValueAfterColon(object, j);
+                    }
+                }
+                i = skipJsonString(object, i) orelse return null;
+                if (i == 0) return null;
+                i -= 1;
+            },
+            '{' => depth += 1,
+            '}' => {
+                if (depth == 0) return null;
+                depth -= 1;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn extractPropertyValue(object: []const u8, property_name: []const u8) ?[]const u8 {
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, object, pos, "\"name\"")) |name_field| {
+        const colon = std.mem.indexOfScalarPos(u8, object, name_field + 6, ':') orelse return null;
+        const name_start = skipWhitespace(object, colon + 1);
+        if (name_start < object.len and object[name_start] == '"') {
+            const found = parseJsonStringValue(object, name_start) orelse return null;
+            if (std.mem.eql(u8, found, property_name)) {
+                const value_field = std.mem.indexOfPos(u8, object, name_field + 6, "\"value\"") orelse return null;
+                const value_colon = std.mem.indexOfScalarPos(u8, object, value_field + 7, ':') orelse return null;
+                return extractA11yValueAfterColon(object, value_colon);
+            }
+        }
+        pos = name_field + 6;
+    }
+    return null;
+}
+
+fn appendStateToken(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, token: []const u8) !void {
+    if (token.len == 0) return;
+    if (buf.items.len > 0) try buf.append(allocator, ' ');
+    try buf.appendSlice(allocator, token);
+}
+
+fn appendStateKeyValue(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
+    if (value.len == 0 or std.mem.eql(u8, value, "undefined") or std.mem.eql(u8, value, "null")) return;
+    if (buf.items.len > 0) try buf.append(allocator, ' ');
+    try buf.print(allocator, "{s}={s}", .{ key, value });
+}
+
+fn isTruthyA11yValue(value: []const u8) bool {
+    return std.mem.eql(u8, value, "true") or
+        std.mem.eql(u8, value, "mixed") or
+        std.mem.eql(u8, value, "page") or
+        std.mem.eql(u8, value, "spelling") or
+        std.mem.eql(u8, value, "grammar");
+}
+
+fn appendBooleanState(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, object: []const u8, property_name: []const u8, token: []const u8) !void {
+    const value = extractPropertyValue(object, property_name) orelse return;
+    if (isTruthyA11yValue(value)) try appendStateToken(buf, allocator, token);
+}
+
+fn buildA11yState(arena: std.mem.Allocator, object: []const u8) []const u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    appendStateKeyValue(&buf, arena, "checked", extractPropertyValue(object, "checked") orelse "") catch return "";
+    appendStateKeyValue(&buf, arena, "pressed", extractPropertyValue(object, "pressed") orelse "") catch return "";
+    appendStateKeyValue(&buf, arena, "expanded", extractPropertyValue(object, "expanded") orelse "") catch return "";
+    appendBooleanState(&buf, arena, object, "disabled", "disabled") catch return "";
+    appendBooleanState(&buf, arena, object, "readonly", "readonly") catch return "";
+    appendBooleanState(&buf, arena, object, "required", "required") catch return "";
+    appendBooleanState(&buf, arena, object, "selected", "selected") catch return "";
+    appendBooleanState(&buf, arena, object, "focused", "focused") catch return "";
+
+    if (extractPropertyValue(object, "invalid")) |invalid| {
+        if (std.mem.eql(u8, invalid, "true")) {
+            appendStateToken(&buf, arena, "invalid") catch return "";
+        } else if (!std.mem.eql(u8, invalid, "false") and invalid.len > 0) {
+            appendStateKeyValue(&buf, arena, "invalid", invalid) catch return "";
+        }
+    }
+    if (extractPropertyValue(object, "autocomplete")) |autocomplete| {
+        if (autocomplete.len > 0 and !std.mem.eql(u8, autocomplete, "none")) {
+            appendStateKeyValue(&buf, arena, "autocomplete", autocomplete) catch return "";
+        }
+    }
+    if (extractPropertyValue(object, "haspopup")) |haspopup| {
+        if (std.mem.eql(u8, haspopup, "true")) {
+            appendStateToken(&buf, arena, "haspopup") catch return "";
+        } else if (!std.mem.eql(u8, haspopup, "false") and haspopup.len > 0) {
+            appendStateKeyValue(&buf, arena, "haspopup", haspopup) catch return "";
+        }
+    }
+
+    return buf.toOwnedSlice(arena) catch "";
 }
 
 // ── HAR Endpoints ───────────────────────────────────────────────────────
@@ -1930,8 +2136,7 @@ fn handleCookies(request: *std.http.Server.Request, arena: std.mem.Allocator, br
     if (name != null and value != null) {
         // Set cookie
         const domain = getQueryParam(target, "domain") orelse "localhost";
-        const params = std.fmt.allocPrint(arena,
-            "{{\"name\":\"{s}\",\"value\":\"{s}\",\"domain\":\"{s}\",\"path\":\"/\"}}", .{ name.?, value.?, domain }) catch {
+        const params = std.fmt.allocPrint(arena, "{{\"name\":\"{s}\",\"value\":\"{s}\",\"domain\":\"{s}\",\"path\":\"/\"}}", .{ name.?, value.?, domain }) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -2004,8 +2209,7 @@ fn handleStorage(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         return;
     };
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2026,8 +2230,7 @@ fn handleStorageClear(request: *std.http.Server.Request, arena: std.mem.Allocato
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}.clear() || 'cleared'\",\"returnByValue\":true}}", .{storage_type}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}.clear() || 'cleared'\",\"returnByValue\":true}}", .{storage_type}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2098,8 +2301,7 @@ fn handleGet(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge
         return;
     };
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2274,7 +2476,8 @@ fn handleEmulate(request: *std.http.Server.Request, arena: std.mem.Allocator, br
     const scale_str = getQueryParam(target, "scale") orelse "1";
     const ua = getQueryParam(target, "ua");
 
-    const params = std.fmt.allocPrint(arena,
+    const params = std.fmt.allocPrint(
+        arena,
         "{{\"width\":{s},\"height\":{s},\"deviceScaleFactor\":{s},\"mobile\":false}}",
         .{ width_str, height_str, scale_str },
     ) catch {
@@ -2317,7 +2520,8 @@ fn handleGeolocation(request: *std.http.Server.Request, arena: std.mem.Allocator
     };
     const accuracy_str = getQueryParam(target, "accuracy") orelse "1";
 
-    const params = std.fmt.allocPrint(arena,
+    const params = std.fmt.allocPrint(
+        arena,
         "{{\"latitude\":{s},\"longitude\":{s},\"accuracy\":{s}}}",
         .{ lat, lng, accuracy_str },
     ) catch {
@@ -3002,8 +3206,7 @@ fn handleMarkdown(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         \\})()
     ;
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3029,8 +3232,7 @@ fn handleLinks(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
 
     const js = "JSON.stringify([...document.querySelectorAll('a[href]')].map(a=>({text:a.innerText.trim().substring(0,200),href:a.href})))";
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{js}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3055,8 +3257,7 @@ fn handlePdf(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge
     };
 
     const landscape = getQueryParam(target, "landscape") orelse "false";
-    const params = std.fmt.allocPrint(arena,
-        "{{\"landscape\":{s},\"printBackground\":true}}", .{landscape}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"landscape\":{s},\"printBackground\":true}}", .{landscape}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3099,8 +3300,7 @@ fn handleDomQuery(request: *std.http.Server.Request, arena: std.mem.Allocator, b
     const use_all = if (all) |a| std.mem.eql(u8, a, "true") else false;
     const method = if (use_all) protocol.Methods.dom_query_selector_all else protocol.Methods.dom_query_selector;
 
-    const query_params = std.fmt.allocPrint(arena,
-        "{{\"nodeId\":{d},\"selector\":\"{s}\"}}", .{ root_node_id, selector }) catch {
+    const query_params = std.fmt.allocPrint(arena, "{{\"nodeId\":{d},\"selector\":\"{s}\"}}", .{ root_node_id, selector }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3127,8 +3327,7 @@ fn handleDomHtml(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         return;
     };
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"nodeId\":{s}}}", .{node_id_str}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"nodeId\":{s}}}", .{node_id_str}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3166,8 +3365,7 @@ fn handleCookiesDelete(request: *std.http.Server.Request, arena: std.mem.Allocat
             return;
         };
         break :blk std.fmt.allocPrint(arena, "{{\"name\":\"{s}\",\"domain\":\"{s}\"}}", .{ escaped_name, escaped_domain });
-    } else
-        std.fmt.allocPrint(arena, "{{\"name\":\"{s}\"}}", .{escaped_name});
+    } else std.fmt.allocPrint(arena, "{{\"name\":\"{s}\"}}", .{escaped_name});
 
     const delete_params = params catch {
         resp.sendError(request, 500, "Internal Server Error");
@@ -3203,8 +3401,7 @@ fn handleHeaders(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         return;
     };
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"headers\":{s}}}", .{body}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"headers\":{s}}}", .{body}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3253,8 +3450,7 @@ fn handleScriptInject(request: *std.http.Server.Request, arena: std.mem.Allocato
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const params = std.fmt.allocPrint(arena,
-        "{{\"source\":\"{s}\"}}", .{escaped}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"source\":\"{s}\"}}", .{escaped}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -3756,11 +3952,9 @@ fn handleKeyboardType(request: *std.http.Server.Request, arena: std.mem.Allocato
     // Type each character via Input.dispatchKeyEvent
     for (text) |ch| {
         const char_str = std.fmt.allocPrint(arena, "{c}", .{ch}) catch continue;
-        const key_params = std.fmt.allocPrint(arena,
-            "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str }) catch continue;
+        const key_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str }) catch continue;
         _ = client.send(arena, protocol.Methods.input_dispatch_key_event, key_params) catch continue;
-        const up_params = std.fmt.allocPrint(arena,
-            "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str}) catch continue;
+        const up_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str}) catch continue;
         _ = client.send(arena, protocol.Methods.input_dispatch_key_event, up_params) catch continue;
     }
     const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"typed\":\"{s}\",\"chars\":{d}}}", .{ text, text.len }) catch {
@@ -4018,10 +4212,11 @@ fn handleTabNew(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
     if (activate and !std.mem.eql(u8, new_tab_id, "unknown")) {
         _ = activateTarget(arena, bridge, new_tab_id);
     }
-    const hydrated_tab = if (wait and !std.mem.eql(u8, new_tab_id, "unknown"))
-        waitForRegisteredTab(arena, bridge, cfg, cdp_port, new_tab_id)
-    else
-        null;
+    var hydrated_tab: ?TabEntry = null;
+    if (wait and !std.mem.eql(u8, new_tab_id, "unknown")) {
+        hydrated_tab = waitForRegisteredTab(arena, bridge, cfg, cdp_port, new_tab_id);
+        hydrated_tab = waitForTabPageReady(arena, bridge, new_tab_id, url) orelse hydrated_tab;
+    }
     rememberCurrentTab(request, bridge, new_tab_id);
     const final_url = if (hydrated_tab) |tab| tab.url else url;
     const final_title = if (hydrated_tab) |tab| tab.title else "";
@@ -4076,8 +4271,7 @@ fn handleHighlight(request: *std.http.Server.Request, arena: std.mem.Allocator, 
             resp.sendError(request, 400, "Ref not found");
             return;
         };
-        const params = std.fmt.allocPrint(arena,
-            "{{\"highlightConfig\":{{\"showInfo\":true,\"contentColor\":{{\"r\":111,\"g\":168,\"b\":220,\"a\":0.66}},\"borderColor\":{{\"r\":111,\"g\":168,\"b\":220,\"a\":1}}}},\"backendNodeId\":{d}}}", .{bid}) catch {
+        const params = std.fmt.allocPrint(arena, "{{\"highlightConfig\":{{\"showInfo\":true,\"contentColor\":{{\"r\":111,\"g\":168,\"b\":220,\"a\":0.66}},\"borderColor\":{{\"r\":111,\"g\":168,\"b\":220,\"a\":1}}}},\"backendNodeId\":{d}}}", .{bid}) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -4088,8 +4282,7 @@ fn handleHighlight(request: *std.http.Server.Request, arena: std.mem.Allocator, 
         resp.sendJson(request, response);
     } else if (selector) |sel| {
         // Highlight via JS + overlay
-        const params = std.fmt.allocPrint(arena,
-            "{{\"expression\":\"(function(){{ var el=document.querySelector('{s}'); if(!el) return 'not_found'; el.style.outline='3px solid #6fa8dc'; return 'highlighted'; }})()\",\"returnByValue\":true}}", .{sel}) catch {
+        const params = std.fmt.allocPrint(arena, "{{\"expression\":\"(function(){{ var el=document.querySelector('{s}'); if(!el) return 'not_found'; el.style.outline='3px solid #6fa8dc'; return 'highlighted'; }})()\",\"returnByValue\":true}}", .{sel}) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -4142,8 +4335,7 @@ fn handleSetOffline(request: *std.http.Server.Request, arena: std.mem.Allocator,
     };
 
     const offline = std.mem.eql(u8, mode, "on") or std.mem.eql(u8, mode, "true");
-    const params = std.fmt.allocPrint(arena,
-        "{{\"offline\":{s},\"latency\":0,\"downloadThroughput\":-1,\"uploadThroughput\":-1}}", .{if (offline) "true" else "false"}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"offline\":{s},\"latency\":0,\"downloadThroughput\":-1,\"uploadThroughput\":-1}}", .{if (offline) "true" else "false"}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4171,8 +4363,7 @@ fn handleSetMedia(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         return;
     };
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"features\":[{{\"name\":\"prefers-color-scheme\",\"value\":\"{s}\"}}]}}", .{scheme}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"features\":[{{\"name\":\"prefers-color-scheme\",\"value\":\"{s}\"}}]}}", .{scheme}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4223,8 +4414,7 @@ fn handleSetCredentials(request: *std.http.Server.Request, arena: std.mem.Alloca
     };
     _ = encoder.encode(encoded, b64_input);
 
-    const header_params = std.fmt.allocPrint(arena,
-        "{{\"headers\":{{\"Authorization\":\"Basic {s}\"}}}}", .{encoded}) catch {
+    const header_params = std.fmt.allocPrint(arena, "{{\"headers\":{{\"Authorization\":\"Basic {s}\"}}}}", .{encoded}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4265,30 +4455,22 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
 
     // Build JS to find elements by semantic locator
     const js = if (std.mem.eql(u8, by, "role"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[role=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100),ref:'found_'+i}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('[role=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100),ref:'found_'+i}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "text"))
         if (exact != null and std.mem.eql(u8, exact.?, "true"))
-            std.fmt.allocPrint(arena,
-                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.trim()===\"{s}\"&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
+            std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.trim()===\"{s}\"&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
         else
-            std.fmt.allocPrint(arena,
-                "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.includes(\"{s}\")&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
+            std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('*')].filter(el=>el.innerText.includes(\"{s}\")&&el.children.length===0).slice(0,20).map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "label"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('label')].filter(l=>l.innerText.includes(\"{s}\")).map((l,i)=>{{var el=l.htmlFor?document.getElementById(l.htmlFor):l.querySelector('input,select,textarea');return {{index:i,label:l.innerText.substring(0,100),tag:el?el.tagName:'none'}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('label')].filter(l=>l.innerText.includes(\"{s}\")).map((l,i)=>{{var el=l.htmlFor?document.getElementById(l.htmlFor):l.querySelector('input,select,textarea');return {{index:i,label:l.innerText.substring(0,100),tag:el?el.tagName:'none'}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "placeholder"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[placeholder]')].filter(el=>el.placeholder.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,placeholder:el.placeholder}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('[placeholder]')].filter(el=>el.placeholder.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,placeholder:el.placeholder}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "testid"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[data-testid=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('[data-testid=\"{s}\"]')].map((el,i)=>{{return {{index:i,tag:el.tagName,text:el.innerText.substring(0,100)}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "alt"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[alt]')].filter(el=>el.alt.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,alt:el.alt}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('[alt]')].filter(el=>el.alt.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,alt:el.alt}}}}))", .{escaped_value})
     else if (std.mem.eql(u8, by, "title"))
-        std.fmt.allocPrint(arena,
-            "JSON.stringify([...document.querySelectorAll('[title]')].filter(el=>el.title.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,title:el.title}}}}))", .{escaped_value})
+        std.fmt.allocPrint(arena, "JSON.stringify([...document.querySelectorAll('[title]')].filter(el=>el.title.includes(\"{s}\")).map((el,i)=>{{return {{index:i,tag:el.tagName,title:el.title}}}}))", .{escaped_value})
     else {
         resp.sendError(request, 400, "Unknown 'by' type. Use: role|text|label|placeholder|testid|alt|title");
         return;
@@ -4303,8 +4485,7 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4328,8 +4509,7 @@ fn handleTraceStart(request: *std.http.Server.Request, arena: std.mem.Allocator,
         return;
     };
     const categories = getQueryParam(target, "categories") orelse "-*,devtools.timeline,v8.execute,disabled-by-default-devtools.timeline";
-    const params = std.fmt.allocPrint(arena,
-        "{{\"categories\":\"{s}\",\"options\":\"sampling-frequency=10000\"}}", .{categories}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"categories\":\"{s}\",\"options\":\"sampling-frequency=10000\"}}", .{categories}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4466,10 +4646,11 @@ fn handleWindowNew(request: *std.http.Server.Request, arena: std.mem.Allocator, 
     if (activate and !std.mem.eql(u8, new_tab_id, "unknown")) {
         _ = activateTarget(arena, bridge, new_tab_id);
     }
-    const hydrated_tab = if (wait and !std.mem.eql(u8, new_tab_id, "unknown"))
-        waitForRegisteredTab(arena, bridge, cfg, cdp_port, new_tab_id)
-    else
-        null;
+    var hydrated_tab: ?TabEntry = null;
+    if (wait and !std.mem.eql(u8, new_tab_id, "unknown")) {
+        hydrated_tab = waitForRegisteredTab(arena, bridge, cfg, cdp_port, new_tab_id);
+        hydrated_tab = waitForTabPageReady(arena, bridge, new_tab_id, url) orelse hydrated_tab;
+    }
     rememberCurrentTab(request, bridge, new_tab_id);
     const final_url = if (hydrated_tab) |tab| tab.url else url;
     const final_title = if (hydrated_tab) |tab| tab.title else "";
@@ -4520,8 +4701,7 @@ fn handleSetViewport(request: *std.http.Server.Request, arena: std.mem.Allocator
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const params = std.fmt.allocPrint(arena,
-        "{{\"width\":{s},\"height\":{s},\"deviceScaleFactor\":{s},\"mobile\":false}}", .{ width, height, scale }) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"width\":{s},\"height\":{s},\"deviceScaleFactor\":{s},\"mobile\":false}}", .{ width, height, scale }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4530,8 +4710,7 @@ fn handleSetViewport(request: *std.http.Server.Request, arena: std.mem.Allocator
         return;
     };
     _ = response;
-    const body = std.fmt.allocPrint(arena,
-        "{{\"status\":\"ok\",\"width\":{s},\"height\":{s},\"scale\":{s}}}", .{ width, height, scale }) catch {
+    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"width\":{s},\"height\":{s},\"scale\":{s}}}", .{ width, height, scale }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4604,8 +4783,7 @@ fn handleDomAttributes(request: *std.http.Server.Request, arena: std.mem.Allocat
             resp.sendError(request, 500, "Could not resolve element");
             return;
         };
-        const call_params = std.fmt.allocPrint(arena,
-            "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"function() {{ var attrs={{}}; for(var a of this.attributes){{ attrs[a.name]=a.value; }} return JSON.stringify(attrs); }}\",\"returnByValue\":true}}", .{object_id}) catch {
+        const call_params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"function() {{ var attrs={{}}; for(var a of this.attributes){{ attrs[a.name]=a.value; }} return JSON.stringify(attrs); }}\",\"returnByValue\":true}}", .{object_id}) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -4615,8 +4793,7 @@ fn handleDomAttributes(request: *std.http.Server.Request, arena: std.mem.Allocat
         };
         resp.sendJson(request, response);
     } else if (selector) |sel| {
-        const params = std.fmt.allocPrint(arena,
-            "{{\"expression\":\"(function(){{ var el=document.querySelector('{s}'); if(!el) return 'null'; var attrs={{}}; for(var a of el.attributes){{ attrs[a.name]=a.value; }} return JSON.stringify(attrs); }})()\",\"returnByValue\":true}}", .{sel}) catch {
+        const params = std.fmt.allocPrint(arena, "{{\"expression\":\"(function(){{ var el=document.querySelector('{s}'); if(!el) return 'null'; var attrs={{}}; for(var a of el.attributes){{ attrs[a.name]=a.value; }} return JSON.stringify(attrs); }})()\",\"returnByValue\":true}}", .{sel}) catch {
             resp.sendError(request, 500, "Internal Server Error");
             return;
         };
@@ -4713,8 +4890,7 @@ fn handlePerfLcp(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         "setTimeout(() => resolve(JSON.stringify({lcp_ms: null, error: 'timeout'})), 10000); " ++
         "}})";
 
-    const params = std.fmt.allocPrint(arena,
-        "{{\"expression\":\"{s}\",\"awaitPromise\":true,\"returnByValue\":true}}", .{lcp_js}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"awaitPromise\":true,\"returnByValue\":true}}", .{lcp_js}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4865,8 +5041,7 @@ fn handleAuthExtract(request: *std.http.Server.Request, arena: std.mem.Allocator
     else
         "";
 
-    const query = std.fmt.allocPrint(arena,
-        "sqlite3 -json '{s}' \"SELECT host_key as domain, name, value, path, is_secure as secure, is_httponly as httpOnly, expires_utc as expires FROM cookies{s} LIMIT 500;\"", .{ db_path, domain_filter }) catch {
+    const query = std.fmt.allocPrint(arena, "sqlite3 -json '{s}' \"SELECT host_key as domain, name, value, path, is_secure as secure, is_httponly as httpOnly, expires_utc as expires FROM cookies{s} LIMIT 500;\"", .{ db_path, domain_filter }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4970,7 +5145,6 @@ fn handleWsStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
     };
     resp.sendJson(request, response);
 }
-
 
 test "screenshot routes match" {
     for ([_][]const u8{ "/screenshot/annotated", "/screenshot/diff", "/screencast/start", "/screencast/stop" }) |p| {
@@ -5210,42 +5384,27 @@ test "action check/uncheck routes" {
 test "total endpoint count" {
     // Verify we have the expected number of routes
     const routes = [_][]const u8{
-        "/health", "/tabs", "/discover", "/navigate", "/snapshot", "/action",
-        "/text", "/screenshot", "/evaluate", "/browdie",
-        "/har/start", "/har/stop", "/har/status",
-        "/close", "/cookies", "/cookies/clear", "/cookies/delete", "/cookies/set",
-        "/storage/local", "/storage/session", "/storage/local/clear", "/storage/session/clear",
-        "/get", "/back", "/forward", "/reload",
-        "/diff/snapshot", "/emulate", "/geolocation", "/upload",
-        "/session/save", "/session/load",
-        "/auth/profile/save", "/auth/profile/load", "/auth/profile/list", "/auth/profile/delete",
-        "/auth/extract",
-        "/debug/enable", "/debug/disable",
-        "/screenshot/annotated", "/screenshot/diff",
-        "/screencast/start", "/screencast/stop", "/video/start", "/video/stop",
-        "/console", "/intercept/start", "/intercept/stop", "/intercept/requests",
-        "/markdown", "/links", "/pdf",
-        "/dom/query", "/dom/html",
-        "/headers", "/script/inject", "/stop",
+        "/health",              "/tabs",            "/discover",            "/navigate",              "/snapshot",          "/action",
+        "/text",                "/screenshot",      "/evaluate",            "/browdie",               "/har/start",         "/har/stop",
+        "/har/status",          "/close",           "/cookies",             "/cookies/clear",         "/cookies/delete",    "/cookies/set",
+        "/storage/local",       "/storage/session", "/storage/local/clear", "/storage/session/clear", "/get",               "/back",
+        "/forward",             "/reload",          "/diff/snapshot",       "/emulate",               "/geolocation",       "/upload",
+        "/session/save",        "/session/load",    "/auth/profile/save",   "/auth/profile/load",     "/auth/profile/list", "/auth/profile/delete",
+        "/auth/extract",        "/debug/enable",    "/debug/disable",       "/screenshot/annotated",  "/screenshot/diff",   "/screencast/start",
+        "/screencast/stop",     "/video/start",     "/video/stop",          "/console",               "/intercept/start",   "/intercept/stop",
+        "/intercept/requests",  "/markdown",        "/links",               "/pdf",                   "/dom/query",         "/dom/html",
+        "/headers",             "/script/inject",   "/stop",
         // Tier 1 new endpoints
-        "/scrollintoview", "/drag",
-        "/keyboard/type", "/keyboard/inserttext",
-        "/keydown", "/keyup",
-        "/wait",
-        "/tab/new", "/tab/close",
-        "/highlight", "/errors",
-        "/set/offline", "/set/media", "/set/credentials",
+                       "/scrollintoview",        "/drag",              "/keyboard/type",
+        "/keyboard/inserttext", "/keydown",         "/keyup",               "/wait",                  "/tab/new",           "/tab/close",
+        "/highlight",           "/errors",          "/set/offline",         "/set/media",             "/set/credentials",
         // Tier 2 new endpoints
-        "/find",
-        "/trace/start", "/trace/stop",
-        "/profiler/start", "/profiler/stop",
-        "/inspect",
-        "/window/new", "/session/list",
-        "/set/viewport", "/set/useragent",
-        "/dom/attributes", "/frames", "/network",
+          "/find",
+        "/trace/start",         "/trace/stop",      "/profiler/start",      "/profiler/stop",         "/inspect",           "/window/new",
+        "/session/list",        "/set/viewport",    "/set/useragent",       "/dom/attributes",        "/frames",            "/network",
         "/perf/lcp",
         // Tier 3 new endpoints
-        "/ws/start", "/ws/stop",
+                   "/ws/start",        "/ws/stop",
     };
     try std.testing.expectEqual(@as(usize, 87), routes.len);
 }
@@ -5312,6 +5471,27 @@ test "runtime evaluate payload escapes embedded expression quotes" {
 
     try std.testing.expect(std.mem.indexOf(u8, payload, "\\\"Text input\\\"") != null);
     try std.testing.expect(std.mem.startsWith(u8, payload, "{\"expression\":\""));
+}
+
+test "parseA11yNodes extracts value description and state" {
+    const raw =
+        \\{"id":1,"result":{"nodes":[{"nodeId":"1","ignored":false,"role":{"type":"role","value":"checkbox"},"name":{"type":"computedString","value":"Email me"},"value":{"type":"string","value":"yes"},"description":{"type":"computedString","value":"Weekly updates"},"properties":[{"name":"checked","value":{"type":"tristate","value":"false"}},{"name":"required","value":{"type":"boolean","value":true}},{"name":"disabled","value":{"type":"boolean","value":false}}],"backendDOMNodeId":42}]}}
+    ;
+    const nodes = try parseA11yNodes(std.testing.allocator, raw);
+    defer {
+        for (nodes) |node| {
+            if (node.state.len > 0) std.testing.allocator.free(node.state);
+        }
+        std.testing.allocator.free(nodes);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), nodes.len);
+    try std.testing.expectEqualStrings("checkbox", nodes[0].role);
+    try std.testing.expectEqualStrings("Email me", nodes[0].name);
+    try std.testing.expectEqualStrings("yes", nodes[0].value);
+    try std.testing.expectEqualStrings("Weekly updates", nodes[0].description);
+    try std.testing.expectEqualStrings("checked=false required", nodes[0].state);
+    try std.testing.expectEqual(@as(?u32, 42), nodes[0].backend_node_id);
 }
 
 test "buildGetExpression html without selector returns null" {

--- a/src/snapshot/a11y.zig
+++ b/src/snapshot/a11y.zig
@@ -5,6 +5,8 @@ pub const A11yNode = struct {
     role: []const u8,
     name: []const u8,
     value: []const u8,
+    description: []const u8 = "",
+    state: []const u8 = "",
     backend_node_id: ?u32,
     depth: u16,
 };
@@ -153,12 +155,17 @@ pub fn buildSnapshot(
 
         // Truncate name — 70 chars captures all useful info without waste
         const name = if (node.name.len > 70) node.name[0..70] else node.name;
+        const value = if (node.value.len > 80) node.value[0..80] else node.value;
+        const description = if (node.description.len > 100) node.description[0..100] else node.description;
+        const state = if (node.state.len > 120) node.state[0..120] else node.state;
 
         try result.append(allocator, .{
             .ref = ref,
             .role = node.role,
             .name = name,
-            .value = node.value,
+            .value = value,
+            .description = description,
+            .state = state,
             .backend_node_id = node.backend_node_id,
             .depth = node.depth,
         });
@@ -206,6 +213,8 @@ pub fn buildSnapshot(
                 .role = node.role,
                 .name = node.name,
                 .value = node.value,
+                .description = node.description,
+                .state = node.state,
                 .backend_node_id = node.backend_node_id,
                 .depth = node.depth,
             });
@@ -216,7 +225,6 @@ pub fn buildSnapshot(
     }
 
     return result.toOwnedSlice(allocator);
-
 }
 
 /// Compact text-tree format: `role "name" @ref` — agent-browser style.
@@ -236,6 +244,12 @@ pub fn formatCompact(nodes: []const A11yNode, allocator: std.mem.Allocator) ![]c
         if (node.ref.len > 0) try buf.print(allocator, " @{s}", .{node.ref});
         if (node.value.len > 0) {
             try buf.print(allocator, " = {s}", .{node.value});
+        }
+        if (node.state.len > 0) {
+            try buf.print(allocator, " [{s}]", .{node.state});
+        }
+        if (node.description.len > 0) {
+            try buf.print(allocator, " desc=\"{s}\"", .{node.description});
         }
         try buf.appendSlice(allocator, "\n");
     }
@@ -257,6 +271,12 @@ pub fn formatText(nodes: []const A11yNode, allocator: std.mem.Allocator) ![]cons
         }
         if (node.value.len > 0) {
             try buf.print(allocator, " value=\"{s}\"", .{node.value});
+        }
+        if (node.state.len > 0) {
+            try buf.print(allocator, " state=\"{s}\"", .{node.state});
+        }
+        if (node.description.len > 0) {
+            try buf.print(allocator, " description=\"{s}\"", .{node.description});
         }
         try buf.appendSlice(allocator, "\n");
     }
@@ -318,4 +338,25 @@ test "buildSnapshot filters interactive" {
 
     try std.testing.expectEqual(@as(usize, 2), result.len);
     try std.testing.expectEqualStrings("button", result[0].role);
+}
+
+test "formatCompact includes state and description" {
+    const nodes = [_]A11yNode{
+        .{
+            .ref = "e0",
+            .role = "checkbox",
+            .name = "Email me",
+            .value = "",
+            .description = "Receives weekly updates",
+            .state = "checked=false required",
+            .backend_node_id = 1,
+            .depth = 0,
+        },
+    };
+
+    const text = try formatCompact(&nodes, std.testing.allocator);
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.indexOf(u8, text, "[checked=false required]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "desc=\"Receives weekly updates\"") != null);
 }


### PR DESCRIPTION
Adds lower-token, richer accessibility snapshots for agent browser loops.\n\n### Changes\n- Include a11y value, description, and control state in snapshots\n- Wire HTTP `format=compact` for low-token interactive snapshots\n- Wait for `/tab/new` hydration so the first session snapshot is not `about:blank`\n- Update README and Kuri skill docs to prefer `filter=interactive&format=compact`\n\n### Verification\n- `zig build test -Doptimize=ReleaseSafe --summary all`\n- `zig build -Doptimize=ReleaseSafe --summary all`\n- Local session-first smoke: `/tab/new -> /page/info -> /snapshot?filter=interactive&format=compact` on Hacker News returned live page info and usable refs\n\nDo not merge until CI is green.