### PR TITLE
release: use self-managed release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
   # ── macOS arm64: build + sign + notarize on real macOS runner ───────────────
   build-macos-arm:
     runs-on: macos-latest
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
@@ -46,12 +52,6 @@ jobs:
 
       - name: Sign & notarize
         if: ${{ env.APPLE_CERTIFICATE != '' }}
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
           KEYCHAIN="build-$(uuidgen).keychain"
           KEYCHAIN_PASS="$(uuidgen)"
@@ -89,6 +89,12 @@ jobs:
   # ── macOS x86_64: build + sign + notarize ───────────────────────────────────
   build-macos-x86:
     runs-on: macos-13
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v2
@@ -99,12 +105,6 @@ jobs:
 
       - name: Sign & notarize
         if: ${{ env.APPLE_CERTIFICATE != '' }}
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
           KEYCHAIN="build-$(uuidgen).keychain"
           KEYCHAIN_PASS="$(uuidgen)"
@@ -139,32 +139,85 @@ jobs:
           name: kuri-x86_64-macos
           path: dist/*.tar.gz
 
-  # ── Create GitHub Release with all artifacts ─────────────────────────────────
-  release:
+  # ── Publish self-managed release channel ────────────────────────────────────
+  publish-channel:
     needs: [build-linux, build-macos-arm, build-macos-x86]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release-channel
+          path: channel
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
           path: dist
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*.tar.gz
-          prerelease: ${{ contains(github.ref_name, 'rc') }}
-          generate_release_notes: true
-          body: |
-            ## Install
+      - name: Publish stable channel
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME}"
+          CHANNEL_DIR="channel/stable/${VERSION}"
+          mkdir -p "$CHANNEL_DIR"
+          cp dist/*.tar.gz "$CHANNEL_DIR/"
 
-            **curl (macOS / Linux):**
-            ```sh
-            curl -fsSL https://raw.githubusercontent.com/justrach/kuri/main/install.sh | sh
-            ```
+          python3 - <<'PY'
+          from pathlib import Path
+          import datetime
+          import hashlib
+          import json
+          import os
 
-            **bun / npm:**
-            ```sh
-            bun install -g kuri-agent
-            # or: npm install -g kuri-agent
-            ```
+          version = os.environ["GITHUB_REF_NAME"]
+          commit = os.environ["GITHUB_SHA"]
+          root = Path("channel")
+          version_dir = root / "stable" / version
+          base = "https://raw.githubusercontent.com/justrach/kuri/release-channel/stable"
+          assets = {}
 
-            **Manual:** download the tarball for your platform below, unpack to your `$PATH`.
+          for path in sorted(version_dir.glob("kuri-*.tar.gz")):
+              target = path.name.removeprefix(f"kuri-{version}-").removesuffix(".tar.gz")
+              assets[target] = {
+                  "url": f"{base}/{version}/{path.name}",
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                  "size": path.stat().st_size,
+                  "notarized": target.endswith("macos"),
+              }
+
+          manifest = {
+              "channel": "stable",
+              "version": version,
+              "commit": commit,
+              "published_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "install_url": f"{base}/install.sh",
+              "assets": assets,
+          }
+
+          (root / "stable" / "latest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+          (version_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+          with (version_dir / "sha256sums.txt").open("w") as out:
+              for target, meta in assets.items():
+                  out.write(f"{meta['sha256']}  kuri-{version}-{target}.tar.gz\n")
+          PY
+
+          cat > channel/README.md <<'EOF'
+          # Kuri Release Channel
+
+          Self-managed release channel for `justrach/kuri`. This branch intentionally does not use GitHub Releases.
+
+          ## Stable
+
+          ```sh
+          curl -fsSL https://raw.githubusercontent.com/justrach/kuri/release-channel/stable/install.sh | sh
+          ```
+
+          Manifest:
+
+          - https://raw.githubusercontent.com/justrach/kuri/release-channel/stable/latest.json
+          EOF
+
+          cd channel
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md stable
+          git commit -m "release: publish stable ${VERSION}" || exit 0
+          git push origin HEAD:release-channel

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,8 @@
 set -e
 
 REPO="justrach/kuri"
+CHANNEL="${KURI_CHANNEL:-stable}"
+BASE_URL="${KURI_RELEASE_BASE:-https://raw.githubusercontent.com/${REPO}/release-channel/${CHANNEL}}"
 INSTALL_DIR="${KURI_INSTALL_DIR:-$HOME/.local/bin}"
 
 # ── Detect platform ───────────────────────────────────────────────────────────
@@ -22,26 +24,48 @@ case "$ARCH" in
   *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
 esac
 
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
 TARGET="${ARCH_NAME}-${OS_NAME}"
 
-# ── Fetch latest release tag ──────────────────────────────────────────────────
-echo "Fetching latest kuri release..."
-VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+# ── Fetch channel manifest ────────────────────────────────────────────────────
+echo "Fetching kuri ${CHANNEL} channel manifest..."
+MANIFEST_URL="${BASE_URL}/latest.json"
+curl -fsSL "$MANIFEST_URL" -o "$TMP/latest.json"
 
-if [ -z "$VERSION" ]; then
-  echo "Error: could not determine latest version" >&2
+VERSION="$(grep '"version"' "$TMP/latest.json" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')"
+ASSET_BLOCK="$(sed -n "/\"${TARGET}\"[[:space:]]*:/,/}/p" "$TMP/latest.json")"
+URL="$(printf '%s\n' "$ASSET_BLOCK" | grep '"url"' | head -1 | sed 's/.*"url": *"\([^"]*\)".*/\1/')"
+SHA256="$(printf '%s\n' "$ASSET_BLOCK" | grep '"sha256"' | head -1 | sed 's/.*"sha256": *"\([^"]*\)".*/\1/')"
+
+if [ -z "$VERSION" ] || [ -z "$URL" ]; then
+  echo "Error: no ${TARGET} asset in ${MANIFEST_URL}" >&2
   exit 1
 fi
 
 echo "Installing kuri ${VERSION} (${TARGET})..."
 
-# ── Download & unpack ─────────────────────────────────────────────────────────
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# ── Download, verify & unpack ─────────────────────────────────────────────────
+curl -fL "$URL" -o "$TMP/kuri.tar.gz"
 
-URL="https://github.com/${REPO}/releases/download/${VERSION}/kuri-${VERSION}-${TARGET}.tar.gz"
-curl -fsSL "$URL" -o "$TMP/kuri.tar.gz"
+if [ -n "$SHA256" ]; then
+  ACTUAL=""
+  if command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "$TMP/kuri.tar.gz" 2>/dev/null | awk '{print $1}')" || ACTUAL=""
+  fi
+  if [ -z "$ACTUAL" ] && command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$TMP/kuri.tar.gz" 2>/dev/null | awk '{print $1}')" || ACTUAL=""
+  fi
+  if [ -z "$ACTUAL" ] && command -v openssl >/dev/null 2>&1; then
+    ACTUAL="$(openssl dgst -sha256 "$TMP/kuri.tar.gz" 2>/dev/null | awk '{print $NF}')" || ACTUAL=""
+  fi
+  if [ -n "$ACTUAL" ] && [ "$ACTUAL" != "$SHA256" ]; then
+    echo "Error: checksum mismatch for ${TARGET}" >&2
+    exit 1
+  fi
+fi
+
 tar -xzf "$TMP/kuri.tar.gz" -C "$TMP"
 
 # ── Install binaries ──────────────────────────────────────────────────────────
@@ -65,6 +89,8 @@ done
 echo ""
 echo "Installed:$INSTALLED"
 echo "Location:  $INSTALL_DIR"
+echo "Channel:   $CHANNEL"
+echo "Version:   $VERSION"
 echo ""
 
 case ":$PATH:" in

--- a/npm/bin/install.js
+++ b/npm/bin/install.js
@@ -4,12 +4,13 @@
 const https = require("https");
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const { execFileSync } = require("child_process");
 const os = require("os");
-const zlib = require("zlib");
 
 const REPO = "justrach/kuri";
 const VERSION = require("../package.json").version;
+const CHANNEL_BASE = process.env.KURI_RELEASE_BASE || `https://raw.githubusercontent.com/${REPO}/release-channel/stable`;
 const BIN_DIR = path.join(__dirname);
 const BIN_PATH = path.join(BIN_DIR, "kuri-agent-bin");
 
@@ -37,13 +38,42 @@ function downloadFile(url, dest) {
   });
 }
 
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => { body += chunk; });
+      res.on("end", () => {
+        try { resolve(JSON.parse(body)); } catch (err) { reject(err); }
+      });
+    }).on("error", reject);
+  });
+}
+
+function sha256File(file) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(file));
+  return hash.digest("hex");
+}
+
 async function main() {
   const target = platform();
-  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/kuri-v${VERSION}-${target}.tar.gz`;
+  const manifestUrl = `${CHANNEL_BASE}/v${VERSION}/manifest.json`;
+  const manifest = await fetchJson(manifestUrl);
+  const asset = manifest.assets && manifest.assets[target];
+  if (!asset || !asset.url) throw new Error(`no ${target} asset in ${manifestUrl}`);
+
+  const url = asset.url;
   const tmp = path.join(os.tmpdir(), `kuri-${Date.now()}.tar.gz`);
 
   console.log(`kuri-agent: downloading ${target} binary...`);
   await downloadFile(url, tmp);
+  if (asset.sha256) {
+    const actual = sha256File(tmp);
+    if (actual !== asset.sha256) throw new Error(`checksum mismatch for ${target}`);
+  }
 
   // Extract kuri-agent from tarball using tar
   fs.mkdirSync(BIN_DIR, { recursive: true });

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 <h1 align="center">Kuri 🌰</h1>
 
 <p align="center">
-  <a href="https://github.com/justrach/kuri/releases/latest"><img src="https://img.shields.io/github/v/release/justrach/kuri?style=flat-square" alt="Release"></a>
+  <a href="https://raw.githubusercontent.com/justrach/kuri/release-channel/stable/latest.json"><img src="https://img.shields.io/badge/stable-v0.3.1-brightgreen?style=flat-square" alt="Stable release"></a>
   <a href="https://github.com/justrach/kuri/blob/main/LICENSE"><img src="https://img.shields.io/github/license/justrach/kuri?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/zig-0.16.0-f7a41d?style=flat-square" alt="Zig">
   <img src="https://img.shields.io/badge/node__modules-0_files-brightgreen?style=flat-square" alt="node_modules">
@@ -96,7 +96,7 @@ curl -fsSL https://raw.githubusercontent.com/justrach/kuri/main/install.sh | sh
 ```
 
 Detects your platform, downloads the right binary, installs to `~/.local/bin`.
-macOS binaries are notarized — no Gatekeeper prompt.
+Downloads come from Kuri's self-managed `release-channel` branch, not GitHub Releases. macOS binaries are signed and notarized.
 
 ### bun / npm
 
@@ -109,7 +109,13 @@ Downloads the correct native binary for your platform at install time.
 
 ### Manual
 
-Download the tarball for your platform from [GitHub Releases](https://github.com/justrach/kuri/releases/latest) and unpack it to your `$PATH`.
+Download the tarball for your platform from the [stable release manifest](https://raw.githubusercontent.com/justrach/kuri/release-channel/stable/latest.json) and unpack it to your `$PATH`.
+
+Stable install URL:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/justrach/kuri/release-channel/stable/install.sh | sh
+```
 
 ### Build from source
 


### PR DESCRIPTION
Publishes and wires Kuri's self-managed release channel instead of GitHub Releases.\n\n### Changes\n- Installers read release-channel manifests from raw GitHub URLs\n- npm installer downloads from versioned channel manifests and verifies SHA-256\n- README points users to the stable channel URL\n- tag release workflow publishes assets/manifests to the release-channel branch instead of creating a GitHub Release\n- macOS release workflow notarization condition now sees Apple secret env when configured\n\n### Already published\n- release-channel branch contains stable v0.3.1 assets and manifests\n- macOS aarch64/x86_64 artifacts were signed and accepted by Apple notarization locally\n\n### Verification\n- sh -n install.sh\n- node --check npm/bin/install.js\n- KURI_INSTALL_DIR=/tmp/kuri-install-test sh install.sh\n- /tmp/kuri-install-test/kuri-fetch --version\n\nDo not merge until CI is green.