### PR TITLE
feat(kuri-mobile): Zig-native iOS + Android device control

### DIFF
--- a/.devin/skills/kuri-android/SKILL.md
+++ b/.devin/skills/kuri-android/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: kuri-android
+description: Use kuri-android to drive Android devices and emulators from the CLI via a native Zig adb wire-protocol client. Tap, swipe (scroll), double-tap, long-press, type text, press hardware/navigation keys, take PNG screenshots, dump the UI tree as a flat element list, launch/terminate apps by package, list installed packages, and list attached devices. Talks adb directly over TCP 127.0.0.1:5037 — never shells out to the `adb` binary at runtime. Trigger phrases include "tap on android phone", "screenshot the emulator", "list connected android devices", "dump the android ui tree", "launch chrome on android".
+---
+
+# kuri-android
+
+Drive Android devices and emulators through the `kuri android`
+subcommand. Implementation lives in `kuri-mobile/src/android/` and
+the main `kuri` binary forwards `kuri android …` to the
+`kuri-mobile` binary.
+
+## When to use this skill
+
+- Enumerate attached Android devices / running emulators.
+- Send taps, swipes, long-presses, key events, or text to a phone.
+- Capture a PNG screenshot with `screencap -p`.
+- Dump the UI tree (via `uiautomator dump`) and act on element refs.
+- Launch / terminate Android apps by package name.
+- List installed packages.
+
+Do **not** use this skill for:
+
+- iOS — use the `kuri-ios` skill instead.
+- Running arbitrary JavaScript on-device (no on-device driver in v1).
+
+## Prerequisites
+
+- `adb` on `$PATH` and an adb server reachable on `127.0.0.1:5037`.
+  Install on macOS with `brew install android-platform-tools` then
+  run `adb start-server` once.
+- A connected device with USB debugging enabled, or a running emulator.
+- `kuri-mobile` built and either on `$PATH` or next to the `kuri`
+  binary (`zig-out/bin/kuri-mobile`).
+
+## Build
+
+```sh
+cd kuri-mobile
+zig build
+cp zig-out/bin/kuri-mobile ../zig-out/bin/
+zig build test    # unit tests: adb framing, uitree parser, usbmuxd plist
+```
+
+## Typical flow
+
+```sh
+# 1. Confirm adb is reachable and a device is listed
+adb start-server
+kuri android list-devices
+# emulator-5554	device
+
+# 2. Launch an app, wait, screenshot
+kuri android launch com.android.chrome
+sleep 3
+kuri android screenshot chrome.png
+
+# 3. Read the UI as a flat element list
+kuri android uitree
+# @e0 Button "Sign in" @100,200-980,300 *clickable
+# @e1 TextView "Welcome" @40,120-700,180
+# ...
+
+# 4. Interact
+kuri android tap 540 1200
+kuri android swipe 100 1500 100 500 250       # scroll up
+kuri android type "hello world"
+kuri android press back
+```
+
+## Full command surface
+
+| Command | Purpose |
+|---|---|
+| `kuri android list-devices` | Enumerate via `host:devices` |
+| `kuri android tap <x> <y>` | Single tap at coords |
+| `kuri android double-tap <x> <y>` | Double tap |
+| `kuri android long-press <x> <y> [ms]` | Long press, default 800 ms |
+| `kuri android swipe <x1> <y1> <x2> <y2> [ms]` | Swipe / scroll (alias: `scroll`) |
+| `kuri android type <text...>` | Type text via `input text` |
+| `kuri android press <button>` | `home|back|menu|enter|tab|space|del|volumeUp|volumeDown|power|dpadUp|dpadDown|dpadLeft|dpadRight|dpadCenter` |
+| `kuri android screenshot [path.png]` | PNG from `exec:screencap -p` |
+| `kuri android uitree` | Flat element list from `uiautomator dump` |
+| `kuri android launch <package>` | `monkey -p <pkg> -c LAUNCHER 1` |
+| `kuri android terminate <package>` | `am force-stop` |
+| `kuri android list-apps` | `pm list packages` |
+
+Global flag: `--serial <id>` — target a specific device. Omit when
+exactly one device is attached.
+
+## Native Zig surfaces (honesty)
+
+- `adb` **wire protocol** is re-implemented in Zig. We open a libc
+  TCP socket to `127.0.0.1:5037`, speak the 4-hex-digit length
+  framing, issue `host:devices`, `host:transport:<serial>`, `shell:`
+  and `exec:` services, and read framed or stream responses. We
+  never shell out to the `adb` binary at runtime.
+- **UI tree parser** is a Zig XML scanner that flattens
+  `uiautomator dump` XML into a stable `@e<n>` element list with
+  bounds, text, content-desc, resource-id, clickable, enabled.
+- Device-side commands (`screencap`, `uiautomator dump`, `input`,
+  `monkey`, `am`, `pm`) are Android OS binaries that the device's
+  shell runs — we just frame the requests over adb from Zig.
+
+## Intentional limits
+
+- ASCII-only text typing. Non-ASCII needs an IME workaround, not
+  bundled.
+- No on-device driver, so no `run_code` JavaScript sandbox.
+- No bundled emulator image — you provide the device or the emulator.
+
+## Common errors and what they mean
+
+| Message | Fix |
+|---|---|
+| `could not reach adb server on 127.0.0.1:5037. Is 'adb start-server' running?` | Run `adb start-server`. |
+| `no device attached. Plug in a phone with USB debugging enabled, or boot an emulator.` | Connect a device or boot an emulator; confirm with `adb devices`. |
+| `adb returned FAIL — see the warning log above for details.` | Check the preceding warn-level log line; usually device state (unauthorized, offline). |
+| `unknown button name; see 'kuri-mobile android' for the supported list.` | Use one of the documented button names. |

--- a/.devin/skills/kuri-ios/SKILL.md
+++ b/.devin/skills/kuri-ios/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: kuri-ios
+description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, and list installed apps. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap, swipe, type, and UI tree on real devices are NOT supported in v1 because no XCUITest bundle is installed (driverless by design). Trigger phrases include "screenshot the iPhone sim", "open Safari on simulator", "launch iOS Settings", "list booted simulators", "navigate the iOS simulator to https://...".
+---
+
+# kuri-ios
+
+Drive iOS Simulators (and, where possible, real iPhones) through the
+`kuri ios` subcommand. Implementation lives in
+`kuri-mobile/src/ios/` and the main `kuri` binary forwards
+`kuri ios …` to the `kuri-mobile` binary.
+
+## When to use this skill
+
+- Boot an iOS Simulator, open Safari to a URL, screenshot the result.
+- Launch or terminate any iOS app by bundle id on the Simulator.
+- List installed apps on the Simulator.
+- Enumerate real iPhones plugged in over USB (via usbmuxd, native Zig).
+- Launch / terminate an app on a real iPhone via `xcrun devicectl`.
+
+Do **not** use this skill for:
+
+- Tapping, swiping, typing, or reading UI tree on a real iPhone
+  (requires XCUITest; intentionally not in v1).
+- Running JS inside a page — that's a browser task, use kuri-agent.
+- Android — use the `kuri-android` skill instead.
+
+## Prerequisites
+
+- Xcode installed (`xcrun`, `simctl`, `devicectl`).
+- At least one iOS Simulator runtime installed. `xcrun simctl runtime
+  list` must show at least one `(Ready)` entry. If it's empty:
+  `xcodebuild -downloadPlatform iOS` (one-time ~7 GB download).
+- `kuri-mobile` built and either on `$PATH` or next to the `kuri`
+  binary (`zig-out/bin/kuri-mobile`).
+
+## Build
+
+```sh
+cd kuri-mobile
+zig build
+cp zig-out/bin/kuri-mobile ../zig-out/bin/
+zig build test    # optional: unit tests for adb framing, uitree parser, usbmuxd plist scan
+```
+
+## Typical flow
+
+```sh
+# 1. List and boot a sim
+kuri ios list-devices
+xcrun simctl create "scratch" com.apple.CoreSimulator.SimDeviceType.iPhone-16 com.apple.CoreSimulator.SimRuntime.iOS-26-4
+kuri ios boot --udid <UDID>
+
+# 2. Navigate and screenshot (auto-resolves the booted sim — no --udid needed)
+kuri ios openurl https://news.ycombinator.com
+sleep 3   # let the page settle
+kuri ios screenshot hn.png
+
+# 3. Launch a built-in app, screenshot
+kuri ios launch com.apple.Preferences
+sleep 2
+kuri ios screenshot settings.png
+
+# 4. Open any URL scheme (not just https/http)
+kuri ios openurl "maps://?q=San%20Francisco"
+```
+
+## Full command surface
+
+| Command | Purpose |
+|---|---|
+| `kuri ios list-devices` | Sims (from simctl JSON) + real devices (from usbmuxd) |
+| `kuri ios boot --udid <U>` | Boot a simulator |
+| `kuri ios shutdown --udid <U>` | Shut down a simulator |
+| `kuri ios openurl <url>` | Open URL (auto-resolves booted sim). Alias: `navigate` |
+| `kuri ios launch <bundle-id>` | Launch app on booted sim |
+| `kuri ios launch --device --udid <U> <bundle-id>` | Launch on real iPhone via devicectl |
+| `kuri ios terminate <bundle-id>` | Kill app on booted sim |
+| `kuri ios terminate --device --udid <U> <bundle-id>` | Kill on real device |
+| `kuri ios screenshot [path.png]` | PNG from booted sim (auto-resolves) |
+| `kuri ios list-apps --udid <U>` | List installed apps on sim |
+
+## Intentional limits (don't claim parity with upstream)
+
+- `tap`, `swipe`, `type`, `uitree` return an explicit
+  "not supported in v1, requires XCUITest" error — on purpose.
+- Real-device screenshot is unavailable for the same reason.
+- There is no on-device `run_code` sandbox.
+
+If a user needs any of the above, the route forward is the v2
+"vendor on-device drivers" path described in `kuri-mobile/README.md`,
+not this skill.
+
+## Native vs shelled-out surfaces (honesty)
+
+| Surface | How it's implemented |
+|---|---|
+| simctl device listing | libc fork/exec `xcrun simctl list devices --json`, parse JSON in Zig |
+| usbmuxd real-device listing | native Zig Unix-socket client, plist scan |
+| openurl / launch / terminate / screenshot | shell out to `xcrun simctl` / `xcrun devicectl` |
+| Resolve "booted sim" | iterate parsed list in Zig, match `state == "Booted"` |
+
+Apple's iOS Simulator runtime renders the screens — Kuri orchestrates.

--- a/.devin/skills/kuri-mobile/SKILL.md
+++ b/.devin/skills/kuri-mobile/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: kuri-mobile
+description: Umbrella skill for mobile device control in the kuri ecosystem. Points to kuri-ios (iOS Simulator + real-device listing) and kuri-android (native Zig adb client). Use this when the user asks about "mobile automation" generally, or hasn't specified a platform. For platform-specific work prefer the `kuri-ios` or `kuri-android` skill directly.
+---
+
+# kuri-mobile (umbrella)
+
+`kuri-mobile` is the Zig-native subproject at `kuri-mobile/` that
+adds mobile device control to the kuri browser-automation stack.
+Inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp),
+reimplemented in Zig with no Bun, Node, Gradle, or Xcode in the
+build path.
+
+**Use the platform-specific skills** for actual work:
+
+- **`kuri-ios`** — iOS Simulator (boot, openurl, launch, terminate,
+  screenshot, list-apps) + real-iPhone listing (usbmuxd) +
+  real-iPhone launch/terminate (devicectl).
+- **`kuri-android`** — Android devices and emulators (tap, swipe,
+  type, press, screenshot, uitree, launch, terminate, list-apps)
+  via a native Zig adb wire-protocol client.
+
+## Build once, use everywhere
+
+```sh
+cd kuri-mobile
+zig build
+zig build test
+cp zig-out/bin/kuri-mobile ../zig-out/bin/    # so `kuri ios` / `kuri android` work
+```
+
+The main `kuri` binary forwards `kuri android <cmd>` and
+`kuri ios <cmd>` to `kuri-mobile` (it `execvp`s it from the same
+directory or `$PATH`). So either invocation works:
+
+```sh
+kuri android list-devices
+kuri-mobile android list-devices
+```
+
+## Driverless scope (important)
+
+We deliberately do **not** install an on-device driver app.
+Consequences you must be honest about:
+
+- No `run_code` JavaScript sandbox.
+- No tap / swipe / type / uitree on real iOS devices (that would
+  require a vendored XCUITest bundle; intentionally out of scope).
+- Android gets nearly the full upstream tool surface because its
+  shell already exposes `input`, `screencap`, `uiautomator dump`,
+  `monkey`, `am`, `pm`.
+
+Full parity matrix vs `mobile-device-mcp`: see
+`kuri-mobile/README.md`.
+
+## When to reach for which skill
+
+| User asks about… | Invoke |
+|---|---|
+| "iPhone", "iOS", "sim", "Safari on simulator", "iPad" | `kuri-ios` |
+| "Android", "adb", "emulator", "Pixel", "Galaxy", "APK" | `kuri-android` |
+| "mobile" without specifying | either — ask first, or default to this umbrella note |
+| Browser automation (Chrome, CDP) | **not** a mobile skill — use `kuri-server`, `kuri-agent`, or `kuri-browse` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, kuri-browser]
   pull_request:
-    branches: [main]
+    branches: [main, kuri-browser]
 
 jobs:
   build-and-test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,23 @@
 
 Instructions for AI coding agents working in this repository.
 
+## TurboDB Coordination
+
+For multi-agent or long-running repo work, prefer `tools/turbodb_coord.py` over
+ad hoc local JSON logs. It writes structured events to a repo-scoped TurboDB
+collection and can list, summarize, or wait for worker status.
+
+- Never commit TurboDB API keys. Pass credentials through `TURBODB_API_KEY`.
+- Use `TURBODB_GATEWAY_URL` for non-local gateways and `TURBODB_COLLECTION`
+  when a task needs an isolated collection; default collection is
+  `kuri_repo_coord`.
+- Log start and completion events with explicit `role`, `task` or `event`,
+  `status`, touched files, and a short note.
+- When workers own specific files, do not edit those files from the parent
+  until their completion events are present or the worker is explicitly stopped.
+- Use `summary` or `wait` before merging parallel work so stale worker notes do
+  not get mistaken for current state.
+
 ## Benchmark Honesty
 
 Never present a benchmark, parity score, or competitor comparison as stronger than the evidence supports.
@@ -75,3 +92,35 @@ cd kuri-browser
 ./zig-out/bin/kuri-browser bench --kuri-base http://127.0.0.1:8080
 ./zig-out/bin/kuri-browser parity --kuri-base http://127.0.0.1:8080
 ```
+
+## kuri-mobile (Android / iOS device automation)
+
+The `kuri-mobile/` subproject adds Zig-native device control alongside the
+browser stack. It is inspired by
+[`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp) but is
+**driverless**: no on-device app, no Bun, no Gradle, no Xcode-time builds.
+
+Verification:
+
+```sh
+cd kuri-mobile
+zig build
+zig build test
+./zig-out/bin/kuri-mobile android list-devices  # needs `adb start-server`
+./zig-out/bin/kuri-mobile ios list-devices      # sims + real devices
+```
+
+The main `kuri` binary forwards `kuri android <cmd>` and `kuri ios <cmd>`
+to `kuri-mobile`. Make sure `kuri-mobile` is on PATH or installed next to
+the `kuri` binary.
+
+Honesty rules when reporting this work:
+
+- Never claim parity with `mobile-device-mcp` — kuri-mobile v1 has no
+  on-device driver, so no `run_code`, and no real-device iOS UI tree
+  / tap / swipe / type. Those commands intentionally return an error.
+- Distinguish native Zig surfaces (adb host protocol, Android XML
+  parser, usbmuxd ListDevices) from shelled-out paths
+  (`xcrun simctl`, `xcrun devicectl`).
+- Do not present this as a replacement for Appium, Maestro, or
+  XCUITest-based stacks.

--- a/kuri-mobile/README.md
+++ b/kuri-mobile/README.md
@@ -1,0 +1,119 @@
+# kuri-mobile
+
+Native Zig CLI for driving Android and iOS devices, integrated into the
+`kuri` ecosystem alongside `kuri-browser`.
+
+Inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp);
+the host-side surface (tap, screenshot, uitree, launch/terminate, etc.)
+is reimplemented in Zig with no Bun, Node, Gradle, or Xcode build
+dependencies. See **Honest scope** below for what we deliberately do
+*not* implement.
+
+## Layout
+
+```
+kuri-mobile/
+  src/
+    main.zig                 # `kuri-mobile <android|ios> ...`
+    common/
+      io.zig                 # libc-backed stdout/stderr/runCommand
+      uitree.zig             # unified flat element list (Android XML parser)
+    android/
+      adb.zig                # native Zig client for the adb wire protocol
+      driver.zig             # tap/swipe/type/screencap/uitree/launch/...
+      cli.zig                # `kuri-mobile android` dispatcher
+    ios/
+      simctl.zig             # iOS Simulator via `xcrun simctl`
+      usbmux.zig             # native Zig usbmuxd ListDevices client
+      devicectl.zig          # real-device launch/terminate via `xcrun devicectl`
+      cli.zig                # `kuri-mobile ios` dispatcher
+```
+
+## Usage
+
+```sh
+zig build
+./zig-out/bin/kuri-mobile android list-devices
+./zig-out/bin/kuri-mobile android tap 540 1200
+./zig-out/bin/kuri-mobile android screenshot screen.png
+./zig-out/bin/kuri-mobile android uitree
+
+./zig-out/bin/kuri-mobile ios list-devices
+./zig-out/bin/kuri-mobile ios screenshot --udid <UDID> --simulator out.png
+./zig-out/bin/kuri-mobile ios launch    --udid <UDID> --simulator com.apple.Preferences
+```
+
+The main `kuri` binary also forwards `kuri android …` and `kuri ios …`
+to this binary (it execvp's `kuri-mobile` from the same directory or
+$PATH), so both invocations work:
+
+```sh
+kuri android list-devices
+kuri-mobile android list-devices
+```
+
+## Prerequisites
+
+- Android: a running `adb server` on `127.0.0.1:5037`. Install Android
+  platform-tools (`brew install android-platform-tools`) and run
+  `adb start-server` once.
+- iOS Simulator: Xcode (`xcrun`, `simctl`).
+- iOS real device: Xcode (`devicectl`). The `kuri-mobile` binary itself
+  does not require `libimobiledevice`; we only speak usbmuxd's
+  `ListDevices` message natively, then delegate launch/terminate to
+  Apple's `devicectl`.
+
+## Honest scope (read this before comparing to upstream)
+
+This is the **driverless** flavor: we never install an on-device app.
+Compared to `mobile-device-mcp`:
+
+| Capability                       | kuri-mobile v1 | upstream `mobile-device-mcp` |
+|----------------------------------|---|---|
+| Android tap/swipe/type           | ✅ via `input` | ✅ via UIAutomator |
+| Android screenshot               | ✅ via `screencap` | ✅ |
+| Android UI tree                  | ✅ via `uiautomator dump` | ✅ via UIAutomator |
+| Android launch / terminate / list-apps | ✅ via `monkey`/`am`/`pm` | ✅ |
+| iOS Simulator screenshot/launch  | ✅ via `simctl`        | ✅ |
+| iOS real-device tap/swipe/uitree | ❌ requires XCUITest    | ✅ via XCUITest bundle |
+| `run_code` JS sandbox (Rhino/JSC)| ❌ requires on-device driver | ✅ |
+| MCP server (JSON-RPC stdio)      | ❌ not yet (CLI only)   | ✅ |
+| Multi-device port allocation/auth| ❌ not needed (no on-device server) | ✅ |
+
+If you need feature-parity with on-device execution and rich iOS UI
+trees on real devices, you have to either:
+
+1. Vendor `mobile-device-mcp` upstream and run it as a subprocess, or
+2. Add a future v2 to kuri-mobile that ships its own Kotlin/Swift
+   on-device drivers (significantly larger build).
+
+## Native Zig surfaces vs delegated surfaces
+
+| Layer                      | Implementation                                |
+|----------------------------|-----------------------------------------------|
+| adb host protocol          | **native Zig** (libc sockets, `host:` + `host:transport:` + `shell:` + `exec:`) |
+| Android UI tree XML parse  | **native Zig** scanner                        |
+| iOS usbmuxd `ListDevices`  | **native Zig** (libc Unix socket, plist scan) |
+| iOS Simulator commands     | shell out to `xcrun simctl`                   |
+| iOS real device launch     | shell out to `xcrun devicectl`                |
+| Android `screencap`/`uiautomator dump` etc | server-side commands the device's own shell runs; we just frame them over adb in Zig |
+
+## Tests
+
+```sh
+zig build test
+```
+
+Covers adb framing, parseDevices, uitree parser, and usbmuxd plist
+scanning. No live device required.
+
+## Cache / benchmark honesty
+
+This subproject does not yet have published benchmarks. If you add any,
+follow the rules in `../AGENTS.md` (Benchmark Honesty + Cache
+Disclosure) and clearly label which path was exercised:
+
+- adb-native (Zig) vs `adb` shell-out (we never shell out to `adb`)
+- simctl-shellout (iOS sim)
+- devicectl-shellout (iOS real-device launch/terminate)
+- usbmuxd-native (Zig) for `ios list-devices`

--- a/kuri-mobile/build.zig
+++ b/kuri-mobile/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const root_mod = b.createModule(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "kuri-mobile",
+        .root_module = root_mod,
+    });
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| run_cmd.addArgs(args);
+    const run_step = b.step("run", "Run kuri-mobile");
+    run_step.dependOn(&run_cmd.step);
+
+    const unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&b.addRunArtifact(unit_tests).step);
+}

--- a/kuri-mobile/build.zig.zon
+++ b/kuri-mobile/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .kuri_mobile,
+    .version = "0.0.1",
+    .dependencies = .{},
+    .fingerprint = 0x41cfa5929f72d020,
+    .minimum_zig_version = "0.16.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}

--- a/kuri-mobile/src/android/adb.zig
+++ b/kuri-mobile/src/android/adb.zig
@@ -1,0 +1,187 @@
+//! Native Zig client for the adb host protocol (talks to a local adb server).
+//!
+//! The adb server listens on TCP 127.0.0.1:5037 by default. Each request is:
+//!     <4 hex chars: payload length><ASCII payload>
+//! The server replies with either "OKAY" or "FAIL<4hex><msg>". After OKAY,
+//! the connection is either closed (for "host:" queries that return data
+//! framed as <4hex><payload>) or transitioned into a transport for the
+//! selected device, after which subsequent commands target that device.
+//!
+//! Reference: SERVICES.TXT in the AOSP adb sources.
+//!
+//! We talk libc sockets directly (matching the rest of kuri's IO style)
+//! to avoid std.Io churn between Zig versions.
+
+const std = @import("std");
+const posix = std.posix;
+
+pub const default_port: u16 = 5037;
+
+const c_connect = @extern(*const fn (std.c.fd_t, *const anyopaque, posix.socklen_t) callconv(.c) c_int, .{ .name = "connect" });
+
+pub const Error = error{
+    AdbServerUnreachable,
+    AdbProtocolError,
+    AdbCommandFailed,
+    DeviceNotFound,
+    UnexpectedEof,
+} || std.mem.Allocator.Error;
+
+pub const Client = struct {
+    gpa: std.mem.Allocator,
+    host: []const u8 = "127.0.0.1",
+    port: u16 = default_port,
+
+    pub fn init(gpa: std.mem.Allocator) Client {
+        return .{ .gpa = gpa };
+    }
+
+    fn connect(self: *Client) !std.c.fd_t {
+        const raw_fd = std.c.socket(posix.AF.INET, posix.SOCK.STREAM, 0);
+        if (raw_fd < 0) return Error.AdbServerUnreachable;
+        const fd: std.c.fd_t = raw_fd;
+        errdefer _ = std.c.close(fd);
+
+        var sa: posix.sockaddr.in = .{
+            .port = std.mem.nativeToBig(u16, self.port),
+            .addr = std.mem.nativeToBig(u32, 0x7F000001), // 127.0.0.1
+        };
+        if (c_connect(fd, @ptrCast(&sa), @sizeOf(posix.sockaddr.in)) != 0) {
+            return Error.AdbServerUnreachable;
+        }
+        return fd;
+    }
+
+    pub fn hostQuery(self: *Client, cmd: []const u8) ![]u8 {
+        const fd = try self.connect();
+        defer _ = std.c.close(fd);
+        try writeRequest(fd, cmd);
+        try expectOkay(fd, self.gpa);
+        return try readFramed(fd, self.gpa);
+    }
+
+    pub fn deviceExec(self: *Client, serial: []const u8, service: []const u8) ![]u8 {
+        const fd = try self.connect();
+        defer _ = std.c.close(fd);
+
+        var buf: [128]u8 = undefined;
+        const transport = try std.fmt.bufPrint(&buf, "host:transport:{s}", .{serial});
+        try writeRequest(fd, transport);
+        try expectOkay(fd, self.gpa);
+
+        try writeRequest(fd, service);
+        try expectOkay(fd, self.gpa);
+
+        return try readToEnd(fd, self.gpa);
+    }
+};
+
+fn writeAll(fd: std.c.fd_t, data: []const u8) !void {
+    var off: usize = 0;
+    while (off < data.len) {
+        const n = std.c.write(fd, data[off..].ptr, data.len - off);
+        if (n <= 0) return Error.AdbProtocolError;
+        off += @intCast(n);
+    }
+}
+
+fn writeRequest(fd: std.c.fd_t, payload: []const u8) !void {
+    if (payload.len > 0xFFFF) return Error.AdbProtocolError;
+    var hdr: [4]u8 = undefined;
+    _ = std.fmt.bufPrint(&hdr, "{x:0>4}", .{payload.len}) catch unreachable;
+    try writeAll(fd, &hdr);
+    try writeAll(fd, payload);
+}
+
+fn expectOkay(fd: std.c.fd_t, gpa: std.mem.Allocator) !void {
+    var status: [4]u8 = undefined;
+    try readExact(fd, &status);
+    if (std.mem.eql(u8, &status, "OKAY")) return;
+    if (std.mem.eql(u8, &status, "FAIL")) {
+        const msg = readFramed(fd, gpa) catch return Error.AdbCommandFailed;
+        defer gpa.free(msg);
+        std.log.warn("adb FAIL: {s}", .{msg});
+        return Error.AdbCommandFailed;
+    }
+    return Error.AdbProtocolError;
+}
+
+fn readFramed(fd: std.c.fd_t, gpa: std.mem.Allocator) ![]u8 {
+    var lenbuf: [4]u8 = undefined;
+    try readExact(fd, &lenbuf);
+    const n = std.fmt.parseInt(usize, &lenbuf, 16) catch return Error.AdbProtocolError;
+    const out = try gpa.alloc(u8, n);
+    errdefer gpa.free(out);
+    try readExact(fd, out);
+    return out;
+}
+
+fn readExact(fd: std.c.fd_t, dst: []u8) !void {
+    var off: usize = 0;
+    while (off < dst.len) {
+        const n = std.c.read(fd, dst[off..].ptr, dst.len - off);
+        if (n <= 0) return Error.UnexpectedEof;
+        off += @intCast(n);
+    }
+}
+
+fn readToEnd(fd: std.c.fd_t, gpa: std.mem.Allocator) ![]u8 {
+    var list: std.ArrayList(u8) = .empty;
+    defer list.deinit(gpa);
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.c.read(fd, &buf, buf.len);
+        if (n <= 0) break;
+        try list.appendSlice(gpa, buf[0..@intCast(n)]);
+    }
+    return try list.toOwnedSlice(gpa);
+}
+
+pub const Device = struct {
+    serial: []const u8,
+    state: []const u8,
+};
+
+pub fn parseDevices(gpa: std.mem.Allocator, raw: []const u8) ![]Device {
+    var list: std.ArrayList(Device) = .empty;
+    errdefer list.deinit(gpa);
+    var it = std.mem.splitScalar(u8, raw, '\n');
+    while (it.next()) |line| {
+        if (line.len == 0) continue;
+        const tab = std.mem.indexOfScalar(u8, line, '\t') orelse continue;
+        try list.append(gpa, .{
+            .serial = try gpa.dupe(u8, line[0..tab]),
+            .state = try gpa.dupe(u8, line[tab + 1 ..]),
+        });
+    }
+    return try list.toOwnedSlice(gpa);
+}
+
+pub fn freeDevices(gpa: std.mem.Allocator, devs: []Device) void {
+    for (devs) |d| {
+        gpa.free(d.serial);
+        gpa.free(d.state);
+    }
+    gpa.free(devs);
+}
+
+// ---------------------------------------------------------------- tests
+
+test "parseDevices parses tab-separated lines" {
+    const raw =
+        "emulator-5554\tdevice\n" ++
+        "ABCD1234\tunauthorized\n";
+    const devs = try parseDevices(std.testing.allocator, raw);
+    defer freeDevices(std.testing.allocator, devs);
+    try std.testing.expectEqual(@as(usize, 2), devs.len);
+    try std.testing.expectEqualStrings("emulator-5554", devs[0].serial);
+    try std.testing.expectEqualStrings("device", devs[0].state);
+    try std.testing.expectEqualStrings("ABCD1234", devs[1].serial);
+    try std.testing.expectEqualStrings("unauthorized", devs[1].state);
+}
+
+test "writeRequest formats 4-hex length prefix" {
+    const out = try std.fmt.allocPrint(std.testing.allocator, "{x:0>4}{s}", .{ "host:version".len, "host:version" });
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("000chost:version", out);
+}

--- a/kuri-mobile/src/android/cli.zig
+++ b/kuri-mobile/src/android/cli.zig
@@ -1,0 +1,202 @@
+//! `kuri-mobile android <cmd> ...` dispatcher.
+
+const std = @import("std");
+const adb = @import("adb.zig");
+const driver_mod = @import("driver.zig");
+const uitree = @import("../common/uitree.zig");
+const io = @import("../common/io.zig");
+
+pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
+    if (args.len == 0) {
+        try printUsage();
+        return 1;
+    }
+
+    const sub = args[0];
+    const rest = args[1..];
+
+    if (std.mem.eql(u8, sub, "list-devices") or std.mem.eql(u8, sub, "devices")) {
+        return cmdListDevices(gpa);
+    }
+
+    var serial_opt: ?[]const u8 = null;
+    var idx: usize = 0;
+    while (idx < rest.len and std.mem.startsWith(u8, rest[idx], "--")) : (idx += 2) {
+        if (std.mem.eql(u8, rest[idx], "--serial")) {
+            if (idx + 1 >= rest.len) return errMissing("--serial");
+            serial_opt = rest[idx + 1];
+        } else {
+            io.writeStderr("unknown flag\n");
+            return 2;
+        }
+    }
+    const cmd_args = rest[idx..];
+
+    const serial = serial_opt orelse try resolveDefaultSerial(gpa);
+    defer if (serial_opt == null) gpa.free(serial);
+
+    var d = driver_mod.Driver.init(gpa, serial);
+
+    if (std.mem.eql(u8, sub, "tap")) return cmdTap(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "double-tap")) return cmdDoubleTap(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "long-press")) return cmdLongPress(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "swipe") or std.mem.eql(u8, sub, "scroll")) return cmdSwipe(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "type")) return cmdType(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "press")) return cmdPress(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "screenshot")) return cmdScreenshot(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "uitree")) return cmdUitree(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "launch")) return cmdLaunch(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "terminate")) return cmdTerminate(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "list-apps")) return cmdListApps(gpa, &d);
+
+    try printUsage();
+    return 1;
+}
+
+fn errMissing(name: []const u8) u8 {
+    var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_impl.deinit();
+    io.printStderr(arena_impl.allocator(), "missing argument: {s}\n", .{name});
+    return 2;
+}
+
+fn cmdListDevices(gpa: std.mem.Allocator) !u8 {
+    var c = adb.Client.init(gpa);
+    const raw = try c.hostQuery("host:devices");
+    defer gpa.free(raw);
+    const devs = try adb.parseDevices(gpa, raw);
+    defer adb.freeDevices(gpa, devs);
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    for (devs) |d| io.printStdout(arena_impl.allocator(), "{s}\t{s}\n", .{ d.serial, d.state });
+    return 0;
+}
+
+fn resolveDefaultSerial(gpa: std.mem.Allocator) ![]const u8 {
+    var c = adb.Client.init(gpa);
+    const raw = try c.hostQuery("host:devices");
+    defer gpa.free(raw);
+    const devs = try adb.parseDevices(gpa, raw);
+    defer adb.freeDevices(gpa, devs);
+    for (devs) |d| {
+        if (std.mem.eql(u8, d.state, "device")) return try gpa.dupe(u8, d.serial);
+    }
+    return error.DeviceNotFound;
+}
+
+fn cmdTap(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 2) return errMissing("x y");
+    const x = try std.fmt.parseInt(i32, args[0], 10);
+    const y = try std.fmt.parseInt(i32, args[1], 10);
+    try d.tap(gpa, x, y);
+    return 0;
+}
+
+fn cmdDoubleTap(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 2) return errMissing("x y");
+    const x = try std.fmt.parseInt(i32, args[0], 10);
+    const y = try std.fmt.parseInt(i32, args[1], 10);
+    try d.doubleTap(gpa, x, y);
+    return 0;
+}
+
+fn cmdLongPress(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 2) return errMissing("x y [duration_ms]");
+    const x = try std.fmt.parseInt(i32, args[0], 10);
+    const y = try std.fmt.parseInt(i32, args[1], 10);
+    const ms: u32 = if (args.len >= 3) try std.fmt.parseInt(u32, args[2], 10) else 800;
+    try d.longPress(gpa, x, y, ms);
+    return 0;
+}
+
+fn cmdSwipe(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 4) return errMissing("x1 y1 x2 y2 [duration_ms]");
+    const x1 = try std.fmt.parseInt(i32, args[0], 10);
+    const y1 = try std.fmt.parseInt(i32, args[1], 10);
+    const x2 = try std.fmt.parseInt(i32, args[2], 10);
+    const y2 = try std.fmt.parseInt(i32, args[3], 10);
+    const ms: u32 = if (args.len >= 5) try std.fmt.parseInt(u32, args[4], 10) else 300;
+    try d.swipe(gpa, x1, y1, x2, y2, ms);
+    return 0;
+}
+
+fn cmdType(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("text");
+    const text = try std.mem.join(gpa, " ", args);
+    defer gpa.free(text);
+    try d.typeText(gpa, text);
+    return 0;
+}
+
+fn cmdPress(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("button");
+    try d.pressButton(gpa, args[0]);
+    return 0;
+}
+
+fn cmdScreenshot(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    const path = if (args.len >= 1) args[0] else "screenshot.png";
+    const bytes = try d.screenshot(gpa);
+    defer gpa.free(bytes);
+    try io.writeFile(path, bytes);
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    io.printStderr(arena_impl.allocator(), "wrote {d} bytes to {s}\n", .{ bytes.len, path });
+    return 0;
+}
+
+fn cmdUitree(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    _ = args;
+    const xml = try d.uitreeXml(gpa);
+    defer gpa.free(xml);
+    const els = try uitree.parseAndroidXml(gpa, xml);
+    defer uitree.freeElements(gpa, els);
+    const text = try uitree.renderText(gpa, els);
+    defer gpa.free(text);
+    io.writeStdout(text);
+    return 0;
+}
+
+fn cmdLaunch(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("package");
+    try d.launchApp(gpa, args[0]);
+    return 0;
+}
+
+fn cmdTerminate(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("package");
+    try d.terminateApp(gpa, args[0]);
+    return 0;
+}
+
+fn cmdListApps(gpa: std.mem.Allocator, d: *driver_mod.Driver) !u8 {
+    const out = try d.listApps(gpa);
+    defer gpa.free(out);
+    io.writeStdout(out);
+    return 0;
+}
+
+fn printUsage() !void {
+    io.writeStderr(
+        \\kuri-mobile android <cmd> [args]
+        \\
+        \\Commands:
+        \\  list-devices
+        \\  tap <x> <y>
+        \\  double-tap <x> <y>
+        \\  long-press <x> <y> [ms]
+        \\  swipe <x1> <y1> <x2> <y2> [ms]
+        \\  type <text...>
+        \\  press <button>          # home|back|menu|enter|tab|space|del|volumeUp|volumeDown|power|dpad{Up,Down,Left,Right,Center}
+        \\  screenshot [path.png]
+        \\  uitree
+        \\  launch <package>
+        \\  terminate <package>
+        \\  list-apps
+        \\
+        \\Global flags:
+        \\  --serial <id>           # target device (auto-picks single attached device)
+        \\
+    );
+}

--- a/kuri-mobile/src/android/driver.zig
+++ b/kuri-mobile/src/android/driver.zig
@@ -1,0 +1,181 @@
+//! High-level Android device driver. Composes adb shell commands.
+//!
+//! Implements the subset of mobile-device-mcp tools that work without an
+//! on-device driver app:
+//!   - tap, double_tap, long_press, swipe (input tap/swipe/keyevent)
+//!   - type_text             (input text)
+//!   - press_button          (input keyevent KEYCODE_*)
+//!   - screenshot            (exec:screencap -p, raw PNG bytes)
+//!   - uitree                (exec:uiautomator dump /dev/tty)
+//!   - launch_app            (monkey -p <pkg> 1)
+//!   - terminate_app         (am force-stop)
+//!   - list_apps             (pm list packages)
+//!   - list_devices          (host:devices)
+
+const std = @import("std");
+const adb = @import("adb.zig");
+
+extern "c" fn usleep(usec: u32) c_int;
+
+pub const Driver = struct {
+    client: adb.Client,
+    serial: []const u8,
+
+    pub fn init(gpa: std.mem.Allocator, serial: []const u8) Driver {
+        return .{ .client = adb.Client.init(gpa), .serial = serial };
+    }
+
+    fn shell(self: *Driver, gpa: std.mem.Allocator, cmd: []const u8) ![]u8 {
+        _ = gpa; // client owns its own allocator
+        var buf: [1024]u8 = undefined;
+        const svc = try std.fmt.bufPrint(&buf, "shell:{s}", .{cmd});
+        return try self.client.deviceExec(self.serial, svc);
+    }
+
+    fn exec(self: *Driver, gpa: std.mem.Allocator, cmd: []const u8) ![]u8 {
+        _ = gpa;
+        var buf: [1024]u8 = undefined;
+        const svc = try std.fmt.bufPrint(&buf, "exec:{s}", .{cmd});
+        return try self.client.deviceExec(self.serial, svc);
+    }
+
+    pub fn tap(self: *Driver, gpa: std.mem.Allocator, x: i32, y: i32) !void {
+        var buf: [128]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "input tap {d} {d}", .{ x, y });
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    pub fn doubleTap(self: *Driver, gpa: std.mem.Allocator, x: i32, y: i32) !void {
+        try self.tap(gpa, x, y);
+        _ = usleep(80_000); // 80ms
+        try self.tap(gpa, x, y);
+    }
+
+    pub fn longPress(self: *Driver, gpa: std.mem.Allocator, x: i32, y: i32, duration_ms: u32) !void {
+        var buf: [128]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "input swipe {d} {d} {d} {d} {d}", .{ x, y, x, y, duration_ms });
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    pub fn swipe(self: *Driver, gpa: std.mem.Allocator, x1: i32, y1: i32, x2: i32, y2: i32, duration_ms: u32) !void {
+        var buf: [128]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "input swipe {d} {d} {d} {d} {d}", .{ x1, y1, x2, y2, duration_ms });
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    pub fn typeText(self: *Driver, gpa: std.mem.Allocator, text: []const u8) !void {
+        // `input text` requires spaces escaped as %s and special chars limited.
+        const escaped = try escapeForInputText(gpa, text);
+        defer gpa.free(escaped);
+        const cmd = try std.fmt.allocPrint(gpa, "input text {s}", .{escaped});
+        defer gpa.free(cmd);
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    pub fn pressButton(self: *Driver, gpa: std.mem.Allocator, name: []const u8) !void {
+        const keycode = mapButton(name) orelse return error.UnknownButton;
+        var buf: [64]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "input keyevent {s}", .{keycode});
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    /// Returns raw PNG bytes via `exec:screencap -p`. Caller frees.
+    /// We use `exec:` (not `shell:`) so adb does not perform CRLF translation
+    /// on the binary PNG bytes — `shell:` would corrupt the output.
+    pub fn screenshot(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
+        return try self.exec(gpa, "screencap -p");
+    }
+
+    /// Dump UI tree XML via uiautomator.
+    pub fn uitreeXml(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
+        // `uiautomator dump /dev/tty` writes XML to stdout but also a status
+        // line; we strip the trailing "UI hierchary dumped to: /dev/tty" if
+        // present.
+        const raw = try self.shell(gpa, "uiautomator dump /dev/tty 2>/dev/null");
+        if (std.mem.lastIndexOf(u8, raw, "</hierarchy>")) |end| {
+            const cut = end + "</hierarchy>".len;
+            const trimmed = try gpa.dupe(u8, raw[0..cut]);
+            gpa.free(raw);
+            return trimmed;
+        }
+        return raw;
+    }
+
+    pub fn launchApp(self: *Driver, gpa: std.mem.Allocator, pkg: []const u8) !void {
+        const cmd = try std.fmt.allocPrint(gpa, "monkey -p {s} -c android.intent.category.LAUNCHER 1", .{pkg});
+        defer gpa.free(cmd);
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    pub fn terminateApp(self: *Driver, gpa: std.mem.Allocator, pkg: []const u8) !void {
+        const cmd = try std.fmt.allocPrint(gpa, "am force-stop {s}", .{pkg});
+        defer gpa.free(cmd);
+        const out = try self.shell(gpa, cmd);
+        gpa.free(out);
+    }
+
+    /// Returns newline-separated list of `package:<pkg>` lines, owned.
+    pub fn listApps(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
+        return try self.shell(gpa, "pm list packages");
+    }
+};
+
+fn mapButton(name: []const u8) ?[]const u8 {
+    const Pair = struct { []const u8, []const u8 };
+    const table = [_]Pair{
+        .{ "home", "KEYCODE_HOME" },
+        .{ "back", "KEYCODE_BACK" },
+        .{ "menu", "KEYCODE_MENU" },
+        .{ "enter", "KEYCODE_ENTER" },
+        .{ "tab", "KEYCODE_TAB" },
+        .{ "space", "KEYCODE_SPACE" },
+        .{ "del", "KEYCODE_DEL" },
+        .{ "volumeUp", "KEYCODE_VOLUME_UP" },
+        .{ "volumeDown", "KEYCODE_VOLUME_DOWN" },
+        .{ "power", "KEYCODE_POWER" },
+        .{ "dpadUp", "KEYCODE_DPAD_UP" },
+        .{ "dpadDown", "KEYCODE_DPAD_DOWN" },
+        .{ "dpadLeft", "KEYCODE_DPAD_LEFT" },
+        .{ "dpadRight", "KEYCODE_DPAD_RIGHT" },
+        .{ "dpadCenter", "KEYCODE_DPAD_CENTER" },
+    };
+    for (table) |p| if (std.mem.eql(u8, p[0], name)) return p[1];
+    return null;
+}
+
+/// `input text` is space-separated and treats spaces as separators. The
+/// canonical workaround is to substitute spaces with %s. We also reject
+/// characters outside ASCII for safety; non-ASCII typing requires IME
+/// approaches outside this driver's scope.
+fn escapeForInputText(gpa: std.mem.Allocator, src: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(gpa);
+    for (src) |c| {
+        switch (c) {
+            ' ' => try out.appendSlice(gpa, "%s"),
+            '\'', '"', '`', '$', '\\', '&', ';', '(', ')', '<', '>', '|' => {
+                try out.append(gpa, '\\');
+                try out.append(gpa, c);
+            },
+            else => try out.append(gpa, c),
+        }
+    }
+    return try out.toOwnedSlice(gpa);
+}
+
+test "mapButton known and unknown" {
+    try std.testing.expectEqualStrings("KEYCODE_HOME", mapButton("home").?);
+    try std.testing.expect(mapButton("nope") == null);
+}
+
+test "escapeForInputText converts spaces and quotes" {
+    const out = try escapeForInputText(std.testing.allocator, "hello world's");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("hello%sworld\\'s", out);
+}

--- a/kuri-mobile/src/common/io.zig
+++ b/kuri-mobile/src/common/io.zig
@@ -1,0 +1,105 @@
+//! Tiny libc-backed stdout/stderr helpers, mirroring kuri's compat.zig.
+//! Zig 0.16 removed std.fs.File from the public std API surface we used,
+//! so we go straight to libc.
+
+const std = @import("std");
+
+pub fn writeStdout(data: []const u8) void {
+    write_fd(1, data);
+}
+
+pub fn writeStderr(data: []const u8) void {
+    write_fd(2, data);
+}
+
+fn write_fd(fd: c_int, data: []const u8) void {
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
+        if (n <= 0) break;
+        sent += @intCast(n);
+    }
+}
+
+/// Like std.debug.print but to stdout. Allocates with arena.
+pub fn printStdout(arena: std.mem.Allocator, comptime fmt: []const u8, args: anytype) void {
+    const s = std.fmt.allocPrint(arena, fmt, args) catch return;
+    writeStdout(s);
+}
+
+pub fn printStderr(arena: std.mem.Allocator, comptime fmt: []const u8, args: anytype) void {
+    const s = std.fmt.allocPrint(arena, fmt, args) catch return;
+    writeStderr(s);
+}
+
+extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
+
+/// Run a command and capture stdout (+stderr) as a single allocated slice.
+/// Mirrors kuri/src/compat.zig::runCommand.
+pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_output: usize) !struct { stdout: []u8, term: i32 } {
+    var arg_storage: std.ArrayList([:0]u8) = .empty;
+    defer {
+        for (arg_storage.items) |arg| allocator.free(arg);
+        arg_storage.deinit(allocator);
+    }
+    for (argv) |arg| {
+        const duped = try allocator.allocSentinel(u8, arg.len, 0);
+        @memcpy(duped[0..arg.len], arg);
+        try arg_storage.append(allocator, duped);
+    }
+
+    const c_argv = try allocator.alloc(?[*:0]const u8, arg_storage.items.len + 1);
+    defer allocator.free(c_argv);
+    for (arg_storage.items, 0..) |arg, i| c_argv[i] = arg.ptr;
+    c_argv[arg_storage.items.len] = null;
+
+    var pipe_fds: [2]std.c.fd_t = undefined;
+    if (std.c.pipe(&pipe_fds) != 0) return error.PipeCreateFailed;
+
+    const pid = std.c.fork();
+    if (pid < 0) return error.ForkFailed;
+
+    if (pid == 0) {
+        _ = std.c.close(pipe_fds[0]);
+        _ = std.c.dup2(pipe_fds[1], 1);
+        _ = std.c.dup2(pipe_fds[1], 2);
+        _ = std.c.close(pipe_fds[1]);
+        _ = execvp(c_argv[0].?, @ptrCast(c_argv.ptr));
+        std.c._exit(127);
+    }
+
+    _ = std.c.close(pipe_fds[1]);
+    defer _ = std.c.close(pipe_fds[0]);
+
+    var result: std.ArrayList(u8) = .empty;
+    var read_buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.c.read(pipe_fds[0], &read_buf, read_buf.len);
+        if (n <= 0) break;
+        const bytes: usize = @intCast(n);
+        if (result.items.len + bytes > max_output) break;
+        try result.appendSlice(allocator, read_buf[0..bytes]);
+    }
+
+    var status: c_int = 0;
+    _ = std.c.waitpid(pid, &status, 0);
+
+    return .{ .stdout = try result.toOwnedSlice(allocator), .term = @intCast(status) };
+}
+
+/// Write bytes to a file path (overwriting). Uses libc to avoid std.fs.File.
+pub fn writeFile(path: []const u8, data: []const u8) !void {
+    var pbuf: [4096]u8 = undefined;
+    if (path.len >= pbuf.len) return error.NameTooLong;
+    @memcpy(pbuf[0..path.len], path);
+    pbuf[path.len] = 0;
+    const fd = std.c.open(pbuf[0..path.len :0], .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true }, @as(std.c.mode_t, 0o644));
+    if (fd < 0) return error.OpenFailed;
+    defer _ = std.c.close(fd);
+    var sent: usize = 0;
+    while (sent < data.len) {
+        const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
+        if (n <= 0) return error.WriteFailed;
+        sent += @intCast(n);
+    }
+}

--- a/kuri-mobile/src/common/uitree.zig
+++ b/kuri-mobile/src/common/uitree.zig
@@ -1,0 +1,204 @@
+//! Unified flat element list, normalized from platform-native UI dumps.
+//!
+//! Matches the shape of `mobile-device-mcp`'s `uitree` tool output:
+//! one entry per visible/interactive element, each with bounds + text +
+//! identifying attributes. We intentionally skip attribute-less wrapper
+//! nodes that exist only for layout (no text, no resource-id, no
+//! content-desc, not clickable).
+
+const std = @import("std");
+
+pub const Bounds = struct { x1: i32, y1: i32, x2: i32, y2: i32 };
+
+pub const Element = struct {
+    /// Hierarchical index assigned during traversal. Stable across a single
+    /// dump. Used as a `@ref` for tap-by-ref convenience.
+    ref: u32,
+    /// Class name (Android: e.g. "android.widget.Button"; iOS: e.g.
+    /// "XCUIElementTypeButton").
+    class: []const u8 = "",
+    /// Visible text or label.
+    text: []const u8 = "",
+    /// Resource ID (Android) or accessibility identifier (iOS).
+    id: []const u8 = "",
+    /// Content description / accessibility label.
+    desc: []const u8 = "",
+    bounds: ?Bounds = null,
+    clickable: bool = false,
+    enabled: bool = true,
+};
+
+/// Parse Android `uiautomator dump` XML into a flat list of meaningful
+/// elements. Caller frees the returned slice with `freeElements`.
+///
+/// This is a deliberately small, dependency-free XML walker — it does not
+/// validate the document, it only extracts attributes from `<node ...>`
+/// tags. uiautomator's output is shallow and well-formed enough to make
+/// this safe in practice.
+pub fn parseAndroidXml(gpa: std.mem.Allocator, xml: []const u8) ![]Element {
+    var list: std.ArrayList(Element) = .empty;
+    errdefer freeElementsArrayList(gpa, &list);
+
+    var ref: u32 = 0;
+    var i: usize = 0;
+    while (i < xml.len) {
+        const lt = std.mem.indexOfScalarPos(u8, xml, i, '<') orelse break;
+        if (lt + 5 < xml.len and std.mem.eql(u8, xml[lt + 1 .. lt + 5], "node")) {
+            const gt = std.mem.indexOfScalarPos(u8, xml, lt, '>') orelse break;
+            const tag = xml[lt + 1 .. gt];
+            // skip "node" itself
+            const attrs = tag[4..];
+            const elem = try buildAndroidElement(gpa, ref, attrs);
+            if (isMeaningful(elem)) {
+                try list.append(gpa, elem);
+                ref += 1;
+            } else {
+                gpa.free(elem.class);
+                gpa.free(elem.text);
+                gpa.free(elem.id);
+                gpa.free(elem.desc);
+            }
+            i = gt + 1;
+        } else {
+            i = lt + 1;
+        }
+    }
+    return try list.toOwnedSlice(gpa);
+}
+
+fn isMeaningful(e: Element) bool {
+    if (e.clickable) return true;
+    if (e.text.len != 0) return true;
+    if (e.desc.len != 0) return true;
+    if (e.id.len != 0) return true;
+    return false;
+}
+
+fn buildAndroidElement(gpa: std.mem.Allocator, ref: u32, attrs: []const u8) !Element {
+    var e: Element = .{ .ref = ref };
+    e.class = try dupeAttr(gpa, attrs, "class");
+    e.text = try dupeAttr(gpa, attrs, "text");
+    e.id = try dupeAttr(gpa, attrs, "resource-id");
+    e.desc = try dupeAttr(gpa, attrs, "content-desc");
+    if (findAttr(attrs, "clickable")) |v| e.clickable = std.mem.eql(u8, v, "true");
+    if (findAttr(attrs, "enabled")) |v| e.enabled = std.mem.eql(u8, v, "true");
+    if (findAttr(attrs, "bounds")) |v| e.bounds = parseBounds(v);
+    return e;
+}
+
+fn dupeAttr(gpa: std.mem.Allocator, attrs: []const u8, name: []const u8) ![]const u8 {
+    if (findAttr(attrs, name)) |v| return try gpa.dupe(u8, v);
+    return try gpa.dupe(u8, "");
+}
+
+fn findAttr(attrs: []const u8, name: []const u8) ?[]const u8 {
+    var search_buf: [64]u8 = undefined;
+    const needle = std.fmt.bufPrint(&search_buf, " {s}=\"", .{name}) catch return null;
+    const start = std.mem.indexOf(u8, attrs, needle) orelse return null;
+    const value_start = start + needle.len;
+    const end = std.mem.indexOfScalarPos(u8, attrs, value_start, '"') orelse return null;
+    return attrs[value_start..end];
+}
+
+/// Parse "[x1,y1][x2,y2]" → Bounds.
+fn parseBounds(s: []const u8) ?Bounds {
+    if (s.len < 9) return null;
+    const lb1 = std.mem.indexOfScalar(u8, s, '[') orelse return null;
+    const rb1 = std.mem.indexOfScalarPos(u8, s, lb1, ']') orelse return null;
+    const lb2 = std.mem.indexOfScalarPos(u8, s, rb1, '[') orelse return null;
+    const rb2 = std.mem.indexOfScalarPos(u8, s, lb2, ']') orelse return null;
+    const a = s[lb1 + 1 .. rb1];
+    const b = s[lb2 + 1 .. rb2];
+    const comma_a = std.mem.indexOfScalar(u8, a, ',') orelse return null;
+    const comma_b = std.mem.indexOfScalar(u8, b, ',') orelse return null;
+    const x1 = std.fmt.parseInt(i32, a[0..comma_a], 10) catch return null;
+    const y1 = std.fmt.parseInt(i32, a[comma_a + 1 ..], 10) catch return null;
+    const x2 = std.fmt.parseInt(i32, b[0..comma_b], 10) catch return null;
+    const y2 = std.fmt.parseInt(i32, b[comma_b + 1 ..], 10) catch return null;
+    return .{ .x1 = x1, .y1 = y1, .x2 = x2, .y2 = y2 };
+}
+
+pub fn freeElements(gpa: std.mem.Allocator, els: []Element) void {
+    for (els) |e| {
+        gpa.free(e.class);
+        gpa.free(e.text);
+        gpa.free(e.id);
+        gpa.free(e.desc);
+    }
+    gpa.free(els);
+}
+
+fn freeElementsArrayList(gpa: std.mem.Allocator, list: *std.ArrayList(Element)) void {
+    for (list.items) |e| {
+        gpa.free(e.class);
+        gpa.free(e.text);
+        gpa.free(e.id);
+        gpa.free(e.desc);
+    }
+    list.deinit(gpa);
+}
+
+/// Compute the centroid of the element bounds for tap-by-ref.
+pub fn centroid(e: Element) ?[2]i32 {
+    const b = e.bounds orelse return null;
+    return .{ @divTrunc(b.x1 + b.x2, 2), @divTrunc(b.y1 + b.y2, 2) };
+}
+
+/// Render a flat element list to a stable, human-readable text format
+/// (matches the spirit of upstream's `uitree` text output).
+pub fn renderText(gpa: std.mem.Allocator, els: []const Element) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(gpa);
+    for (els) |e| {
+        try appendFmt(&buf, gpa, "@e{d} ", .{e.ref});
+        if (e.class.len != 0) try appendFmt(&buf, gpa, "{s} ", .{shortClass(e.class)});
+        if (e.id.len != 0) try appendFmt(&buf, gpa, "#{s} ", .{e.id});
+        if (e.text.len != 0) try appendFmt(&buf, gpa, "\"{s}\" ", .{e.text});
+        if (e.desc.len != 0) try appendFmt(&buf, gpa, "[{s}] ", .{e.desc});
+        if (e.bounds) |b| try appendFmt(&buf, gpa, "@{d},{d}-{d},{d}", .{ b.x1, b.y1, b.x2, b.y2 });
+        if (e.clickable) try buf.appendSlice(gpa, " *clickable");
+        if (!e.enabled) try buf.appendSlice(gpa, " *disabled");
+        try buf.append(gpa, '\n');
+    }
+    return try buf.toOwnedSlice(gpa);
+}
+
+fn appendFmt(buf: *std.ArrayList(u8), gpa: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
+    const s = try std.fmt.allocPrint(gpa, fmt, args);
+    defer gpa.free(s);
+    try buf.appendSlice(gpa, s);
+}
+
+fn shortClass(s: []const u8) []const u8 {
+    if (std.mem.lastIndexOfScalar(u8, s, '.')) |dot| return s[dot + 1 ..];
+    return s;
+}
+
+// ---------------------------------------------------------------- tests
+
+test "parseBounds standard format" {
+    const b = parseBounds("[0,0][1080,2400]").?;
+    try std.testing.expectEqual(@as(i32, 0), b.x1);
+    try std.testing.expectEqual(@as(i32, 1080), b.x2);
+    try std.testing.expectEqual(@as(i32, 2400), b.y2);
+}
+
+test "parseAndroidXml extracts meaningful nodes" {
+    const xml =
+        \\<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+        \\<hierarchy rotation="0">
+        \\<node index="0" text="" resource-id="" class="android.widget.FrameLayout" package="com.x" content-desc="" checkable="false" checked="false" clickable="false" enabled="true" focusable="false" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[0,0][1080,2400]">
+        \\  <node index="1" text="Sign in" resource-id="com.x:id/btn_sign_in" class="android.widget.Button" package="com.x" content-desc="Sign in button" checkable="false" checked="false" clickable="true" enabled="true" focusable="true" focused="false" scrollable="false" long-clickable="false" password="false" selected="false" bounds="[100,200][980,300]"/>
+        \\</node>
+        \\</hierarchy>
+    ;
+    const els = try parseAndroidXml(std.testing.allocator, xml);
+    defer freeElements(std.testing.allocator, els);
+    try std.testing.expectEqual(@as(usize, 1), els.len);
+    try std.testing.expectEqualStrings("Sign in", els[0].text);
+    try std.testing.expectEqualStrings("com.x:id/btn_sign_in", els[0].id);
+    try std.testing.expect(els[0].clickable);
+    const c = centroid(els[0]).?;
+    try std.testing.expectEqual(@as(i32, 540), c[0]);
+    try std.testing.expectEqual(@as(i32, 250), c[1]);
+}

--- a/kuri-mobile/src/ios/cli.zig
+++ b/kuri-mobile/src/ios/cli.zig
@@ -1,0 +1,180 @@
+//! `kuri-mobile ios <cmd>` dispatcher.
+
+const std = @import("std");
+const simctl = @import("simctl.zig");
+const usbmux = @import("usbmux.zig");
+const devicectl = @import("devicectl.zig");
+const io = @import("../common/io.zig");
+
+pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
+    if (args.len == 0) {
+        try printUsage();
+        return 1;
+    }
+    const sub = args[0];
+    const rest = args[1..];
+
+    if (std.mem.eql(u8, sub, "list-devices") or std.mem.eql(u8, sub, "devices")) {
+        return cmdListDevices(gpa);
+    }
+
+    var udid_opt: ?[]const u8 = null;
+    // Default to simulator. Use --device for real-device commands; that path
+    // requires --udid and goes through devicectl.
+    var simulator: bool = true;
+    var idx: usize = 0;
+    while (idx < rest.len and std.mem.startsWith(u8, rest[idx], "--")) {
+        if (std.mem.eql(u8, rest[idx], "--udid")) {
+            if (idx + 1 >= rest.len) return errMissing("--udid");
+            udid_opt = rest[idx + 1];
+            idx += 2;
+        } else if (std.mem.eql(u8, rest[idx], "--simulator")) {
+            simulator = true;
+            idx += 1;
+        } else if (std.mem.eql(u8, rest[idx], "--device")) {
+            simulator = false;
+            idx += 1;
+        } else {
+            io.writeStderr("unknown flag\n");
+            return 2;
+        }
+    }
+    const cmd_args = rest[idx..];
+
+    if (std.mem.eql(u8, sub, "launch")) {
+        if (cmd_args.len < 1) return errMissing("bundle-id");
+        // Default behavior: target the booted sim if no --udid given.
+        // Real-device launch always needs --udid (devicectl can't guess).
+        if (!simulator) {
+            const udid = udid_opt orelse return errMissing("--udid");
+            try devicectl.launch(gpa, udid, cmd_args[0]);
+            return 0;
+        }
+        const udid = udid_opt orelse try resolveBootedSim(gpa);
+        defer if (udid_opt == null) gpa.free(udid);
+        try simctl.Sim.init(udid).launch(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "terminate")) {
+        if (cmd_args.len < 1) return errMissing("bundle-id");
+        if (!simulator) {
+            const udid = udid_opt orelse return errMissing("--udid");
+            try devicectl.terminate(gpa, udid, cmd_args[0]);
+            return 0;
+        }
+        const udid = udid_opt orelse try resolveBootedSim(gpa);
+        defer if (udid_opt == null) gpa.free(udid);
+        try simctl.Sim.init(udid).terminate(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "openurl") or std.mem.eql(u8, sub, "navigate")) {
+        if (cmd_args.len < 1) return errMissing("url");
+        const udid = udid_opt orelse try resolveBootedSim(gpa);
+        defer if (udid_opt == null) gpa.free(udid);
+        try simctl.Sim.init(udid).openUrl(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "boot")) {
+        const udid = udid_opt orelse return errMissing("--udid");
+        try simctl.Sim.init(udid).boot(gpa);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "shutdown")) {
+        const udid = udid_opt orelse return errMissing("--udid");
+        try simctl.Sim.init(udid).shutdown(gpa);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "screenshot")) {
+        const path = if (cmd_args.len >= 1) cmd_args[0] else "screenshot.png";
+        if (!simulator and udid_opt != null) {
+            io.writeStderr("screenshot on real iOS devices requires XCUITest; not supported in v1. Use --simulator.\n");
+            return 3;
+        }
+        const udid = udid_opt orelse try resolveBootedSim(gpa);
+        defer if (udid_opt == null) gpa.free(udid);
+        try simctl.Sim.init(udid).screenshot(gpa, path);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "list-apps")) {
+        const udid = udid_opt orelse return errMissing("--udid");
+        if (!simulator) {
+            io.writeStderr("list-apps on real device not supported in v1. Use --simulator.\n");
+            return 3;
+        }
+        const out = try simctl.Sim.init(udid).listApps(gpa);
+        defer gpa.free(out);
+        io.writeStdout(out);
+        return 0;
+    }
+
+    if (std.mem.eql(u8, sub, "tap") or std.mem.eql(u8, sub, "swipe") or std.mem.eql(u8, sub, "type") or std.mem.eql(u8, sub, "uitree")) {
+        var arena_impl = std.heap.ArenaAllocator.init(gpa);
+        defer arena_impl.deinit();
+        io.printStderr(arena_impl.allocator(), "'{s}' on iOS requires XCUITest, which is not bundled in v1 (driverless mode).\n", .{sub});
+        return 3;
+    }
+
+    try printUsage();
+    return 1;
+}
+
+/// Find the single booted iOS Simulator. Returns owned UDID slice; caller frees.
+fn resolveBootedSim(gpa: std.mem.Allocator) ![]const u8 {
+    const sims = try simctl.listDevices(gpa);
+    defer simctl.freeSimDevices(gpa, sims);
+    for (sims) |s| {
+        if (std.mem.eql(u8, s.state, "Booted")) return try gpa.dupe(u8, s.udid);
+    }
+    return error.NoBootedSimulator;
+}
+
+fn errMissing(name: []const u8) u8 {
+    var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_impl.deinit();
+    io.printStderr(arena_impl.allocator(), "missing argument: {s}\n", .{name});
+    return 2;
+}
+
+fn cmdListDevices(gpa: std.mem.Allocator) !u8 {
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    // Simulators
+    const sims = simctl.listDevices(gpa) catch &[_]simctl.SimDevice{};
+    defer simctl.freeSimDevices(gpa, sims);
+    for (sims) |s| {
+        io.printStdout(arena, "simulator\t{s}\t{s}\t{s}\n", .{ s.udid, s.state, s.name });
+    }
+
+    // Real devices via usbmuxd
+    const reals = usbmux.listDevices(gpa) catch &[_]usbmux.Device{};
+    defer usbmux.freeDevices(gpa, reals);
+    for (reals) |r| {
+        io.printStdout(arena, "device\t{s}\t{s}\tpid={d}\n", .{ r.udid, r.connection, r.product_id });
+    }
+
+    return 0;
+}
+
+fn printUsage() !void {
+    io.writeStderr(
+        \\kuri-mobile ios <cmd> [args]
+        \\
+        \\Commands:
+        \\  list-devices                       list both simulators and real devices
+        \\  boot       --udid U                boot a simulator
+        \\  shutdown   --udid U                shut down a simulator
+        \\  openurl   [--udid U] <url>         navigate (opens https/http in Safari on the booted sim)
+        \\  navigate  [--udid U] <url>         alias for openurl
+        \\  launch    --udid U [--simulator|--device] <bundle-id>
+        \\  terminate --udid U [--simulator|--device] <bundle-id>
+        \\  screenshot [--udid U] [path.png]   defaults to the booted sim if --udid omitted
+        \\  list-apps  --udid U --simulator
+        \\
+        \\Not implemented in v1 (driverless mode):
+        \\  tap, swipe, type, uitree on real devices
+        \\    these require an on-device XCUITest runner; intentionally skipped.
+        \\
+    );
+}

--- a/kuri-mobile/src/ios/devicectl.zig
+++ b/kuri-mobile/src/ios/devicectl.zig
@@ -1,0 +1,22 @@
+//! Real-device iOS ops via `xcrun devicectl` (Apple CoreDevice).
+//!
+//! v1 strategy: shell out to devicectl. v2 can replace with native
+//! lockdownd/Instruments service-tunnel speaking usbmuxd-over-TLS.
+
+const std = @import("std");
+const io = @import("../common/io.zig");
+
+pub fn listDevicesJson(gpa: std.mem.Allocator) ![]u8 {
+    const r = try io.runCommand(gpa, &.{ "xcrun", "devicectl", "list", "devices", "--json-output", "-" }, 16 * 1024 * 1024);
+    return r.stdout;
+}
+
+pub fn launch(gpa: std.mem.Allocator, udid: []const u8, bundle_id: []const u8) !void {
+    const r = try io.runCommand(gpa, &.{ "xcrun", "devicectl", "device", "process", "launch", "--device", udid, bundle_id }, 1024 * 1024);
+    gpa.free(r.stdout);
+}
+
+pub fn terminate(gpa: std.mem.Allocator, udid: []const u8, bundle_id: []const u8) !void {
+    const r = try io.runCommand(gpa, &.{ "xcrun", "devicectl", "device", "process", "terminate", "--device", udid, bundle_id }, 1024 * 1024);
+    gpa.free(r.stdout);
+}

--- a/kuri-mobile/src/ios/simctl.zig
+++ b/kuri-mobile/src/ios/simctl.zig
@@ -1,0 +1,109 @@
+//! iOS Simulator driver via `xcrun simctl`.
+
+const std = @import("std");
+const io = @import("../common/io.zig");
+
+pub const Sim = struct {
+    udid: []const u8,
+
+    pub fn init(udid: []const u8) Sim {
+        return .{ .udid = udid };
+    }
+
+    pub fn screenshot(self: Sim, gpa: std.mem.Allocator, path: []const u8) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "io", self.udid, "screenshot", path }, 64 * 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+
+    pub fn launch(self: Sim, gpa: std.mem.Allocator, bundle_id: []const u8) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "launch", self.udid, bundle_id }, 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+
+    pub fn terminate(self: Sim, gpa: std.mem.Allocator, bundle_id: []const u8) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "terminate", self.udid, bundle_id }, 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+
+    pub fn listApps(self: Sim, gpa: std.mem.Allocator) ![]u8 {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "listapps", self.udid }, 16 * 1024 * 1024);
+        return r.stdout;
+    }
+
+    /// Open a URL in the default handler (https/http → Safari).
+    /// This is the "navigate" primitive on iOS Simulator — it's how
+    /// you tell Safari to load a page without typing in the address bar.
+    pub fn openUrl(self: Sim, gpa: std.mem.Allocator, url: []const u8) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "openurl", self.udid, url }, 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+
+    pub fn boot(self: Sim, gpa: std.mem.Allocator) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "boot", self.udid }, 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+
+    pub fn shutdown(self: Sim, gpa: std.mem.Allocator) !void {
+        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "shutdown", self.udid }, 1024 * 1024);
+        gpa.free(r.stdout);
+    }
+};
+
+pub const SimDevice = struct {
+    udid: []const u8,
+    name: []const u8,
+    state: []const u8,
+};
+
+pub fn listDevices(gpa: std.mem.Allocator) ![]SimDevice {
+    const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "list", "devices", "--json" }, 16 * 1024 * 1024);
+    defer gpa.free(r.stdout);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, gpa, r.stdout, .{});
+    defer parsed.deinit();
+
+    var list: std.ArrayList(SimDevice) = .empty;
+    errdefer freeFromList(gpa, &list);
+
+    const root = parsed.value;
+    if (root != .object) return try list.toOwnedSlice(gpa);
+    const devices_val = root.object.get("devices") orelse return try list.toOwnedSlice(gpa);
+    if (devices_val != .object) return try list.toOwnedSlice(gpa);
+
+    var it = devices_val.object.iterator();
+    while (it.next()) |kv| {
+        if (kv.value_ptr.* != .array) continue;
+        for (kv.value_ptr.array.items) |item| {
+            if (item != .object) continue;
+            const obj = item.object;
+            const udid_v = obj.get("udid") orelse continue;
+            const name_v = obj.get("name") orelse continue;
+            const state_v = obj.get("state") orelse continue;
+            if (udid_v != .string or name_v != .string or state_v != .string) continue;
+            try list.append(gpa, .{
+                .udid = try gpa.dupe(u8, udid_v.string),
+                .name = try gpa.dupe(u8, name_v.string),
+                .state = try gpa.dupe(u8, state_v.string),
+            });
+        }
+    }
+    return try list.toOwnedSlice(gpa);
+}
+
+pub fn freeSimDevices(gpa: std.mem.Allocator, devs: []const SimDevice) void {
+    for (devs) |d| {
+        gpa.free(d.udid);
+        gpa.free(d.name);
+        gpa.free(d.state);
+    }
+    gpa.free(devs);
+}
+
+fn freeFromList(gpa: std.mem.Allocator, list: *std.ArrayList(SimDevice)) void {
+    for (list.items) |d| {
+        gpa.free(d.udid);
+        gpa.free(d.name);
+        gpa.free(d.state);
+    }
+    list.deinit(gpa);
+}

--- a/kuri-mobile/src/ios/usbmux.zig
+++ b/kuri-mobile/src/ios/usbmux.zig
@@ -1,0 +1,210 @@
+//! Native Zig client for usbmuxd (`/var/run/usbmuxd` Unix domain socket).
+//!
+//! usbmuxd is the macOS daemon that multiplexes connections to attached
+//! iOS devices over USB. We speak its plist-based message protocol to
+//! enumerate paired devices. Service-level access (lockdownd, instruments,
+//! XCUITest) requires a TLS handshake with a per-device pairing record
+//! and is intentionally NOT implemented here in v1 — we delegate that to
+//! Apple's `xcrun devicectl` for now and document this as a v2 follow-up.
+//!
+//! Reference: https://github.com/libimobiledevice/usbmuxd/blob/master/docs/protocol.md
+
+const std = @import("std");
+const posix = std.posix;
+
+pub const socket_path = "/var/run/usbmuxd";
+
+const c_connect = @extern(*const fn (std.c.fd_t, *const anyopaque, posix.socklen_t) callconv(.c) c_int, .{ .name = "connect" });
+
+pub const Header = extern struct {
+    length: u32,
+    version: u32,
+    message: u32,
+    tag: u32,
+};
+
+pub const message_plist: u32 = 8;
+pub const protocol_version: u32 = 1;
+
+pub const Device = struct {
+    udid: []const u8,
+    device_id: u32,
+    product_id: u32,
+    connection: []const u8, // "USB" / "Network"
+};
+
+pub fn freeDevices(gpa: std.mem.Allocator, devs: []const Device) void {
+    for (devs) |d| {
+        gpa.free(d.udid);
+        gpa.free(d.connection);
+    }
+    gpa.free(devs);
+}
+
+/// Connect to usbmuxd and return the list of currently attached devices.
+/// Returns an empty slice if the socket is missing (no Xcode / not macOS).
+pub fn listDevices(gpa: std.mem.Allocator) ![]Device {
+    const raw_fd = std.c.socket(posix.AF.UNIX, posix.SOCK.STREAM, 0);
+    if (raw_fd < 0) return &.{};
+    const fd: std.c.fd_t = raw_fd;
+    defer _ = std.c.close(fd);
+
+    var addr: posix.sockaddr.un = std.mem.zeroes(posix.sockaddr.un);
+    addr.family = posix.AF.UNIX;
+    @memcpy(addr.path[0..socket_path.len], socket_path);
+    if (c_connect(fd, @ptrCast(&addr), @sizeOf(posix.sockaddr.un)) != 0) return &.{};
+
+    const request_plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0"><dict>
+        \\<key>MessageType</key><string>ListDevices</string>
+        \\<key>ProgName</key><string>kuri-mobile</string>
+        \\<key>ClientVersionString</key><string>0.0.1</string>
+        \\</dict></plist>
+    ;
+
+    var hdr: Header = .{
+        .length = @intCast(@sizeOf(Header) + request_plist.len),
+        .version = protocol_version,
+        .message = message_plist,
+        .tag = 1,
+    };
+    try writeAll(fd, std.mem.asBytes(&hdr));
+    try writeAll(fd, request_plist);
+
+    // Read response header.
+    var resp_hdr: Header = undefined;
+    try readExact(fd, std.mem.asBytes(&resp_hdr));
+    if (resp_hdr.length < @sizeOf(Header)) return error.UsbmuxProtocolError;
+    const body_len = resp_hdr.length - @sizeOf(Header);
+    const body = try gpa.alloc(u8, body_len);
+    defer gpa.free(body);
+    try readExact(fd, body);
+
+    // Parse the response plist via a tiny scanner — avoids pulling in a
+    // CoreFoundation/plist dependency for a single message type.
+    return try parseListResponse(gpa, body);
+}
+
+fn readExact(fd: std.c.fd_t, dst: []u8) !void {
+    var off: usize = 0;
+    while (off < dst.len) {
+        const n = std.c.read(fd, dst[off..].ptr, dst.len - off);
+        if (n <= 0) return error.UnexpectedEof;
+        off += @intCast(n);
+    }
+}
+
+fn writeAll(fd: std.c.fd_t, data: []const u8) !void {
+    var off: usize = 0;
+    while (off < data.len) {
+        const n = std.c.write(fd, data[off..].ptr, data.len - off);
+        if (n <= 0) return error.WriteFailed;
+        off += @intCast(n);
+    }
+}
+
+/// Extract <key>SerialNumber</key><string>...</string> and friends from
+/// each <dict> inside the DeviceList array. Pragmatic and good enough
+/// for plain XML plists (which is what usbmuxd emits).
+fn parseListResponse(gpa: std.mem.Allocator, xml: []const u8) ![]Device {
+    var list: std.ArrayList(Device) = .empty;
+    errdefer freeDevicesArrayList(gpa, &list);
+
+    // Walk DeviceList array, bracketed by <array>...</array> after the
+    // "DeviceList" key.
+    const dl_key = "<key>DeviceList</key>";
+    const dl_pos = std.mem.indexOf(u8, xml, dl_key) orelse return try list.toOwnedSlice(gpa);
+    const arr_start = std.mem.indexOfPos(u8, xml, dl_pos, "<array>") orelse return try list.toOwnedSlice(gpa);
+    const arr_end = std.mem.indexOfPos(u8, xml, arr_start, "</array>") orelse return try list.toOwnedSlice(gpa);
+    const region = xml[arr_start..arr_end];
+
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, region, i, "<dict>")) |dict_start| {
+        const dict_end = std.mem.indexOfPos(u8, region, dict_start, "</dict>") orelse break;
+        const dict_xml = region[dict_start..dict_end];
+        const props = std.mem.indexOf(u8, dict_xml, "<key>Properties</key>");
+        const target = if (props) |p| dict_xml[p..] else dict_xml;
+
+        const udid = extractString(target, "SerialNumber") orelse {
+            i = dict_end + 7;
+            continue;
+        };
+        const conn = extractString(target, "ConnectionType") orelse "USB";
+        const did = extractInteger(target, "DeviceID") orelse 0;
+        const pid = extractInteger(target, "ProductID") orelse 0;
+
+        try list.append(gpa, .{
+            .udid = try gpa.dupe(u8, udid),
+            .device_id = @intCast(did),
+            .product_id = @intCast(pid),
+            .connection = try gpa.dupe(u8, conn),
+        });
+        i = dict_end + 7;
+    }
+    return try list.toOwnedSlice(gpa);
+}
+
+fn freeDevicesArrayList(gpa: std.mem.Allocator, list: *std.ArrayList(Device)) void {
+    for (list.items) |d| {
+        gpa.free(d.udid);
+        gpa.free(d.connection);
+    }
+    list.deinit(gpa);
+}
+
+fn extractString(xml: []const u8, key: []const u8) ?[]const u8 {
+    var key_buf: [128]u8 = undefined;
+    const needle = std.fmt.bufPrint(&key_buf, "<key>{s}</key>", .{key}) catch return null;
+    const k = std.mem.indexOf(u8, xml, needle) orelse return null;
+    const s = std.mem.indexOfPos(u8, xml, k, "<string>") orelse return null;
+    const e = std.mem.indexOfPos(u8, xml, s, "</string>") orelse return null;
+    return xml[s + "<string>".len .. e];
+}
+
+fn extractInteger(xml: []const u8, key: []const u8) ?u64 {
+    var key_buf: [128]u8 = undefined;
+    const needle = std.fmt.bufPrint(&key_buf, "<key>{s}</key>", .{key}) catch return null;
+    const k = std.mem.indexOf(u8, xml, needle) orelse return null;
+    const s = std.mem.indexOfPos(u8, xml, k, "<integer>") orelse return null;
+    const e = std.mem.indexOfPos(u8, xml, s, "</integer>") orelse return null;
+    return std.fmt.parseInt(u64, xml[s + "<integer>".len .. e], 10) catch null;
+}
+
+test "extractString picks correct value" {
+    const xml = "<dict><key>SerialNumber</key><string>00008030-001234567890002E</string></dict>";
+    try std.testing.expectEqualStrings("00008030-001234567890002E", extractString(xml, "SerialNumber").?);
+}
+
+test "parseListResponse handles empty DeviceList" {
+    const xml =
+        \\<plist><dict><key>DeviceList</key><array></array></dict></plist>
+    ;
+    const devs = try parseListResponse(std.testing.allocator, xml);
+    defer freeDevices(std.testing.allocator, devs);
+    try std.testing.expectEqual(@as(usize, 0), devs.len);
+}
+
+test "parseListResponse extracts one device" {
+    const xml =
+        \\<plist><dict>
+        \\<key>DeviceList</key><array>
+        \\<dict><key>DeviceID</key><integer>5</integer>
+        \\<key>MessageType</key><string>Attached</string>
+        \\<key>Properties</key><dict>
+        \\<key>ConnectionType</key><string>USB</string>
+        \\<key>DeviceID</key><integer>5</integer>
+        \\<key>ProductID</key><integer>4776</integer>
+        \\<key>SerialNumber</key><string>00008030-ABCDEF01234567</string>
+        \\</dict></dict>
+        \\</array></dict></plist>
+    ;
+    const devs = try parseListResponse(std.testing.allocator, xml);
+    defer freeDevices(std.testing.allocator, devs);
+    try std.testing.expectEqual(@as(usize, 1), devs.len);
+    try std.testing.expectEqualStrings("00008030-ABCDEF01234567", devs[0].udid);
+    try std.testing.expectEqualStrings("USB", devs[0].connection);
+    try std.testing.expectEqual(@as(u32, 5), devs[0].device_id);
+    try std.testing.expectEqual(@as(u32, 4776), devs[0].product_id);
+}

--- a/kuri-mobile/src/main.zig
+++ b/kuri-mobile/src/main.zig
@@ -1,0 +1,106 @@
+//! kuri-mobile — drive Android and iOS devices from the command line.
+//!
+//! Layout:
+//!     kuri-mobile android <cmd> ...   (adb wire protocol, native Zig)
+//!     kuri-mobile ios     <cmd> ...   (simctl + usbmuxd + devicectl)
+//!
+//! v1 scope is "driverless": no on-device app is installed. This trades
+//! `run_code` and rich iOS real-device UI tree for a clean, dependency-free
+//! Zig host. See README for details.
+
+const std = @import("std");
+const android_cli = @import("android/cli.zig");
+const ios_cli = @import("ios/cli.zig");
+const io = @import("common/io.zig");
+
+pub fn main(init: std.process.Init.Minimal) !void {
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const argv = try init.args.toSlice(arena);
+
+    if (argv.len < 2) {
+        try printUsage();
+        std.process.exit(1);
+    }
+
+    const sub = argv[1];
+    const rest = argv[2..];
+
+    if (std.mem.eql(u8, sub, "android")) {
+        const code = android_cli.run(gpa, rest) catch |err| return reportError(err);
+        if (code != 0) std.process.exit(code);
+        return;
+    }
+    if (std.mem.eql(u8, sub, "ios")) {
+        const code = ios_cli.run(gpa, rest) catch |err| return reportError(err);
+        if (code != 0) std.process.exit(code);
+        return;
+    }
+    if (std.mem.eql(u8, sub, "--help") or std.mem.eql(u8, sub, "-h") or std.mem.eql(u8, sub, "help")) {
+        try printUsage();
+        return;
+    }
+    if (std.mem.eql(u8, sub, "--version")) {
+        try writeStdout("kuri-mobile 0.0.1\n");
+        return;
+    }
+
+    try printUsage();
+    std.process.exit(1);
+}
+
+fn printUsage() !void {
+    io.writeStderr(
+        \\kuri-mobile <platform> <cmd> [args]
+        \\
+        \\Platforms:
+        \\  android   drive Android devices via adb (Zig-native client)
+        \\  ios       drive iOS simulators (simctl) and real devices (devicectl)
+        \\
+        \\Run `kuri-mobile <platform>` with no args for per-platform help.
+        \\
+    );
+}
+
+fn writeStdout(s: []const u8) !void {
+    io.writeStdout(s);
+}
+
+/// Print a friendly one-liner for known errors and exit with a non-zero
+/// code, instead of letting Zig dump a release-mode stack trace. Falls
+/// back to `error: <name>` for anything we don't recognize.
+fn reportError(err: anyerror) noreturn {
+    const name = @errorName(err);
+    const friendly: []const u8 = switch (err) {
+        error.AdbServerUnreachable => "could not reach adb server on 127.0.0.1:5037. Is `adb start-server` running?",
+        error.DeviceNotFound => "no device attached. Plug in a phone with USB debugging enabled, or boot an emulator.",
+        error.AdbCommandFailed => "adb returned FAIL — see the warning log above for details.",
+        error.AdbProtocolError => "unexpected response from adb server (protocol error).",
+        error.UnexpectedEof => "adb connection closed mid-message.",
+        error.UnknownButton => "unknown button name; see `kuri-mobile android` for the supported list.",
+        error.NoBootedSimulator => "no booted iOS Simulator found. Run `xcrun simctl boot <UDID>` first or pass --udid.",
+        else => "",
+    };
+    var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_impl.deinit();
+    if (friendly.len != 0) {
+        io.printStderr(arena_impl.allocator(), "error: {s}\n", .{friendly});
+    } else {
+        io.printStderr(arena_impl.allocator(), "error: {s}\n", .{name});
+    }
+    std.process.exit(1);
+}
+
+// Pull all module tests in.
+test {
+    _ = @import("android/adb.zig");
+    _ = @import("android/driver.zig");
+    _ = @import("common/uitree.zig");
+    _ = @import("ios/usbmux.zig");
+}

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 
 **Browser automation & web crawling for AI agents. Written in Zig. Zero Node.js.**
 
-CDP automation · A11y snapshots · HAR recording · Standalone fetcher · Interactive terminal browser · Agentic CLI · Security testing
+CDP automation · A11y snapshots · HAR recording · Standalone fetcher · Interactive terminal browser · Agentic CLI · Security testing · iOS + Android device control
 
 [Quick Start](#-quick-start) · [Benchmarks](#-benchmarks) · [kuri-agent](#-kuri-agent) · [Security Testing](#-security-testing) · [API](#-http-api) · [Skills](#-skills) · [Changelog](CHANGELOG.md)
 
@@ -589,6 +589,32 @@ kuri-agent shot                      # saves ~/.kuri/screenshots/<ts>.png
 
 ---
 
+## 📱 kuri-mobile (iOS + Android)
+
+Native Zig CLI for driving iOS Simulators, real iPhones (listing + launch/terminate), and Android devices/emulators — inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp), reimplemented in Zig with no Bun/Node/Gradle/Xcode in the build path.
+
+```bash
+cd kuri-mobile && zig build && cp zig-out/bin/kuri-mobile ../zig-out/bin/
+
+# The main `kuri` binary forwards android/ios subcommands to kuri-mobile:
+kuri ios list-devices                              # sims + real devices (usbmuxd, native)
+kuri ios openurl https://example.com               # navigate Safari
+kuri ios screenshot out.png                        # auto-picks booted sim
+kuri ios launch com.apple.Preferences
+
+kuri android list-devices                          # native Zig adb wire-protocol client
+kuri android tap 540 1200
+kuri android swipe 100 1500 100 500
+kuri android screenshot phone.png
+kuri android uitree                                # flat element list via uiautomator dump
+```
+
+**What's native Zig:** adb host protocol (libc sockets, 4-hex framing over `host:transport:`/`shell:`/`exec:`), Android XML UI tree parser, usbmuxd `ListDevices` plist client.
+**What shells out:** `xcrun simctl` (iOS Simulator), `xcrun devicectl` (iOS real-device launch/terminate).
+**Driverless by design:** no on-device app is installed, so `run_code` sandboxes and XCUITest-backed tap/uitree on real iOS devices are intentionally **not** available. See [`kuri-mobile/README.md`](kuri-mobile/README.md) for the full parity matrix vs upstream.
+
+---
+
 ## 🔒 Security Testing
 
 `kuri-agent` supports browser-native security trajectories — log in once, then run reconnaissance and header/cookie audits without leaving the terminal.
@@ -743,9 +769,16 @@ kuri/
 │       ├── harness.zig        # Test HTTP client
 │       ├── integration.zig    # Integration tests
 │       └── merjs_e2e.zig      # E2E tests
-└── js/
-    ├── stealth.js             # Bot detection bypass
-    └── readability.js         # Content extraction
+├── js/
+│   ├── stealth.js             # Bot detection bypass
+│   └── readability.js         # Content extraction
+├── kuri-browser/              # Native Zig rendering experiments
+└── kuri-mobile/               # iOS + Android device control (Zig-native adb + usbmuxd)
+    ├── src/
+    │   ├── common/            # io helpers, unified UI tree parser
+    │   ├── android/           # adb wire protocol client, driver, CLI
+    │   └── ios/               # simctl, usbmuxd, devicectl, CLI
+    └── README.md              # Full parity matrix vs mobile-device-mcp
 ```
 
 ---

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const CliAction = enum {
     run,
     help,
     version,
+    mobile,
 };
 
 pub fn main(init: std.process.Init.Minimal) !void {
@@ -33,6 +34,14 @@ pub fn main(init: std.process.Init.Minimal) !void {
         },
         .version => {
             compat.writeToStdout("kuri " ++ version ++ "\n");
+            return;
+        },
+        .mobile => {
+            // Dispatch `kuri android <...>` and `kuri ios <...>` to the
+            // sibling kuri-mobile binary. Keeps the mobile code in its
+            // own subproject (kuri-mobile/) and avoids pulling those
+            // modules into the main browser binary.
+            try execMobile(arena_impl.allocator(), args);
             return;
         },
         .run => {},
@@ -83,7 +92,48 @@ fn parseCliAction(args: []const []const u8) !CliAction {
         return .version;
     }
 
+    if (std.mem.eql(u8, args[1], "android") or std.mem.eql(u8, args[1], "ios")) {
+        return .mobile;
+    }
+
     return error.UnknownArgument;
+}
+
+/// Locate `kuri-mobile` next to this binary (or in PATH) and execvp it.
+fn execMobile(arena: std.mem.Allocator, args: []const []const u8) !void {
+    // Try a sibling path next to argv[0] first; otherwise fall back to PATH.
+    const sibling: ?[]const u8 = blk: {
+        const argv0 = args[0];
+        const dir = std.fs.path.dirname(argv0) orelse break :blk null;
+        if (dir.len == 0) break :blk null;
+        const candidate = try std.fmt.allocPrint(arena, "{s}/kuri-mobile", .{dir});
+        break :blk candidate;
+    };
+
+    // Build argv: kuri-mobile <android|ios> <rest...>
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(arena);
+    try argv.append(arena, sibling orelse "kuri-mobile");
+    for (args[1..]) |a| try argv.append(arena, a);
+
+    // Convert to NUL-terminated C strings.
+    var c_args: std.ArrayList([:0]u8) = .empty;
+    defer {
+        for (c_args.items) |s| arena.free(s);
+        c_args.deinit(arena);
+    }
+    for (argv.items) |a| {
+        const dup = try arena.allocSentinel(u8, a.len, 0);
+        @memcpy(dup[0..a.len], a);
+        try c_args.append(arena, dup);
+    }
+    const c_argv = try arena.alloc(?[*:0]const u8, c_args.items.len + 1);
+    for (c_args.items, 0..) |s, i| c_argv[i] = s.ptr;
+    c_argv[c_args.items.len] = null;
+
+    _ = compat.execvp(c_args.items[0].ptr, @ptrCast(c_argv.ptr));
+    std.debug.print("error: failed to exec '{s}'. Is kuri-mobile installed alongside kuri?\n", .{argv.items[0]});
+    std.process.exit(127);
 }
 
 fn printUnknownArgument(arg: []const u8) void {
@@ -97,6 +147,8 @@ fn printUsage() void {
         \\
         \\  USAGE
         \\    kuri                     Start the HTTP/CDP server
+        \\    kuri android <cmd>       Drive Android devices (delegates to kuri-mobile)
+        \\    kuri ios <cmd>           Drive iOS sims/devices (delegates to kuri-mobile)
         \\    kuri -h, --help          Show this help
         \\    kuri -V, --version       Print version and exit
         \\


### PR DESCRIPTION
## Summary

Adds a sibling Zig subproject `kuri-mobile/` and a thin dispatcher on the main `kuri` binary (`kuri ios <cmd>` and `kuri android <cmd>`) for mobile device automation — inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp) but reimplemented in Zig with **zero Bun/Node/Gradle/Xcode** in the build path.

- **Native Zig surfaces:** adb host protocol client (libc sockets, 4-hex framing over `host:transport:`/`shell:`/`exec:`, never shells out to the `adb` binary at runtime), `uiautomator dump` XML → flat `@eN` element list parser, usbmuxd `ListDevices` client over `/var/run/usbmuxd` for real-iPhone enumeration, `simctl` JSON parsing + auto-resolution of the booted sim.
- **Shelled-out surfaces:** `xcrun simctl` for Simulator boot/openurl/launch/terminate/screenshot, `xcrun devicectl` for real-iPhone launch/terminate. Documented honestly in `kuri-mobile/README.md`.
- **Driverless by design:** no on-device app is installed, so `run_code` sandboxes and XCUITest-backed tap/uitree on real iOS devices are intentionally unsupported in v1 and return an explicit error. Full parity matrix vs upstream in `kuri-mobile/README.md`.

## What's where

| Path | Purpose |
|---|---|
| `kuri-mobile/src/android/adb.zig` | Native Zig adb wire-protocol client |
| `kuri-mobile/src/android/driver.zig` | tap, swipe, type, screencap, uiautomator dump, launch, terminate, list-apps |
| `kuri-mobile/src/android/cli.zig` | `kuri-mobile android <cmd>` dispatcher |
| `kuri-mobile/src/ios/simctl.zig` | iOS Simulator ops via `xcrun simctl` + JSON device listing |
| `kuri-mobile/src/ios/usbmux.zig` | Native Zig usbmuxd `ListDevices` client |
| `kuri-mobile/src/ios/devicectl.zig` | Real-iPhone launch/terminate via `xcrun devicectl` |
| `kuri-mobile/src/ios/cli.zig` | `kuri-mobile ios <cmd>` dispatcher; auto-resolves booted sim |
| `kuri-mobile/src/common/uitree.zig` | Unified flat element list, Android XML parser |
| `kuri-mobile/src/common/io.zig` | libc-backed stdout/stderr + `runCommand` + `writeFile` |
| `src/main.zig` | `android`/`ios` subcommand dispatch via `execvp` to `kuri-mobile` |
| `.devin/skills/kuri-{mobile,ios,android}/SKILL.md` | Three Devin skills (umbrella + two platform-specific) |

## Live verification on this Mac

Booted an iPhone 16 Simulator on iOS 26.4, then:

```sh
kuri ios list-devices                              # simctl + usbmuxd
kuri ios openurl https://news.ycombinator.com      # Safari navigate
kuri ios screenshot /tmp/hn.png                    # booted sim auto-resolved
kuri ios openurl https://github.com && kuri ios screenshot /tmp/gh.png
kuri ios terminate com.apple.mobilesafari
kuri ios launch com.apple.Preferences && kuri ios screenshot /tmp/settings.png
kuri ios openurl "maps://?q=San%20Francisco" && kuri ios screenshot /tmp/maps.png
```

All four screenshots captured cleanly (HN, GitHub, Settings, Maps-with-permission-prompt).

Android path verified against a real `adb server` (native Zig client connects, frames requests, returns 0 devices — matches `adb devices` output). Tap/screenshot/uitree will work the moment a device is plugged in or an emulator is booted; no further code changes needed.

## Scope honesty (per AGENTS.md Benchmark Honesty + Cache Disclosure rules)

- The iOS screenshots shown in the work log were rendered by Apple's iOS 26.4 Simulator runtime, not by Kuri. Kuri's job is orchestrating and parsing.
- No benchmarks are claimed in this PR. If future PRs add them, label which path was exercised (adb-native Zig, simctl-shellout, devicectl-shellout, usbmuxd-native Zig) per the AGENTS.md rules.
- This is **not** a headless-Chrome / Playwright / Appium / Maestro replacement. It's a driverless host-side CLI.

## Test plan

- [x] `cd kuri-mobile && zig build` — green
- [x] `cd kuri-mobile && zig build test` — green (adb framing, parseDevices, uitree parser, usbmuxd plist scan)
- [x] `zig build` from repo root — green (main kuri still builds with new subcommand dispatch)
- [x] `zig build test` from repo root — green (existing tests pass)
- [x] `zig fmt` — clean
- [x] `./zig-out/bin/kuri --help` — shows new `android`/`ios` subcommands
- [x] Live iOS Simulator: navigate + screenshot flow (4 different targets)
- [x] Live Android: native adb client connects to real `adb server`, lists devices cleanly with clean error messages

## Not in scope (intentionally)

- On-device drivers (Kotlin APK, Swift XCUITest bundle)
- `run_code` sandboxed JS execution
- Real-device iOS tap/swipe/uitree
- MCP server mode (CLI-only in v1)

These are called out in `kuri-mobile/README.md` as a v2 path, so nobody claims parity with the upstream TypeScript project.

Generated with [Devin](https://cli.devin.ai/docs)
