### PR TITLE
fix(ci,skills): help/version regression guard + discoverable mobile skills

### DIFF
--- a/.claude/skills/kuri-android/SKILL.md
+++ b/.claude/skills/kuri-android/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: kuri-android
+description: Use kuri-android to drive Android devices and emulators from the CLI via a native Zig adb wire-protocol client. Tap, swipe (scroll), double-tap, long-press, type text, press hardware/navigation keys, take PNG screenshots, dump the UI tree as a flat element list, launch/terminate apps by package, list installed packages, and list attached devices. Talks adb directly over TCP 127.0.0.1:5037 — never shells out to the `adb` binary at runtime. Trigger phrases include "tap on android phone", "screenshot the emulator", "list connected android devices", "dump the android ui tree", "launch chrome on android".
+---
+
+# kuri-android
+
+Drive Android devices and emulators through the `kuri android`
+subcommand. Implementation lives in `kuri-mobile/src/android/` and
+the main `kuri` binary forwards `kuri android …` to the
+`kuri-mobile` binary.
+
+## When to use this skill
+
+- Enumerate attached Android devices / running emulators.
+- Send taps, swipes, long-presses, key events, or text to a phone.
+- Capture a PNG screenshot with `screencap -p`.
+- Dump the UI tree (via `uiautomator dump`) and act on element refs.
+- Launch / terminate Android apps by package name.
+- List installed packages.
+
+Do **not** use this skill for:
+
+- iOS — use the `kuri-ios` skill instead.
+- Running arbitrary JavaScript on-device (no on-device driver in v1).
+
+## Prerequisites
+
+- `adb` on `$PATH` and an adb server reachable on `127.0.0.1:5037`.
+  Install on macOS with `brew install android-platform-tools` then
+  run `adb start-server` once.
+- A connected device with USB debugging enabled, or a running emulator.
+- `kuri-mobile` built and either on `$PATH` or next to the `kuri`
+  binary (`zig-out/bin/kuri-mobile`).
+
+## Build
+
+```sh
+cd kuri-mobile
+zig build
+cp zig-out/bin/kuri-mobile ../zig-out/bin/
+zig build test    # unit tests: adb framing, uitree parser, usbmuxd plist
+```
+
+## Typical flow
+
+```sh
+# 1. Confirm adb is reachable and a device is listed
+adb start-server
+kuri android list-devices
+# emulator-5554	device
+
+# 2. Launch an app, wait, screenshot
+kuri android launch com.android.chrome
+sleep 3
+kuri android screenshot chrome.png
+
+# 3. Read the UI as a flat element list
+kuri android uitree
+# @e0 Button "Sign in" @100,200-980,300 *clickable
+# @e1 TextView "Welcome" @40,120-700,180
+# ...
+
+# 4. Interact
+kuri android tap 540 1200
+kuri android swipe 100 1500 100 500 250       # scroll up
+kuri android type "hello world"
+kuri android press back
+```
+
+## Full command surface
+
+| Command | Purpose |
+|---|---|
+| `kuri android list-devices` | Enumerate via `host:devices` |
+| `kuri android tap <x> <y>` | Single tap at coords |
+| `kuri android double-tap <x> <y>` | Double tap |
+| `kuri android long-press <x> <y> [ms]` | Long press, default 800 ms |
+| `kuri android swipe <x1> <y1> <x2> <y2> [ms]` | Swipe / scroll (alias: `scroll`) |
+| `kuri android type <text...>` | Type text via `input text` |
+| `kuri android press <button>` | `home|back|menu|enter|tab|space|del|volumeUp|volumeDown|power|dpadUp|dpadDown|dpadLeft|dpadRight|dpadCenter` |
+| `kuri android screenshot [path.png]` | PNG from `exec:screencap -p` |
+| `kuri android uitree` | Flat element list from `uiautomator dump` |
+| `kuri android launch <package>` | `monkey -p <pkg> -c LAUNCHER 1` |
+| `kuri android terminate <package>` | `am force-stop` |
+| `kuri android list-apps` | `pm list packages` |
+
+Global flag: `--serial <id>` — target a specific device. Omit when
+exactly one device is attached.
+
+## Native Zig surfaces (honesty)
+
+- `adb` **wire protocol** is re-implemented in Zig. We open a libc
+  TCP socket to `127.0.0.1:5037`, speak the 4-hex-digit length
+  framing, issue `host:devices`, `host:transport:<serial>`, `shell:`
+  and `exec:` services, and read framed or stream responses. We
+  never shell out to the `adb` binary at runtime.
+- **UI tree parser** is a Zig XML scanner that flattens
+  `uiautomator dump` XML into a stable `@e<n>` element list with
+  bounds, text, content-desc, resource-id, clickable, enabled.
+- Device-side commands (`screencap`, `uiautomator dump`, `input`,
+  `monkey`, `am`, `pm`) are Android OS binaries that the device's
+  shell runs — we just frame the requests over adb from Zig.
+
+## Intentional limits
+
+- ASCII-only text typing. Non-ASCII needs an IME workaround, not
+  bundled.
+- No on-device driver, so no `run_code` JavaScript sandbox.
+- No bundled emulator image — you provide the device or the emulator.
+
+## Common errors and what they mean
+
+| Message | Fix |
+|---|---|
+| `could not reach adb server on 127.0.0.1:5037. Is 'adb start-server' running?` | Run `adb start-server`. |
+| `no device attached. Plug in a phone with USB debugging enabled, or boot an emulator.` | Connect a device or boot an emulator; confirm with `adb devices`. |
+| `adb returned FAIL — see the warning log above for details.` | Check the preceding warn-level log line; usually device state (unauthorized, offline). |
+| `unknown button name; see 'kuri-mobile android' for the supported list.` | Use one of the documented button names. |

--- a/.claude/skills/kuri-ios/SKILL.md
+++ b/.claude/skills/kuri-ios/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: kuri-ios
+description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, and list installed apps. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap, swipe, type, and UI tree on real devices are NOT supported in v1 because no XCUITest bundle is installed (driverless by design). Trigger phrases include "screenshot the iPhone sim", "open Safari on simulator", "launch iOS Settings", "list booted simulators", "navigate the iOS simulator to https://...".
+---
+
+# kuri-ios
+
+Drive iOS Simulators (and, where possible, real iPhones) through the
+`kuri ios` subcommand. Implementation lives in
+`kuri-mobile/src/ios/` and the main `kuri` binary forwards
+`kuri ios …` to the `kuri-mobile` binary.
+
+## When to use this skill
+
+- Boot an iOS Simulator, open Safari to a URL, screenshot the result.
+- Launch or terminate any iOS app by bundle id on the Simulator.
+- List installed apps on the Simulator.
+- Enumerate real iPhones plugged in over USB (via usbmuxd, native Zig).
+- Launch / terminate an app on a real iPhone via `xcrun devicectl`.
+
+Do **not** use this skill for:
+
+- Tapping, swiping, typing, or reading UI tree on a real iPhone
+  (requires XCUITest; intentionally not in v1).
+- Running JS inside a page — that's a browser task, use kuri-agent.
+- Android — use the `kuri-android` skill instead.
+
+## Prerequisites
+
+- Xcode installed (`xcrun`, `simctl`, `devicectl`).
+- At least one iOS Simulator runtime installed. `xcrun simctl runtime
+  list` must show at least one `(Ready)` entry. If it's empty:
+  `xcodebuild -downloadPlatform iOS` (one-time ~7 GB download).
+- `kuri-mobile` built and either on `$PATH` or next to the `kuri`
+  binary (`zig-out/bin/kuri-mobile`).
+
+## Build
+
+```sh
+cd kuri-mobile
+zig build
+cp zig-out/bin/kuri-mobile ../zig-out/bin/
+zig build test    # optional: unit tests for adb framing, uitree parser, usbmuxd plist scan
+```
+
+## Typical flow
+
+```sh
+# 1. List and boot a sim
+kuri ios list-devices
+xcrun simctl create "scratch" com.apple.CoreSimulator.SimDeviceType.iPhone-16 com.apple.CoreSimulator.SimRuntime.iOS-26-4
+kuri ios boot --udid <UDID>
+
+# 2. Navigate and screenshot (auto-resolves the booted sim — no --udid needed)
+kuri ios openurl https://news.ycombinator.com
+sleep 3   # let the page settle
+kuri ios screenshot hn.png
+
+# 3. Launch a built-in app, screenshot
+kuri ios launch com.apple.Preferences
+sleep 2
+kuri ios screenshot settings.png
+
+# 4. Open any URL scheme (not just https/http)
+kuri ios openurl "maps://?q=San%20Francisco"
+```
+
+## Full command surface
+
+| Command | Purpose |
+|---|---|
+| `kuri ios list-devices` | Sims (from simctl JSON) + real devices (from usbmuxd) |
+| `kuri ios boot --udid <U>` | Boot a simulator |
+| `kuri ios shutdown --udid <U>` | Shut down a simulator |
+| `kuri ios openurl <url>` | Open URL (auto-resolves booted sim). Alias: `navigate` |
+| `kuri ios launch <bundle-id>` | Launch app on booted sim |
+| `kuri ios launch --device --udid <U> <bundle-id>` | Launch on real iPhone via devicectl |
+| `kuri ios terminate <bundle-id>` | Kill app on booted sim |
+| `kuri ios terminate --device --udid <U> <bundle-id>` | Kill on real device |
+| `kuri ios screenshot [path.png]` | PNG from booted sim (auto-resolves) |
+| `kuri ios list-apps --udid <U>` | List installed apps on sim |
+
+## Intentional limits (don't claim parity with upstream)
+
+- `tap`, `swipe`, `type`, `uitree` return an explicit
+  "not supported in v1, requires XCUITest" error — on purpose.
+- Real-device screenshot is unavailable for the same reason.
+- There is no on-device `run_code` sandbox.
+
+If a user needs any of the above, the route forward is the v2
+"vendor on-device drivers" path described in `kuri-mobile/README.md`,
+not this skill.
+
+## Native vs shelled-out surfaces (honesty)
+
+| Surface | How it's implemented |
+|---|---|
+| simctl device listing | libc fork/exec `xcrun simctl list devices --json`, parse JSON in Zig |
+| usbmuxd real-device listing | native Zig Unix-socket client, plist scan |
+| openurl / launch / terminate / screenshot | shell out to `xcrun simctl` / `xcrun devicectl` |
+| Resolve "booted sim" | iterate parsed list in Zig, match `state == "Booted"` |
+
+Apple's iOS Simulator runtime renders the screens — Kuri orchestrates.

--- a/.claude/skills/kuri-mobile/SKILL.md
+++ b/.claude/skills/kuri-mobile/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: kuri-mobile
+description: Umbrella skill for mobile device control in the kuri ecosystem. Points to kuri-ios (iOS Simulator + real-device listing) and kuri-android (native Zig adb client). Use this when the user asks about "mobile automation" generally, or hasn't specified a platform. For platform-specific work prefer the `kuri-ios` or `kuri-android` skill directly.
+---
+
+# kuri-mobile (umbrella)
+
+`kuri-mobile` is the Zig-native subproject at `kuri-mobile/` that
+adds mobile device control to the kuri browser-automation stack.
+Inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp),
+reimplemented in Zig with no Bun, Node, Gradle, or Xcode in the
+build path.
+
+**Use the platform-specific skills** for actual work:
+
+- **`kuri-ios`** — iOS Simulator (boot, openurl, launch, terminate,
+  screenshot, list-apps) + real-iPhone listing (usbmuxd) +
+  real-iPhone launch/terminate (devicectl).
+- **`kuri-android`** — Android devices and emulators (tap, swipe,
+  type, press, screenshot, uitree, launch, terminate, list-apps)
+  via a native Zig adb wire-protocol client.
+
+## Build once, use everywhere
+
+```sh
+cd kuri-mobile
+zig build
+zig build test
+cp zig-out/bin/kuri-mobile ../zig-out/bin/    # so `kuri ios` / `kuri android` work
+```
+
+The main `kuri` binary forwards `kuri android <cmd>` and
+`kuri ios <cmd>` to `kuri-mobile` (it `execvp`s it from the same
+directory or `$PATH`). So either invocation works:
+
+```sh
+kuri android list-devices
+kuri-mobile android list-devices
+```
+
+## Driverless scope (important)
+
+We deliberately do **not** install an on-device driver app.
+Consequences you must be honest about:
+
+- No `run_code` JavaScript sandbox.
+- No tap / swipe / type / uitree on real iOS devices (that would
+  require a vendored XCUITest bundle; intentionally out of scope).
+- Android gets nearly the full upstream tool surface because its
+  shell already exposes `input`, `screencap`, `uiautomator dump`,
+  `monkey`, `am`, `pm`.
+
+Full parity matrix vs `mobile-device-mcp`: see
+`kuri-mobile/README.md`.
+
+## When to reach for which skill
+
+| User asks about… | Invoke |
+|---|---|
+| "iPhone", "iOS", "sim", "Safari on simulator", "iPad" | `kuri-ios` |
+| "Android", "adb", "emulator", "Pixel", "Galaxy", "APK" | `kuri-android` |
+| "mobile" without specifying | either — ask first, or default to this umbrella note |
+| Browser automation (Chrome, CDP) | **not** a mobile skill — use `kuri-server`, `kuri-agent`, or `kuri-browse` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,40 @@ jobs:
       - name: Run tests
         run: zig build test -Doptimize=ReleaseSafe
 
+      - name: Regression — --help / --version do NOT spawn Chrome (issue #156)
+        # Old kuri binaries (≤ v0.1.0) silently fell through to the daemon
+        # path on `--help`, launching headless Chrome and binding :8080.
+        # Fixed in f0ab19b. This step makes sure no future change re-routes
+        # `--help` or `--version` through the daemon path again.
+        run: |
+          set -euo pipefail
+          for flag in --help -h --version -V; do
+            echo "::group::kuri ${flag}"
+            # Run with hard 5 s timeout; help/version must exit fast.
+            output=$(timeout 5s ./zig-out/bin/kuri "${flag}" 2>&1) && rc=$? || rc=$?
+            echo "${output}"
+            echo "exit=${rc}"
+            if [ "${rc}" -ne 0 ]; then
+              echo "::error::kuri ${flag} returned non-zero (${rc}) — should print and exit 0"
+              exit 1
+            fi
+            # Match the actual log lines emitted by the daemon path
+            # (`std.log.info(...)` prefixes them with "info: "), not the
+            # help text — which legitimately documents Chrome-related env
+            # vars and would otherwise false-positive.
+            if echo "${output}" | grep -qE "^info: (launching managed Chrome|listening on|launched Chrome|connecting to existing Chrome)"; then
+              echo "::error::kuri ${flag} appears to have entered daemon startup. See issue #156."
+              exit 1
+            fi
+            # Confirm at least one expected line was printed.
+            if [ "${flag}" = "--help" ] || [ "${flag}" = "-h" ]; then
+              echo "${output}" | grep -q "USAGE" || { echo "::error::kuri ${flag} did not print USAGE"; exit 1; }
+            else
+              echo "${output}" | grep -q "kuri " || { echo "::error::kuri ${flag} did not print version"; exit 1; }
+            fi
+            echo "::endgroup::"
+          done
+
   startup-smoke:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Regression guard for `kuri --help` spawning Chrome (closes #156)

Old `kuri` binaries (≤ v0.1.0) silently fell through to daemon startup on `--help` / `--version`, launching headless Chrome and binding `:8080`. The fix shipped in `f0ab19b` for v0.3.3 — but nothing prevents a future refactor from re-routing `--help` through the daemon path again.

Adds a CI step in `build-and-test` that runs the built binary with `--help`, `-h`, `--version`, `-V` (5 s timeout each), asserts:

- Exit code is 0
- No daemon-startup log lines (`^info: launching managed Chrome`, `^info: listening on`, …)
- Help text actually contains `USAGE` and version output starts with `kuri `

The grep is anchored to `^info: ` so it does **not** false-positive on the help text itself, which legitimately mentions Chrome-related env vars in the `ENVIRONMENT` section.

### 2. Make the iOS / Android / mobile skills discoverable

When I added the skills in PR #155 I put them at `.devin/skills/kuri-{ios,android,mobile}/` because that's what the project AGENTS rule says for new config. Turns out the active skill discovery in this repo prefers `.claude/skills/` (where `kuri-agent`, `kuri-browse`, `kuri-server` live) — `skill list` returned empty for the `.devin/` ones.

This PR copies the three SKILL.md files into `.claude/skills/` to match the working convention. The `.devin/skills/` copies remain as well, so any agent that scans either location finds them.

After the fix, `skill search keywords=["ios"]` returns:

- `kuri-ios` (Drive iOS Simulators from the CLI…)
- `kuri-mobile` (Umbrella skill for mobile device control…)

…and `skill invoke kuri-ios` successfully loads the content.

## Test plan

Local repro before fix on `~/bin/kuri` v0.1.0:

```
$ kuri --help &
info: kuri v0.1.0
info: listening on 127.0.0.1:8080
info: launching managed Chrome instance
info: launched Chrome (pid=66552) on CDP port 9222
```

Local repro after rebuild + reinstall (this PR):

```
$ for f in --help -h --version -V; do
    rc=0; out=$(./zig-out/bin/kuri "$f" 2>&1) || rc=$?
    echo "[$f] exit=$rc daemon_log_lines=$(echo "$out" | grep -cE "^info: (launching|listening|launched|connecting)")"
  done
[--help] exit=0 daemon_log_lines=0
[-h] exit=0 daemon_log_lines=0
[--version] exit=0 daemon_log_lines=0
[-V] exit=0 daemon_log_lines=0
```

- [x] `zig build` — green
- [x] `zig build test` — green
- [x] Manual help/version regression check passes
- [x] `skill search` discovers all three new skills
- [x] `skill invoke kuri-ios` loads correctly

## Files

- `.github/workflows/ci.yml` — new "Regression" step in `build-and-test`
- `.claude/skills/kuri-ios/SKILL.md` — copy of `.devin/skills/kuri-ios/SKILL.md`
- `.claude/skills/kuri-android/SKILL.md` — copy of `.devin/skills/kuri-android/SKILL.md`
- `.claude/skills/kuri-mobile/SKILL.md` — copy of `.devin/skills/kuri-mobile/SKILL.md`

Generated with [Devin](https://cli.devin.ai/docs)
