### PR TITLE
feat(kuri-mobile,ios): expose doubletap + longpress CLI subcommands

### DIFF
--- a/.claude/skills/kuri-ios/SKILL.md
+++ b/.claude/skills/kuri-ios/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kuri-ios
-description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, list installed apps, and (on the Simulator only) tap, swipe/pan, and type via native CGEvent into the Simulator window. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap/swipe/type/uitree on real devices and uitree on the Simulator are NOT supported in v1 (require XCUITest). Trigger phrases include "screenshot the iPhone sim", "tap on iOS simulator", "swipe up on iPhone sim", "pan the iOS simulator", "type into iOS simulator", "open Safari on simulator", "launch iOS Settings", "list booted simulators".
+description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, list installed apps, and (on the Simulator only) tap, doubletap, longpress, swipe/pan, and type via native CGEvent into the Simulator window. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap/swipe/type/uitree on real devices and uitree on the Simulator are NOT supported in v1 (require XCUITest). Multi-touch (pinch, rotate, two-finger pan) and hardware buttons (Home, Lock, Volume) are not wired yet. Trigger phrases include "screenshot the iPhone sim", "tap on iOS simulator", "doubletap iOS sim", "long press iOS sim", "swipe up on iPhone sim", "pan the iOS simulator", "type into iOS simulator", "open Safari on simulator", "launch iOS Settings", "list booted simulators".
 ---
 
 # kuri-ios
@@ -87,9 +87,10 @@ kuri ios openurl "maps://?q=San%20Francisco"
 | `kuri ios screenshot [path.png]` | PNG from booted sim (auto-resolves) |
 | `kuri ios list-apps --udid <U>` | List installed apps on sim |
 | `kuri ios tap <x> <y>` | Tap at device pixel coords on the booted sim |
+| `kuri ios doubletap <x> <y>` | Two quick taps at the same point (alias: `dbltap`) |
+| `kuri ios longpress <x> <y> [hold_ms]` | Press and hold (default 500ms — iOS haptic-touch threshold; alias: `long-press`) |
 | `kuri ios swipe <x1> <y1> <x2> <y2> [ms]` | Swipe/pan on the sim. Aliases: `pan`, `scroll` |
 | `kuri ios type <text...>` | Send keystrokes to the focused field on the sim |
-
 ## Intentional limits (don't claim parity with upstream)
 
 - `tap`, `swipe`, `type` work on the iOS **Simulator only** (CGEvent into

--- a/.devin/skills/kuri-ios/SKILL.md
+++ b/.devin/skills/kuri-ios/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kuri-ios
-description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, list installed apps, and (on the Simulator only) tap, swipe/pan, and type via native CGEvent into the Simulator window. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap/swipe/type/uitree on real devices and uitree on the Simulator are NOT supported in v1 (require XCUITest). Trigger phrases include "screenshot the iPhone sim", "tap on iOS simulator", "swipe up on iPhone sim", "pan the iOS simulator", "type into iOS simulator", "open Safari on simulator", "launch iOS Settings", "list booted simulators".
+description: Use kuri-ios to drive iOS Simulators from the CLI — list sims, boot/shutdown, navigate Safari to URLs (openurl), launch and terminate apps by bundle id, capture PNG screenshots, list installed apps, and (on the Simulator only) tap, doubletap, longpress, swipe/pan, and type via native CGEvent into the Simulator window. Real iPhones over USB are supported for listing and launch/terminate via usbmuxd + xcrun devicectl. Tap/swipe/type/uitree on real devices and uitree on the Simulator are NOT supported in v1 (require XCUITest). Multi-touch (pinch, rotate, two-finger pan) and hardware buttons (Home, Lock, Volume) are not wired yet. Trigger phrases include "screenshot the iPhone sim", "tap on iOS simulator", "doubletap iOS sim", "long press iOS sim", "swipe up on iPhone sim", "pan the iOS simulator", "type into iOS simulator", "open Safari on simulator", "launch iOS Settings", "list booted simulators".
 ---
 
 # kuri-ios
@@ -87,9 +87,10 @@ kuri ios openurl "maps://?q=San%20Francisco"
 | `kuri ios screenshot [path.png]` | PNG from booted sim (auto-resolves) |
 | `kuri ios list-apps --udid <U>` | List installed apps on sim |
 | `kuri ios tap <x> <y>` | Tap at device pixel coords on the booted sim |
+| `kuri ios doubletap <x> <y>` | Two quick taps at the same point (alias: `dbltap`) |
+| `kuri ios longpress <x> <y> [hold_ms]` | Press and hold (default 500ms — iOS haptic-touch threshold; alias: `long-press`) |
 | `kuri ios swipe <x1> <y1> <x2> <y2> [ms]` | Swipe/pan on the sim. Aliases: `pan`, `scroll` |
 | `kuri ios type <text...>` | Send keystrokes to the focused field on the sim |
-
 ## Intentional limits (don't claim parity with upstream)
 
 - `tap`, `swipe`, `type` work on the iOS **Simulator only** (CGEvent into

--- a/kuri-mobile/src/ios/cli.zig
+++ b/kuri-mobile/src/ios/cli.zig
@@ -111,6 +111,8 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     }
 
     if (std.mem.eql(u8, sub, "tap")) return cmdTap(gpa, udid_opt, simulator, cmd_args);
+    if (std.mem.eql(u8, sub, "doubletap") or std.mem.eql(u8, sub, "dbltap")) return cmdDoubleTap(gpa, udid_opt, simulator, cmd_args);
+    if (std.mem.eql(u8, sub, "longpress") or std.mem.eql(u8, sub, "long-press")) return cmdLongPress(gpa, udid_opt, simulator, cmd_args);
     if (std.mem.eql(u8, sub, "swipe") or std.mem.eql(u8, sub, "scroll") or std.mem.eql(u8, sub, "pan")) return cmdSwipe(gpa, udid_opt, simulator, cmd_args);
     if (std.mem.eql(u8, sub, "type")) return cmdType(gpa, udid_opt, simulator, cmd_args);
     if (std.mem.eql(u8, sub, "uitree")) {
@@ -184,6 +186,32 @@ fn cmdTap(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: 
     defer r.deinit(gpa);
     const p = try prepSimAndPoint(gpa, r.udid, x, y);
     sim_input.tap(p);
+    return 0;
+}
+
+fn cmdDoubleTap(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
+    if (guardSim(simulator)) |code| return code;
+    if (args.len < 2) return errMissing("x y");
+    const x = try parseF64(args[0]);
+    const y = try parseF64(args[1]);
+    const r = try resolveUdid(gpa, udid_opt);
+    defer r.deinit(gpa);
+    const p = try prepSimAndPoint(gpa, r.udid, x, y);
+    sim_input.doubleTap(p);
+    return 0;
+}
+
+fn cmdLongPress(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
+    if (guardSim(simulator)) |code| return code;
+    if (args.len < 2) return errMissing("x y [hold_ms]");
+    const x = try parseF64(args[0]);
+    const y = try parseF64(args[1]);
+    // iOS treats ~500ms as the threshold for "long press" / haptic touch.
+    const hold: u64 = if (args.len >= 3) try std.fmt.parseInt(u64, args[2], 10) else 500;
+    const r = try resolveUdid(gpa, udid_opt);
+    defer r.deinit(gpa);
+    const p = try prepSimAndPoint(gpa, r.udid, x, y);
+    sim_input.longPress(p, hold);
     return 0;
 }
 
@@ -299,13 +327,17 @@ fn printUsage() !void {
         \\  list-apps  --udid U --simulator
         \\
         \\Simulator-only input (macOS, device-pixel coords matching screenshot):
-        \\  tap   [--udid U] <x> <y>
-        \\  swipe [--udid U] <x1> <y1> <x2> <y2> [duration_ms]   (alias: scroll, pan)
-        \\  type  [--udid U] <text...>
+        \\  tap       [--udid U] <x> <y>
+        \\  doubletap [--udid U] <x> <y>                          (alias: dbltap)
+        \\  longpress [--udid U] <x> <y> [hold_ms]                (alias: long-press; default 500ms)
+        \\  swipe     [--udid U] <x1> <y1> <x2> <y2> [duration_ms]   (alias: scroll, pan)
+        \\  type      [--udid U] <text...>
         \\
         \\Not implemented in v1 (driverless mode):
         \\  tap, swipe, type on real iOS devices            -> needs XCUITest
         \\  uitree (simulator or device)                    -> needs XCUITest / Accessibility Inspector
+        \\  pinch / rotate / two-finger gestures            -> need CGEvent flags + multi-touch wiring
+        \\  hardware buttons (Home, Lock, Volume, Shake)    -> need osascript Simulator menu shortcuts
         \\
     );
 }


### PR DESCRIPTION
## Summary

Closes a gap in iOS Simulator input coverage. `sim_input.zig` already implements `doubleTap` and `longPress` (landed alongside tap/swipe/pan in 2b5fade), but neither is wired into the `kuri-mobile ios` CLI dispatcher — so the only click-like gesture available from agents is a single tap.

This adds two subcommands and the obvious aliases, plus updates `printUsage()` and the kuri-ios skill so agents can discover them:

```
kuri-mobile ios doubletap [--udid U] <x> <y>                       (alias: dbltap)
kuri-mobile ios longpress [--udid U] <x> <y> [hold_ms]             (alias: long-press; default 500ms)
```

Help text also now enumerates what is still missing so the gap is visible from `--help`:

- Multi-touch gestures (pinch / rotate / two-finger pan) — need `CGEvent` modifier-flag wiring (the Simulator's standard Option-modifier trick)
- Hardware buttons (Home / Lock / Volume / Shake) — need osascript Simulator-menu shortcuts (Cmd+Shift+H, Cmd+L, etc.)

## Test plan

- [x] `cd kuri-mobile && zig build` — clean
- [x] `zig build` at the repo root — clean (kuri-mobile is a separate sub-project)
- [x] `./kuri-mobile/zig-out/bin/kuri-mobile ios` prints the new subcommands in the help
- [ ] Manual: `kuri-mobile ios doubletap 100 100` on a booted Simulator with two interactive elements
- [ ] Manual: `kuri-mobile ios longpress 100 100 800` triggers iOS haptic-touch menu (e.g. on a Home screen icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)