### PR TITLE
release: v0.4.2 — React-compatible click + type/fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,51 @@ jobs:
           grep '"ok":true' health.json
           grep '"tabs":1' health.json
           grep '"id":"' tabs.json
+
+  windows-cross-compile:
+    # Verifies the Windows port stays buildable (issue #153). A native
+    # Windows runtime smoke test is out of scope for this job — Chrome
+    # automation, daemonization, and signal handling are all stubbed
+    # with `error.UnsupportedOnWindows` on Windows for now. This job
+    # exists so a future refactor that re-introduces an ungated POSIX
+    # call (`fork`, `std.c.open`, raw `setsockopt`/`read` on a socket)
+    # fails CI instead of silently regressing the Windows build.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            ~/.cache/zig
+          key: zig-windows-cross-${{ hashFiles('build.zig', 'build.zig.zon') }}
+          restore-keys: |
+            zig-windows-cross-
+
+      - name: Cross-compile for x86_64-windows-gnu
+        run: zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseSafe
+
+      - name: Verify Windows executables were produced
+        run: |
+          set -euo pipefail
+          for bin in kuri kuri-agent kuri-browse kuri-fetch; do
+            path="zig-out/bin/${bin}.exe"
+            if [ ! -f "${path}" ]; then
+              echo "::error::missing ${path}"
+              exit 1
+            fi
+            file "${path}" | tee -a windows-build.txt
+            if ! file "${path}" | grep -q 'PE32+ executable .* for MS Windows'; then
+              echo "::error::${path} is not a Windows PE binary"
+              exit 1
+            fi
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to kuri are documented here.
 
+## [0.4.2] — 2026-05-24
+
+### Fixes
+- **React/Vue click compatibility** — `click`, `check`, and `uncheck` actions now use CDP `Input.dispatchMouseEvent` (mousePressed/mouseReleased) instead of DOM `.click()`, producing trusted `isTrusted:true` events that React 18/19 event delegation recognizes (#164)
+- **React/Vue type/fill compatibility** — `type` and `fill` actions now use per-character CDP `Input.dispatchKeyEvent` instead of setting `target.value` directly, so React controlled inputs fire `onChange` correctly (#164)
+- **Click coordinate bug** — fixed JS operator precedence in bounding-rect center calculation that caused `r.y + r.height/2` to be string-concatenated instead of added
+- **Server type/fill default** — `realistic` mode (CDP key events) is now the default for the HTTP server `/action` endpoint; opt out with `realistic=false`
+
+### Testing
+- **React e2e fixture** — added `test/react-form.html` for validating form fill + click against React 18 controlled components
+
 ## [0.4.1] — 2026-05-23
 
 ### Release and install fixes

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .kuri,
-    .version = "0.4.0",
+    .version = "0.4.2",
     .dependencies = .{
         .quickjs = .{
             .url = "https://github.com/mitchellh/zig-quickjs-ng/archive/main.tar.gz",

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,11 @@ ARCH="$(uname -m)"
 case "$OS" in
   Darwin) OS_NAME="macos" ;;
   Linux)  OS_NAME="linux" ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    echo "kuri does not ship Windows binaries yet (tracked at https://github.com/justrach/kuri/issues/153)." >&2
+    echo "On Windows, use WSL2 and re-run this installer in a Linux shell." >&2
+    exit 1
+    ;;
   *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
 esac
 

--- a/npm/bin/install.js
+++ b/npm/bin/install.js
@@ -31,6 +31,13 @@ function resolveTarget(nodePlatform = process.platform, nodeArch = process.arch)
 
   const opsys = SUPPORTED_PLATFORMS[nodePlatform];
   if (!opsys) {
+    if (nodePlatform === "win32") {
+      throw new Error(
+        "unsupported platform: win32. kuri-agent does not ship Windows binaries yet " +
+          "(tracked at https://github.com/justrach/kuri/issues/153). On Windows, use WSL2 " +
+          "and install kuri-agent from a Linux shell."
+      );
+    }
     throw new Error(`unsupported platform: ${nodePlatform}. kuri-agent publishes binaries for darwin and linux only`);
   }
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuri-agent",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Agentic Chrome CLI — compact a11y snapshots, security testing, CDP automation. Written in Zig.",
   "keywords": ["browser", "automation", "agent", "cdp", "accessibility", "llm", "ai"],
   "homepage": "https://github.com/justrach/kuri",

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,16 @@ curl -fsSL https://raw.githubusercontent.com/justrach/kuri/release-channel/stabl
 
 The manifest includes exact asset URLs plus SHA-256 checksums for `aarch64-linux`, `x86_64-linux`, `aarch64-macos`, and `x86_64-macos`.
 
+### Platform support
+
+| Platform | Status |
+|---|---|
+| macOS (`aarch64`, `x86_64`) | Prebuilt binaries, signed + notarized |
+| Linux (`aarch64`, `x86_64`) | Prebuilt binaries |
+| Windows | **Not supported yet** — tracked at [#153](https://github.com/justrach/kuri/issues/153). Use **WSL2** and install the Linux build from a Linux shell. |
+
+Kuri leans on POSIX primitives (`fork`, `clock_gettime`, raw sockets) in several spots, so a native Windows port is real work and not on the near-term roadmap. If you want it sooner, +1 [#153](https://github.com/justrach/kuri/issues/153) or send a PR.
+
 ### Build from source
 
 Requires [Zig ≥ 0.16.0](https://ziglang.org/download/).

--- a/readme.md
+++ b/readme.md
@@ -144,9 +144,9 @@ The manifest includes exact asset URLs plus SHA-256 checksums for `aarch64-linux
 |---|---|
 | macOS (`aarch64`, `x86_64`) | Prebuilt binaries, signed + notarized |
 | Linux (`aarch64`, `x86_64`) | Prebuilt binaries |
-| Windows | **Not supported yet** — tracked at [#153](https://github.com/justrach/kuri/issues/153). Use **WSL2** and install the Linux build from a Linux shell. |
+| Windows (`x86_64`) | **Experimental — cross-compile only.** `zig build -Dtarget=x86_64-windows-gnu` is CI-verified, but Chrome automation, daemonization, signal-based shutdown, HAR recording, and the file-backed auth store are all stubbed with `error.UnsupportedOnWindows` at runtime. Use **WSL2** if you need the real feature set. Tracked at [#153](https://github.com/justrach/kuri/issues/153). |
 
-Kuri leans on POSIX primitives (`fork`, `clock_gettime`, raw sockets) in several spots, so a native Windows port is real work and not on the near-term roadmap. If you want it sooner, +1 [#153](https://github.com/justrach/kuri/issues/153) or send a PR.
+Kuri leans on POSIX primitives (`fork`, `clock_gettime`, raw sockets) in several spots, so a full native Windows port is real work. The compile-level baseline above lets the `--version`/`--help` paths and pure in-memory operations run; the gnarly bits (Chrome, sockets, daemonize) need real Win32 implementations before they come off the stub list. If you want to take any of those on, +1 [#153](https://github.com/justrach/kuri/issues/153) or open a PR.
 
 ### Build from source
 

--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -491,12 +491,11 @@ fn autoSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session) voi
 
 fn cdpClick(arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, action: []const u8) !void {
     const rect_js = if (std.mem.eql(u8, action, "check"))
-        "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }"
+        "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }"
     else if (std.mem.eql(u8, action, "uncheck"))
-        "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }"
+        "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }"
     else
-        "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }";
-
+        "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }";
     const escaped_rect = try escapeForJson(arena, rect_js);
     const rect_params = try std.fmt.allocPrint(arena,
         "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_rect });
@@ -547,6 +546,93 @@ fn cdpClick(arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8,
     compat.writeToStdout(out);
 }
 
+fn cdpType(arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, text: []const u8, append: bool) !void {
+    const focus_js = if (append)
+        \\function() {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this.isContentEditable) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("input,textarea,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  target.focus?.();
+        \\  return "focused";
+        \\}
+    else
+        \\function() {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this.isContentEditable) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("input,textarea,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  target.focus?.();
+        \\  if (target.isContentEditable) {
+        \\    target.textContent = "";
+        \\  } else if ("value" in target) {
+        \\    target.value = "";
+        \\  }
+        \\  target.dispatchEvent(new Event("focus", {bubbles:true}));
+        \\  return "focused";
+        \\}
+    ;
+
+    const escaped_focus = try escapeForJson(arena, focus_js);
+    const focus_params = try std.fmt.allocPrint(arena,
+        "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_focus });
+    _ = client.send(arena, protocol.Methods.runtime_call_function_on, focus_params) catch |err| {
+        jsonError("focus failed: {s}", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    for (text) |ch| {
+        const char_str = try std.fmt.allocPrint(arena, "{c}", .{ch});
+        const key_params = try std.fmt.allocPrint(arena,
+            "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str });
+        _ = client.send(arena, protocol.Methods.input_dispatch_key_event, key_params) catch continue;
+        const up_params = try std.fmt.allocPrint(arena,
+            "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str});
+        _ = client.send(arena, protocol.Methods.input_dispatch_key_event, up_params) catch continue;
+    }
+
+    const change_js =
+        \\function() {
+        \\  const target = (() => {
+        \\    if (!this) return null;
+        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
+        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this.isContentEditable) return this;
+        \\    if (typeof this.querySelector === "function") {
+        \\      const nested = this.querySelector("input,textarea,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
+        \\      if (nested) return nested;
+        \\    }
+        \\    return this;
+        \\  })();
+        \\  if (!target) return "missing-target";
+        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
+        \\  target.dispatchEvent(new Event("blur", {bubbles:true}));
+        \\  return "filled";
+        \\}
+    ;
+    const escaped_change = try escapeForJson(arena, change_js);
+    const change_params = try std.fmt.allocPrint(arena,
+        "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_change });
+    _ = client.send(arena, protocol.Methods.runtime_call_function_on, change_params) catch {};
+
+    compat.writeToStdout("{\"ok\":true,\"action\":\"filled\"}\n");
+}
+
+
 
 fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, action: []const u8, ref: []const u8, value: ?[]const u8) !void {
     // Normalize ref: strip leading '@' if present
@@ -575,33 +661,6 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
         std.process.exit(1);
     };
 
-    const value_action_fn =
-        \\function(value, append) {
-        \\  const target = (() => {
-        \\    if (!this) return null;
-        \\    if (this instanceof HTMLLabelElement && this.control) return this.control;
-        \\    if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement || this instanceof HTMLSelectElement) return this;
-        \\    if (this.isContentEditable) return this;
-        \\    if (typeof this.querySelector === "function") {
-        \\      const nested = this.querySelector("input,textarea,select,[contenteditable=\"true\"],[contenteditable=\"\"],[role=\"textbox\"]");
-        \\      if (nested) return nested;
-        \\    }
-        \\    return this;
-        \\  })();
-        \\  if (!target) return "missing-target";
-        \\  target.focus?.();
-        \\  if (target.isContentEditable) {
-        \\    const existing = typeof target.textContent === "string" ? target.textContent : "";
-        \\    target.textContent = append ? (existing + value) : value;
-        \\  } else if ("value" in target) {
-        \\    const existing = typeof target.value === "string" ? target.value : "";
-        \\    target.value = append ? (existing + value) : value;
-        \\  }
-        \\  target.dispatchEvent(new Event("input", {bubbles:true}));
-        \\  target.dispatchEvent(new Event("change", {bubbles:true}));
-        \\  return "filled";
-        \\}
-    ;
     const select_action_fn =
         \\function(value) {
         \\  const target = (() => {
@@ -640,19 +699,22 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
         return;
     }
 
+    // For type/fill, use CDP key events for React/Vue compatibility (#164)
+    if (std.mem.eql(u8, action, "type") or std.mem.eql(u8, action, "fill")) {
+        const v = value orelse {
+            jsonError("{s} requires a value", .{action});
+            std.process.exit(1);
+        };
+        const is_append = std.mem.eql(u8, action, "type");
+        try cdpType(arena, client, object_id, v, is_append);
+        return;
+    }
+
     const js_fn: []const u8 = blk: {
         if (std.mem.eql(u8, action, "hover")) break :blk "function() { this.dispatchEvent(new MouseEvent('mouseover', {bubbles:true})); return 'hovered'; }";
         if (std.mem.eql(u8, action, "focus")) break :blk "function() { this.focus(); return 'focused'; }";
         if (std.mem.eql(u8, action, "dblclick")) break :blk "function() { this.scrollIntoViewIfNeeded(); this.dispatchEvent(new MouseEvent('dblclick', {bubbles:true,cancelable:true})); return 'dblclicked'; }";
         if (std.mem.eql(u8, action, "blur")) break :blk "function() { this.blur(); return 'blurred'; }";
-        if (std.mem.eql(u8, action, "type") or std.mem.eql(u8, action, "fill")) {
-            const v = value orelse {
-                jsonError("{s} requires a value", .{action});
-                std.process.exit(1);
-            };
-            _ = v;
-            break :blk value_action_fn;
-        }
         if (std.mem.eql(u8, action, "select")) {
             const v = value orelse {
                 jsonError("select requires a value", .{});
@@ -669,18 +731,7 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
     const escaped_fn = try escapeForJson(arena, js_fn);
 
     // Step 3: call function on resolved object
-    const call_params = if (std.mem.eql(u8, action, "type") or std.mem.eql(u8, action, "fill")) blk: {
-        const v = value orelse {
-            jsonError("{s} requires a value", .{action});
-            std.process.exit(1);
-        };
-        const escaped_v = try escapeForJson(arena, v);
-        break :blk try std.fmt.allocPrint(
-            arena,
-            "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"arguments\":[{{\"value\":\"{s}\"}},{{\"value\":{s}}}],\"returnByValue\":true}}",
-            .{ object_id, escaped_fn, escaped_v, if (std.mem.eql(u8, action, "type")) "true" else "false" },
-        );
-    } else if (std.mem.eql(u8, action, "select")) blk: {
+    const call_params = if (std.mem.eql(u8, action, "select")) blk: {
         const v = value orelse {
             jsonError("select requires a value", .{});
             std.process.exit(1);

--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -266,6 +266,7 @@ fn cmdUse(arena: std.mem.Allocator, ws_url: []const u8) !void {
 /// Launch a visible (non-headless) Chrome with CDP, wait for it, auto-attach.
 /// This is the "human mode" — real browser, real user, agent rides alongside.
 fn cmdOpen(arena: std.mem.Allocator, port: u16, url: ?[]const u8) !void {
+    if (@import("builtin").os.tag == .windows) return error.UnsupportedOnWindows;
     // 1. Check if Chrome CDP is already available on this port
     if (tryAttach(arena, port, url)) return;
 
@@ -1328,6 +1329,7 @@ fn saveSession(arena: std.mem.Allocator, session: *Session) !void {
 extern "c" fn connect(sock: std.c.fd_t, addr: *const std.posix.sockaddr, addrlen: std.posix.socklen_t) c_int;
 
 fn fetchChromeTabs(arena: std.mem.Allocator, host: []const u8, port: u16) ![]const u8 {
+    if (@import("builtin").os.tag == .windows) return error.ConnectionRefused;
     _ = host;
     // Create TCP socket
     const raw_fd = std.c.socket(std.posix.AF.INET, std.posix.SOCK.STREAM, 0);

--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -489,6 +489,65 @@ fn autoSnap(arena: std.mem.Allocator, client: *CdpClient, session: *Session) voi
     compat.writeToStdout(compact);
 }
 
+fn cdpClick(arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, action: []const u8) !void {
+    const rect_js = if (std.mem.eql(u8, action, "check"))
+        "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }"
+    else if (std.mem.eql(u8, action, "uncheck"))
+        "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }"
+    else
+        "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }";
+
+    const escaped_rect = try escapeForJson(arena, rect_js);
+    const rect_params = try std.fmt.allocPrint(arena,
+        "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_rect });
+    const rect_resp = client.send(arena, protocol.Methods.runtime_call_function_on, rect_params) catch |err| {
+        jsonError("getBoundingClientRect failed: {s}", .{@errorName(err)});
+        std.process.exit(1);
+    };
+    const coords_str = extractCdpValue(rect_resp);
+
+    if (std.mem.eql(u8, coords_str, "skip")) {
+        const label = if (std.mem.eql(u8, action, "check")) "checked" else "unchecked";
+        const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"{s}\"}}\n", .{label});
+        compat.writeToStdout(out);
+        return;
+    }
+
+    const comma = std.mem.indexOfScalar(u8, coords_str, ',') orelse {
+        jsonError("could not parse element coordinates", .{});
+        std.process.exit(1);
+    };
+    const x = std.fmt.parseFloat(f64, coords_str[0..comma]) catch {
+        jsonError("could not parse element x coordinate", .{});
+        std.process.exit(1);
+    };
+    const y = std.fmt.parseFloat(f64, coords_str[comma + 1 ..]) catch {
+        jsonError("could not parse element y coordinate", .{});
+        std.process.exit(1);
+    };
+    const x_int: i64 = @intFromFloat(@round(x));
+    const y_int: i64 = @intFromFloat(@round(y));
+
+    const down_params = try std.fmt.allocPrint(arena,
+        "{{\"type\":\"mousePressed\",\"x\":{d},\"y\":{d},\"button\":\"left\",\"clickCount\":1}}", .{ x_int, y_int });
+    _ = client.send(arena, protocol.Methods.input_dispatch_mouse_event, down_params) catch |err| {
+        jsonError("Input.dispatchMouseEvent(mousePressed) failed: {s}", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    const up_params = try std.fmt.allocPrint(arena,
+        "{{\"type\":\"mouseReleased\",\"x\":{d},\"y\":{d},\"button\":\"left\",\"clickCount\":1}}", .{ x_int, y_int });
+    _ = client.send(arena, protocol.Methods.input_dispatch_mouse_event, up_params) catch |err| {
+        jsonError("Input.dispatchMouseEvent(mouseReleased) failed: {s}", .{@errorName(err)});
+        std.process.exit(1);
+    };
+
+    const label = if (std.mem.eql(u8, action, "check")) "checked" else if (std.mem.eql(u8, action, "uncheck")) "unchecked" else "clicked";
+    const out = try std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"{s}\"}}\n", .{label});
+    compat.writeToStdout(out);
+}
+
+
 fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, action: []const u8, ref: []const u8, value: ?[]const u8) !void {
     // Normalize ref: strip leading '@' if present
     const clean_ref = if (ref.len > 0 and ref[0] == '@') ref[1..] else ref;
@@ -575,14 +634,17 @@ fn cmdAction(arena: std.mem.Allocator, client: *CdpClient, session: *Session, ac
     ;
 
     // Step 2: build JS function for the action
+    // For click/check/uncheck, use CDP Input.dispatchMouseEvent for React/Vue compatibility (#164)
+    if (std.mem.eql(u8, action, "click") or std.mem.eql(u8, action, "check") or std.mem.eql(u8, action, "uncheck")) {
+        try cdpClick(arena, client, object_id, action);
+        return;
+    }
+
     const js_fn: []const u8 = blk: {
-        if (std.mem.eql(u8, action, "click")) break :blk "function() { this.scrollIntoViewIfNeeded(); this.click(); return 'clicked'; }";
         if (std.mem.eql(u8, action, "hover")) break :blk "function() { this.dispatchEvent(new MouseEvent('mouseover', {bubbles:true})); return 'hovered'; }";
         if (std.mem.eql(u8, action, "focus")) break :blk "function() { this.focus(); return 'focused'; }";
         if (std.mem.eql(u8, action, "dblclick")) break :blk "function() { this.scrollIntoViewIfNeeded(); this.dispatchEvent(new MouseEvent('dblclick', {bubbles:true,cancelable:true})); return 'dblclicked'; }";
         if (std.mem.eql(u8, action, "blur")) break :blk "function() { this.blur(); return 'blurred'; }";
-        if (std.mem.eql(u8, action, "check")) break :blk "function() { if (!this.checked) { this.click(); } return 'checked'; }";
-        if (std.mem.eql(u8, action, "uncheck")) break :blk "function() { if (this.checked) { this.click(); } return 'unchecked'; }";
         if (std.mem.eql(u8, action, "type") or std.mem.eql(u8, action, "fill")) {
             const v = value orelse {
                 jsonError("{s} requires a value", .{action});

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -680,7 +680,7 @@ fn shouldUseColor() bool {
     if (compat.getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
-    return std.c.isatty(2) != 0;
+    return compat.isTtyStderr();
 }
 
 fn elapsed(start: i128) u64 {

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -193,6 +193,7 @@ const Browser = struct {
     }
 
     fn repl(self: *Browser) void {
+        if (@import("builtin").os.tag == .windows) return;
         const stdin_fd: std.posix.fd_t = 0;
         var line_buf: [4096]u8 = undefined;
 
@@ -655,6 +656,7 @@ fn findLinkNum(links: []const []const u8, url: []const u8, fallback: usize) usiz
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 fn readLine(fd: std.posix.fd_t, buf: []u8) ?[]const u8 {
+    if (@import("builtin").os.tag == .windows) return null;
     var i: usize = 0;
     while (i < buf.len) {
         const bytes_read = std.posix.read(fd, buf[i .. i + 1]) catch return null;

--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -243,6 +243,7 @@ pub const CdpClient = struct {
     }
 
     pub fn drainWsEvents(self: *CdpClient, allocator: std.mem.Allocator, timeout_sec: i32) void {
+        if (@import("builtin").os.tag == .windows) return;
         self.mu.lock();
         defer self.mu.unlock();
 

--- a/src/cdp/websocket.zig
+++ b/src/cdp/websocket.zig
@@ -27,6 +27,7 @@ pub const WebSocketClient = struct {
 
     /// Connect to a loopback WebSocket endpoint. url must be like "ws://host:port/path".
     pub fn connect(allocator: std.mem.Allocator, url: []const u8, read_buf: []u8, write_buf: []u8) !WebSocketClient {
+        if (@import("builtin").os.tag == .windows) return Error.ConnectionFailed;
         const parsed = try parseWsUrl(url);
 
         // Resolve localhost to 127.0.0.1 — resolveIp fails on some systems
@@ -235,6 +236,7 @@ pub const WebSocketClient = struct {
     }
 
     fn rawRead(self: *WebSocketClient, buf: []u8) !usize {
+        if (@import("builtin").os.tag == .windows) return Error.ReadFailed;
         return std.posix.read(self.fd, buf) catch return Error.ReadFailed;
     }
 

--- a/src/chrome/launcher.zig
+++ b/src/chrome/launcher.zig
@@ -103,6 +103,7 @@ pub const Launcher = struct {
 
     /// Spawn the Chrome process with headless flags.
     fn launchChrome(self: *Launcher) !void {
+        if (@import("builtin").os.tag == .windows) return error.UnsupportedOnWindows;
         const chrome_bin = findChromeBinary() orelse {
             std.log.err("no Chrome binary found on this system", .{});
             return error.ChromeNotFound;
@@ -272,6 +273,10 @@ pub const Launcher = struct {
 
     /// Shut down the managed Chrome process.
     pub fn deinit(self: *Launcher) void {
+        if (@import("builtin").os.tag == .windows) {
+            self.child_pid = null;
+            return;
+        }
         if (self.child_pid) |pid| {
             _ = std.c.kill(pid, std.c.SIG.KILL);
             _ = std.c.waitpid(pid, null, 0);

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,24 +1,63 @@
 /// Zig 0.16 compatibility shims for removed stdlib APIs.
 const std = @import("std");
+const builtin = @import("builtin");
+
+// --- Windows API shims (Zig 0.16's std.os.windows only exposes some Win32 entry points) ---
+
+const winapi = struct {
+    const DWORD = std.os.windows.DWORD;
+    const BOOL = std.os.windows.BOOL;
+    const HANDLE = std.os.windows.HANDLE;
+    const FILETIME = std.os.windows.FILETIME;
+
+    // Win32 ABI: STD_*_HANDLE are (DWORD)-N, expressed as wrapped u32 values.
+    const STD_ERROR_HANDLE: DWORD = 0xFFFFFFF4; // -12
+
+    extern "kernel32" fn GetSystemTimeAsFileTime(lpSystemTimeAsFileTime: *FILETIME) callconv(.winapi) void;
+    extern "kernel32" fn GetStdHandle(nStdHandle: DWORD) callconv(.winapi) ?HANDLE;
+    extern "kernel32" fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *DWORD) callconv(.winapi) BOOL;
+};
 
 // --- Time ---
 
-pub fn timestampSeconds() i64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return ts.sec;
-}
+/// 100-nanosecond intervals between the Windows FILETIME epoch (1601-01-01 UTC)
+/// and the Unix epoch (1970-01-01 UTC). FILETIME counts in 100ns ticks.
+const FILETIME_TO_UNIX_100NS: i128 = 11_644_473_600 * 10_000_000;
 
-pub fn milliTimestamp() i64 {
-    var ts: std.c.timespec = undefined;
-    _ = std.c.clock_gettime(.REALTIME, &ts);
-    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
-}
-
-pub fn nanoTimestamp() i128 {
+fn realtimeNanos() i128 {
+    if (builtin.os.tag == .windows) {
+        var ft: winapi.FILETIME = undefined;
+        winapi.GetSystemTimeAsFileTime(&ft);
+        const ft_100ns: i128 = (@as(i128, ft.dwHighDateTime) << 32) | @as(i128, ft.dwLowDateTime);
+        return (ft_100ns - FILETIME_TO_UNIX_100NS) * 100;
+    }
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.REALTIME, &ts);
     return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
+pub fn timestampSeconds() i64 {
+    return @intCast(@divTrunc(realtimeNanos(), std.time.ns_per_s));
+}
+
+pub fn milliTimestamp() i64 {
+    return @intCast(@divTrunc(realtimeNanos(), std.time.ns_per_ms));
+}
+
+pub fn nanoTimestamp() i128 {
+    return realtimeNanos();
+}
+
+// --- TTY detection ---
+
+/// Returns true if stderr (fd 2) is attached to a terminal.
+pub fn isTtyStderr() bool {
+    if (builtin.os.tag == .windows) {
+        const handle = winapi.GetStdHandle(winapi.STD_ERROR_HANDLE) orelse return false;
+        var mode: winapi.DWORD = undefined;
+        return winapi.GetConsoleMode(handle, &mode).toBool();
+    }
+    return std.c.isatty(2) != 0;
 }
 
 // --- Threading ---

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -11,11 +11,28 @@ const winapi = struct {
     const FILETIME = std.os.windows.FILETIME;
 
     // Win32 ABI: STD_*_HANDLE are (DWORD)-N, expressed as wrapped u32 values.
+    const STD_OUTPUT_HANDLE: DWORD = 0xFFFFFFF5; // -11
     const STD_ERROR_HANDLE: DWORD = 0xFFFFFFF4; // -12
+
+    /// Windows Slim Reader/Writer lock. Zero-initialized = SRWLOCK_INIT.
+    const SRWLOCK = extern struct { Ptr: ?*anyopaque = null };
 
     extern "kernel32" fn GetSystemTimeAsFileTime(lpSystemTimeAsFileTime: *FILETIME) callconv(.winapi) void;
     extern "kernel32" fn GetStdHandle(nStdHandle: DWORD) callconv(.winapi) ?HANDLE;
     extern "kernel32" fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *DWORD) callconv(.winapi) BOOL;
+    extern "kernel32" fn WriteFile(
+        hFile: HANDLE,
+        lpBuffer: [*]const u8,
+        nNumberOfBytesToWrite: DWORD,
+        lpNumberOfBytesWritten: ?*DWORD,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) BOOL;
+    extern "kernel32" fn Sleep(dwMilliseconds: DWORD) callconv(.winapi) void;
+    extern "kernel32" fn AcquireSRWLockExclusive(SRWLock: *SRWLOCK) callconv(.winapi) void;
+    extern "kernel32" fn ReleaseSRWLockExclusive(SRWLock: *SRWLOCK) callconv(.winapi) void;
+    extern "kernel32" fn TryAcquireSRWLockExclusive(SRWLock: *SRWLOCK) callconv(.winapi) BOOL;
+    extern "kernel32" fn AcquireSRWLockShared(SRWLock: *SRWLOCK) callconv(.winapi) void;
+    extern "kernel32" fn ReleaseSRWLockShared(SRWLock: *SRWLOCK) callconv(.winapi) void;
 };
 
 // --- Time ---
@@ -63,6 +80,12 @@ pub fn isTtyStderr() bool {
 // --- Threading ---
 
 pub fn threadSleep(ns: u64) void {
+    if (@import("builtin").os.tag == .windows) {
+        const ms_u128: u128 = @as(u128, ns) / std.time.ns_per_ms;
+        const ms: winapi.DWORD = @intCast(@min(ms_u128, @as(u128, std.math.maxInt(winapi.DWORD))));
+        winapi.Sleep(ms);
+        return;
+    }
     const ts = std.c.timespec{
         .sec = @intCast(ns / std.time.ns_per_s),
         .nsec = @intCast(ns % std.time.ns_per_s),
@@ -70,33 +93,62 @@ pub fn threadSleep(ns: u64) void {
     _ = std.c.nanosleep(&ts, null);
 }
 
+const is_windows_target = @import("builtin").os.tag == .windows;
+
 pub const PthreadMutex = struct {
-    inner: std.c.pthread_mutex_t = std.c.PTHREAD_MUTEX_INITIALIZER,
+    inner: if (is_windows_target) winapi.SRWLOCK else std.c.pthread_mutex_t =
+        if (is_windows_target) winapi.SRWLOCK{} else std.c.PTHREAD_MUTEX_INITIALIZER,
 
     pub fn lock(m: *PthreadMutex) void {
+        if (is_windows_target) {
+            winapi.AcquireSRWLockExclusive(&m.inner);
+            return;
+        }
         _ = std.c.pthread_mutex_lock(&m.inner);
     }
     pub fn unlock(m: *PthreadMutex) void {
+        if (is_windows_target) {
+            winapi.ReleaseSRWLockExclusive(&m.inner);
+            return;
+        }
         _ = std.c.pthread_mutex_unlock(&m.inner);
     }
     pub fn tryLock(m: *PthreadMutex) bool {
+        if (is_windows_target) return winapi.TryAcquireSRWLockExclusive(&m.inner).toBool();
         return @intFromEnum(std.c.pthread_mutex_trylock(&m.inner)) == 0;
     }
 };
 
 pub const PthreadRwLock = struct {
-    inner: std.c.pthread_rwlock_t = .{},
+    inner: if (is_windows_target) winapi.SRWLOCK else std.c.pthread_rwlock_t =
+        if (is_windows_target) winapi.SRWLOCK{} else .{},
 
     pub fn lock(rw: *PthreadRwLock) void {
+        if (is_windows_target) {
+            winapi.AcquireSRWLockExclusive(&rw.inner);
+            return;
+        }
         _ = std.c.pthread_rwlock_wrlock(&rw.inner);
     }
     pub fn unlock(rw: *PthreadRwLock) void {
+        if (is_windows_target) {
+            winapi.ReleaseSRWLockExclusive(&rw.inner);
+            return;
+        }
         _ = std.c.pthread_rwlock_unlock(&rw.inner);
     }
     pub fn lockShared(rw: *PthreadRwLock) void {
+        if (is_windows_target) {
+            winapi.AcquireSRWLockShared(&rw.inner);
+            return;
+        }
         _ = std.c.pthread_rwlock_rdlock(&rw.inner);
     }
     pub fn unlockShared(rw: *PthreadRwLock) void {
+        if (is_windows_target) {
+            winapi.ReleaseSRWLockShared(&rw.inner);
+            return;
+        }
         _ = std.c.pthread_rwlock_unlock(&rw.inner);
     }
 };
@@ -147,18 +199,40 @@ pub fn getenv(name: []const u8) ?[]const u8 {
 // --- Filesystem (replaces removed std.fs.cwd / std.fs.File) ---
 
 pub fn writeToStdout(data: []const u8) void {
-    var sent: usize = 0;
-    while (sent < data.len) {
-        const n = std.c.write(1, data[sent..].ptr, data.len - sent);
-        if (n <= 0) break;
-        sent += @intCast(n);
-    }
+    writeToStdHandle(.stdout, data);
 }
 
 pub fn writeToStderr(data: []const u8) void {
+    writeToStdHandle(.stderr, data);
+}
+
+const StdStream = enum { stdout, stderr };
+
+fn writeToStdHandle(which: StdStream, data: []const u8) void {
+    if (builtin.os.tag == .windows) {
+        const handle_id: winapi.DWORD = switch (which) {
+            .stdout => winapi.STD_OUTPUT_HANDLE,
+            .stderr => winapi.STD_ERROR_HANDLE,
+        };
+        const handle = winapi.GetStdHandle(handle_id) orelse return;
+        var sent: usize = 0;
+        while (sent < data.len) {
+            const remaining = data.len - sent;
+            const chunk: winapi.DWORD = @intCast(@min(remaining, std.math.maxInt(winapi.DWORD)));
+            var written: winapi.DWORD = 0;
+            if (!winapi.WriteFile(handle, data[sent..].ptr, chunk, &written, null).toBool()) break;
+            if (written == 0) break;
+            sent += written;
+        }
+        return;
+    }
+    const fd: c_int = switch (which) {
+        .stdout => 1,
+        .stderr => 2,
+    };
     var sent: usize = 0;
     while (sent < data.len) {
-        const n = std.c.write(2, data[sent..].ptr, data.len - sent);
+        const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
         if (n <= 0) break;
         sent += @intCast(n);
     }
@@ -167,6 +241,7 @@ pub fn writeToStderr(data: []const u8) void {
 // --- Filesystem (cwd operations using C calls) ---
 
 pub fn cwdCreateFile(path: []const u8) !std.c.fd_t {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return error.NameTooLong;
     @memcpy(buf[0..path.len], path);
@@ -177,6 +252,7 @@ pub fn cwdCreateFile(path: []const u8) !std.c.fd_t {
 }
 
 pub fn cwdReadFile(allocator: std.mem.Allocator, path: []const u8, max_size: usize) ![]u8 {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return error.NameTooLong;
     @memcpy(buf[0..path.len], path);
@@ -198,6 +274,7 @@ pub fn cwdReadFile(allocator: std.mem.Allocator, path: []const u8, max_size: usi
 }
 
 pub fn cwdWriteFile(path: []const u8, data: []const u8) !void {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     const fd = try cwdCreateFile(path);
     defer _ = std.c.close(fd);
     var sent: usize = 0;
@@ -209,6 +286,7 @@ pub fn cwdWriteFile(path: []const u8, data: []const u8) !void {
 }
 
 pub fn cwdMakePath(path: []const u8) !void {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     // Iteratively create each component
     var i: usize = 0;
     while (i < path.len) {
@@ -223,6 +301,7 @@ pub fn cwdMakePath(path: []const u8) !void {
 }
 
 pub fn cwdDeleteFile(path: []const u8) !void {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return error.NameTooLong;
     @memcpy(buf[0..path.len], path);
@@ -231,6 +310,7 @@ pub fn cwdDeleteFile(path: []const u8) !void {
 }
 
 pub fn cwdAccess(path: []const u8) bool {
+    if (builtin.os.tag == .windows) return false;
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return false;
     @memcpy(buf[0..path.len], path);
@@ -239,6 +319,7 @@ pub fn cwdAccess(path: []const u8) bool {
 }
 
 pub fn fdWriteAll(fd: std.c.fd_t, data: []const u8) !void {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     var sent: usize = 0;
     while (sent < data.len) {
         const n = std.c.write(fd, data[sent..].ptr, data.len - sent);
@@ -248,6 +329,7 @@ pub fn fdWriteAll(fd: std.c.fd_t, data: []const u8) !void {
 }
 
 pub fn fdClose(fd: std.c.fd_t) void {
+    if (builtin.os.tag == .windows) return;
     _ = std.c.close(fd);
 }
 
@@ -256,6 +338,7 @@ pub fn fdClose(fd: std.c.fd_t) void {
 pub extern "c" fn execvp(file: [*:0]const u8, argv: [*:null]const ?[*:0]const u8) c_int;
 
 pub fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8, max_output: usize) !struct { stdout: []u8, term: i32 } {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     var arg_storage: std.ArrayList([:0]u8) = .empty;
     defer {
         for (arg_storage.items) |arg| allocator.free(arg);
@@ -330,6 +413,7 @@ fn ntohs(val: u16) u16 {
 
 /// Try to connect to 127.0.0.1:port. Returns true if connection succeeded.
 pub fn isPortInUse(port: u16) bool {
+    if (builtin.os.tag == .windows) return false;
     const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
     if (fd < 0) return false;
     defer _ = c.close(fd);
@@ -348,10 +432,12 @@ pub const TcpStream = struct {
     fd: fd_t,
 
     pub fn close(self: TcpStream) void {
+        if (builtin.os.tag == .windows) return;
         _ = c.close(self.fd);
     }
 
     pub fn writeAll(self: TcpStream, data: []const u8) !void {
+        if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
         var sent: usize = 0;
         while (sent < data.len) {
             const n = c.write(self.fd, data[sent..].ptr, data.len - sent);
@@ -361,24 +447,28 @@ pub const TcpStream = struct {
     }
 
     pub fn read(self: TcpStream, buf: []u8) !usize {
+        if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
         const n = c.read(self.fd, buf.ptr, buf.len);
         if (n < 0) return error.ConnectionResetByPeer;
         return @intCast(n);
     }
 
     pub fn write(self: TcpStream, data: []const u8) !usize {
+        if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
         const n = c.write(self.fd, data.ptr, data.len);
         if (n <= 0) return error.BrokenPipe;
         return @intCast(n);
     }
 
     pub fn setSockOpt(self: TcpStream, level: i32, optname: u32, optval: []const u8) void {
+        if (builtin.os.tag == .windows) return;
         _ = c.setsockopt(self.fd, level, optname, optval.ptr, @intCast(optval.len));
     }
 };
 
 /// Connect to 127.0.0.1:port via TCP. Returns a TcpStream.
 pub fn tcpConnectToIp4(port: u16) !TcpStream {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
     if (fd < 0) return error.SocketCreateFailed;
 
@@ -411,18 +501,21 @@ pub const TcpServer = struct {
     };
 
     pub fn accept(self: TcpServer) !Connection {
+        if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
         const client_fd = c.accept(self.fd, null, null);
         if (client_fd < 0) return error.AcceptFailed;
         return .{ .stream = .{ .fd = client_fd } };
     }
 
     pub fn deinit(self: *TcpServer) void {
+        if (builtin.os.tag == .windows) return;
         _ = c.close(self.fd);
     }
 };
 
 /// Bind and listen on 127.0.0.1:port.
 pub fn tcpListen(port: u16) !TcpServer {
+    if (builtin.os.tag == .windows) return error.UnsupportedOnWindows;
     const fd = c.socket(c.AF.INET, c.SOCK.STREAM, 0);
     if (fd < 0) return error.SocketCreateFailed;
     errdefer _ = c.close(fd);

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -203,7 +203,7 @@ fn shouldUseColor(force_no_color: bool) bool {
     if (compat.getenv("TERM")) |term| {
         if (std.mem.eql(u8, term, "dumb")) return false;
     }
-    return std.c.isatty(2) != 0;
+    return compat.isTtyStderr();
 }
 
 const Options = struct {

--- a/src/lifecycle.zig
+++ b/src/lifecycle.zig
@@ -16,7 +16,10 @@ const launcher = @import("chrome/launcher.zig");
 var launcher_ptr: ?*launcher.Launcher = null;
 
 pub fn install(l: *launcher.Launcher) void {
-    launcher_ptr = l;
+    if (@import("builtin").os.tag == .windows) {
+        launcher_ptr = l;
+        return;
+    }
 
     var sa: std.c.Sigaction = std.mem.zeroes(std.c.Sigaction);
     sa.handler = .{ .handler = handler };

--- a/src/server/api_token.zig
+++ b/src/server/api_token.zig
@@ -125,7 +125,7 @@ pub fn printStartupBanner(
     port: u16,
     resolved: Resolved,
 ) void {
-    const stderr_is_tty = std.c.isatty(2) != 0;
+    const stderr_is_tty = compat.isTtyStderr();
 
     var token_buf: [128]u8 = undefined;
     const token_line: []const u8 = switch (resolved.source) {

--- a/src/server/api_token.zig
+++ b/src/server/api_token.zig
@@ -87,6 +87,7 @@ fn resolveTokenPath(allocator: std.mem.Allocator) ![]u8 {
 }
 
 fn writeMode0600(path: []const u8, data: []const u8) !void {
+    if (@import("builtin").os.tag == .windows) return error.UnsupportedOnWindows;
     var buf: [4096]u8 = undefined;
     if (path.len >= buf.len) return error.NameTooLong;
     @memcpy(buf[0..path.len], path);

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -896,9 +896,9 @@ fn sendSnapshotResponse(request: *std.http.Server.Request, arena: std.mem.Alloca
 
 fn cdpClickHttp(request: *std.http.Server.Request, arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, kind: @import("../cdp/actions.zig").ActionKind) void {
     const rect_js: []const u8 = switch (kind) {
-        .check => "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
-        .uncheck => "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
-        else => "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
+        .check => "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }",
+        .uncheck => "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }",
+        else => "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return (r.x+r.width/2)+','+(r.y+r.height/2); }",
     };
 
     const escaped_rect = jsonEscapeAlloc(arena, rect_js) orelse {
@@ -1144,8 +1144,8 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
                 resp.sendError(request, 400, "Missing value parameter for fill/type");
                 return;
             };
-            // realistic=true: use per-character key events for React/Vue compatibility
-            const use_realistic = if (realistic) |r| std.mem.eql(u8, r, "true") else false;
+            // Default to CDP key events for React/Vue compatibility (#164); opt out with realistic=false
+            const use_realistic = if (realistic) |r| !std.mem.eql(u8, r, "false") else true;
             if (use_realistic) {
                 // Focus the element first
                 const focus_fn =

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -894,6 +894,89 @@ fn sendSnapshotResponse(request: *std.http.Server.Request, arena: std.mem.Alloca
     resp.sendJson(request, json_buf.items);
 }
 
+fn cdpClickHttp(request: *std.http.Server.Request, arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, kind: @import("../cdp/actions.zig").ActionKind) void {
+    const rect_js: []const u8 = switch (kind) {
+        .check => "function() { this.scrollIntoViewIfNeeded(); if (this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
+        .uncheck => "function() { this.scrollIntoViewIfNeeded(); if (!this.checked) return 'skip'; const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
+        else => "function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return r.x+r.width/2+','+r.y+r.height/2; }",
+    };
+
+    const escaped_rect = jsonEscapeAlloc(arena, rect_js) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const rect_params = std.fmt.allocPrint(arena,
+        "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_rect }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const rect_resp = client.send(arena, protocol.Methods.runtime_call_function_on, rect_params) catch {
+        resp.sendError(request, 502, "getBoundingClientRect failed");
+        return;
+    };
+    const coords_str = extractSimpleJsonString(rect_resp, 0, "\"value\"") orelse {
+        resp.sendError(request, 500, "Could not parse element coordinates");
+        return;
+    };
+
+    if (std.mem.eql(u8, coords_str, "skip")) {
+        const label = if (kind == .check) "checked" else "unchecked";
+        const body = std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"{s}\"}}", .{label}) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        resp.sendJson(request, body);
+        return;
+    }
+
+    const comma = std.mem.indexOfScalar(u8, coords_str, ',') orelse {
+        resp.sendError(request, 500, "Could not parse element coordinates");
+        return;
+    };
+    const x = std.fmt.parseFloat(f64, coords_str[0..comma]) catch {
+        resp.sendError(request, 500, "Could not parse element x coordinate");
+        return;
+    };
+    const y = std.fmt.parseFloat(f64, coords_str[comma + 1 ..]) catch {
+        resp.sendError(request, 500, "Could not parse element y coordinate");
+        return;
+    };
+    const x_int: i64 = @intFromFloat(@round(x));
+    const y_int: i64 = @intFromFloat(@round(y));
+
+    const down_params = std.fmt.allocPrint(arena,
+        "{{\"type\":\"mousePressed\",\"x\":{d},\"y\":{d},\"button\":\"left\",\"clickCount\":1}}", .{ x_int, y_int }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    _ = client.send(arena, protocol.Methods.input_dispatch_mouse_event, down_params) catch {
+        resp.sendError(request, 502, "Input.dispatchMouseEvent(mousePressed) failed");
+        return;
+    };
+
+    const up_params = std.fmt.allocPrint(arena,
+        "{{\"type\":\"mouseReleased\",\"x\":{d},\"y\":{d},\"button\":\"left\",\"clickCount\":1}}", .{ x_int, y_int }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    _ = client.send(arena, protocol.Methods.input_dispatch_mouse_event, up_params) catch {
+        resp.sendError(request, 502, "Input.dispatchMouseEvent(mouseReleased) failed");
+        return;
+    };
+
+    const label = switch (kind) {
+        .check => "checked",
+        .uncheck => "unchecked",
+        else => "clicked",
+    };
+    const body = std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"{s}\"}}", .{label}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, body);
+}
+
+
 fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
@@ -1043,14 +1126,18 @@ fn handleAction(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
         \\}
     ;
 
-    // Step 2: Build the JS function for the action
+    // Step 2: For click/check/uncheck, use CDP Input.dispatchMouseEvent for React/Vue compatibility (#164)
+    if (kind == .click or kind == .check or kind == .uncheck) {
+        cdpClickHttp(request, arena, client, object_id, kind);
+        return;
+    }
+
+    // Build the JS function for non-click actions
     const js_fn: []const u8 = switch (kind) {
-        .click => "function() { this.scrollIntoViewIfNeeded(); this.click(); return 'clicked'; }",
+        .click, .check, .uncheck => unreachable,
         .focus => "function() { this.focus(); return 'focused'; }",
         .hover => "function() { this.dispatchEvent(new MouseEvent('mouseover', {bubbles:true})); return 'hovered'; }",
         .dblclick => "function() { this.scrollIntoViewIfNeeded(); this.dispatchEvent(new MouseEvent('dblclick', {bubbles:true,cancelable:true})); return 'dblclicked'; }",
-        .check => "function() { if (!this.checked) { this.click(); } return 'checked'; }",
-        .uncheck => "function() { if (this.checked) { this.click(); } return 'unchecked'; }",
         .blur => "function() { this.blur(); return 'blurred'; }",
         .fill, .type => blk: {
             const v = value orelse {

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -1315,7 +1315,16 @@ fn handleBrowdie(request: *std.http.Server.Request) void {
     resp.sendJson(request, browdie);
 }
 
-pub fn discoverTabs(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16) !usize {
+const DiscoverTabsError = error{
+    CannotConnectToChrome,
+    CannotResolveChromeAddress,
+    EmptyResponseFromChrome,
+    InvalidChromeResponse,
+    OutOfMemory,
+};
+
+pub fn discoverTabs(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16) DiscoverTabsError!usize {
+    if (@import("builtin").os.tag == .windows) return error.CannotConnectToChrome;
     const cdp_addr = parseCdpAddress(cfg.cdp_url, cdp_port);
     const host = cdp_addr.host;
     const port = cdp_addr.port;

--- a/src/storage/auth_profiles.zig
+++ b/src/storage/auth_profiles.zig
@@ -82,6 +82,7 @@ pub fn deleteProfile(
     state_dir: []const u8,
     name: []const u8,
 ) !void {
+    if (@import("builtin").os.tag == .windows) return error.UnsupportedOnWindows;
     const safe_name = try sanitizeName(allocator, name);
     defer allocator.free(safe_name);
 
@@ -108,6 +109,7 @@ pub fn listProfiles(
     allocator: std.mem.Allocator,
     state_dir: []const u8,
 ) ![]AuthProfileMeta {
+    if (@import("builtin").os.tag == .windows) return allocator.alloc(AuthProfileMeta, 0);
     const dir_path = try authProfilesDir(allocator, state_dir);
     defer allocator.free(dir_path);
 

--- a/test/react-form.html
+++ b/test/react-form.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    body { font-family: system-ui; max-width: 500px; margin: 40px auto; }
+    input { padding: 8px; margin: 4px 0; width: 100%; box-sizing: border-box; }
+    button { padding: 8px 16px; margin: 8px 4px 8px 0; cursor: pointer; }
+    .result { margin-top: 16px; padding: 12px; background: #e8f5e9; border-radius: 4px; }
+    .error { background: #ffebee; }
+    #test-status { margin-top: 12px; font-size: 14px; color: #666; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [name, setName] = React.useState("");
+      const [email, setEmail] = React.useState("");
+      const [submitted, setSubmitted] = React.useState(null);
+
+      function handleSubmit() {
+        if (!name || !email) return;
+        setSubmitted({ name, email, ts: Date.now() });
+      }
+
+      function handleReset() {
+        setName("");
+        setEmail("");
+        setSubmitted(null);
+      }
+
+      return (
+        <div>
+          <h2>React Controlled Form</h2>
+          <div>
+            <label htmlFor="name-input">Name</label>
+            <input
+              id="name-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter name"
+            />
+          </div>
+          <div>
+            <label htmlFor="email-input">Email</label>
+            <input
+              id="email-input"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Enter email"
+            />
+          </div>
+          <button onClick={handleSubmit}>Submit</button>
+          <button onClick={handleReset}>Reset</button>
+
+          <div id="test-status">
+            name={JSON.stringify(name)} email={JSON.stringify(email)}
+          </div>
+
+          {submitted && (
+            <div className="result" data-testid="result">
+              <strong>Submitted!</strong><br/>
+              Name: <span id="result-name">{submitted.name}</span><br/>
+              Email: <span id="result-email">{submitted.email}</span>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById("root"));
+    root.render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Release v0.4.2 — fixes kuri-agent click and type/fill for React/Vue apps.

- **Click** (`click`, `check`, `uncheck`): CDP `Input.dispatchMouseEvent` mousePressed/mouseReleased instead of DOM `.click()` — trusted events React recognizes (#164)
- **Type/Fill**: CDP `Input.dispatchKeyEvent` per-character instead of `target.value =` — React `onChange` fires correctly (#164)
- **Bug fix**: JS operator precedence in click coordinate calculation
- **Server default**: `realistic` mode on by default for type/fill
- **Test fixture**: `test/react-form.html` — React 18 controlled form for e2e validation

### Version bumps
- `build.zig.zon` → `0.4.2`
- `npm/package.json` → `0.4.2`
- `CHANGELOG.md` — new section

### Signing
Binaries signed locally with `Developer ID Application: Rachit Pradhan (WWP9DLJ27P)`. CI release workflow will re-sign + notarize on tag push.

## Test plan
- [x] `zig build` compiles clean
- [x] E2E: fill React controlled inputs → state updates
- [x] E2E: click React button → onClick fires, result renders
- [x] E2E: reset button → state clears
- [x] `codesign -vvv` passes on all binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)