### PR TITLE
feat(ffi): stateless C-ABI shared library for in-process embedding

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,23 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
 
+    // Stateless FFI shared library — embed kuri's fetch/render path in-process
+    // (no server, no Bridge). Pure-Zig deps (validator/markdown) + spawned curl;
+    // needs no quickjs / curl-impersonate linkage. Built with `zig build ffi`.
+    const ffi_lib = b.addLibrary(.{
+        .name = "kuri_ffi",
+        .linkage = .dynamic,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/ffi.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    const ffi_install = b.addInstallArtifact(ffi_lib, .{});
+    const ffi_step = b.step("ffi", "Build the stateless FFI shared library (libkuri_ffi)");
+    ffi_step.dependOn(&ffi_install.step);
+
     // Run step
     const run_exe = b.addRunArtifact(exe);
     run_exe.step.dependOn(b.getInstallStep());

--- a/src/ffi.zig
+++ b/src/ffi.zig
@@ -1,0 +1,48 @@
+//! C-ABI surface for embedding kuri's stateless fetch into a host process.
+//!
+//! No HTTP server, no Bridge, no shared state — one call in, rendered bytes out.
+//! Designed for in-process binding (e.g. Bun `bun:ffi` dlopen) so a host can drive
+//! kuri's fetch/render path without spawning the long-lived `kuri` server.
+//!
+//! Reuses the same helpers the `kuri-fetch` one-shot entrypoint uses:
+//!   validator.validateUrl (SSRF guard) → http_fetch.fetchHttp → markdown.htmlToMarkdown.
+const std = @import("std");
+const validator = @import("crawler/validator.zig");
+const markdown = @import("crawler/markdown.zig");
+const http_fetch = @import("util/http_fetch.zig");
+
+const DEFAULT_UA = "Mozilla/5.0 (compatible; kuri-ffi/0.3.3)";
+
+/// Fetch `url_ptr` (NUL-terminated) and render it.
+///   mode 0 = markdown, anything else = raw HTML.
+/// Returns a C-owned, NUL-terminated buffer the caller MUST free with `kuri_free`,
+/// or null on a blocked URL / fetch / render error. Stateless: no globals touched.
+export fn kuri_fetch(url_ptr: [*:0]const u8, mode: c_int) callconv(.c) ?[*:0]u8 {
+    const url = std.mem.span(url_ptr);
+    validator.validateUrl(url) catch return null;
+
+    var arena_impl = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const html = http_fetch.fetchHttp(arena, url, DEFAULT_UA) catch return null;
+    const out: []const u8 = switch (mode) {
+        0 => markdown.htmlToMarkdown(html, arena) catch return null,
+        else => html,
+    };
+
+    // Copy into a C-owned, NUL-terminated buffer that survives `arena.deinit()`.
+    const buf = std.heap.c_allocator.allocSentinel(u8, out.len, 0) catch return null;
+    @memcpy(buf, out);
+    return buf.ptr;
+}
+
+/// Free a buffer returned by `kuri_fetch`. Null-safe.
+export fn kuri_free(ptr: ?[*:0]u8) callconv(.c) void {
+    if (ptr) |p| std.heap.c_allocator.free(std.mem.span(p));
+}
+
+/// Liveness probe for the embedding host (returns the ABI version).
+export fn kuri_ffi_abi_version() callconv(.c) c_int {
+    return 1;
+}


### PR DESCRIPTION
Adds an optional `zig build ffi` target that emits **libkuri_ffi** (`.dylib`/`.so`/`.dll`), exposing a small stateless C ABI so a host can drive kuri's fetch/render path **in-process** — no HTTP server, no shared `Bridge` state, no subprocess.

## API
```c
char *kuri_fetch(const char *url, int mode);   // 0 = markdown, else raw HTML; NUL-terminated, caller frees
void  kuri_free(char *ptr);
int   kuri_ffi_abi_version(void);              // currently 1
```

## How it works
`src/ffi.zig` reuses the same helpers `kuri-fetch` uses — `validator.validateUrl` (SSRF guard) → `http_fetch.fetchHttp` → `markdown.htmlToMarkdown`. Pure Zig + spawned `curl`, so the lib links **no quickjs and no curl-impersonate** — just libc. It **cross-compiles cleanly for every target** with Zig's bundled libc (verified: aarch64/x86_64-macos, x86_64/aarch64-linux, x86_64-windows).

## Why
Lets an embedding host (e.g. Bun `bun:ffi` `dlopen`) call kuri's fetch directly instead of running the long-lived server — handy for stateless one-shot fetches. Purely additive: one new build step + one new file; no existing target or behavior changes.

## Verified
- `zig build ffi` → `libkuri_ffi.dylib` (native + cross targets).
- Bun `dlopen` → `kuri_fetch("https://example.com", 0)` → markdown rendered in-process.