### PR TITLE
release: v0.4.6 — ship kuri-mobile, driverless iOS uitree, fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   # ── Linux: cross-compile both arches on one runner ─────────────────────────
   build-linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -22,20 +23,34 @@ jobs:
         with:
           version: 0.16.0
       - name: Build
-        run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast
+        run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -p out
       - name: Package
         run: |
           VERSION="${GITHUB_REF_NAME}"
           mkdir -p dist
-          tar -czf "dist/kuri-${VERSION}-${{ matrix.target }}.tar.gz" -C zig-out/bin .
+          tar -czf "dist/kuri-${VERSION}-${{ matrix.target }}.tar.gz" -C out/bin .
       - uses: actions/upload-artifact@v4
         with:
           name: kuri-${{ matrix.target }}
           path: dist/*.tar.gz
 
-  # ── macOS arm64: build + sign + notarize on real macOS runner ───────────────
-  build-macos-arm:
+  # ── macOS: both arches on one Apple Silicon runner ─────────────────────────
+  # Both arches build here on purpose. The previous x86 job pinned `macos-13`,
+  # a label GitHub has retired: it never got a runner, sat queued until the 24h
+  # job limit killed it, and took every release down with it (the publish jobs
+  # `needs:` it, so they were skipped). Zig cross-compiles x86_64-macos from
+  # arm64 fine, and codesign is architecture-agnostic, so one live runner does
+  # both. Each matrix leg installs to its own prefix so the tarballs can't pick
+  # up the other arch's binaries.
+  build-macos:
     runs-on: macos-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [aarch64-macos, x86_64-macos]
+    outputs:
+      signed: ${{ steps.sign.outputs.signed }}
     env:
       APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
       APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -48,11 +63,20 @@ jobs:
         with:
           version: 0.16.0
       - name: Build
-        run: zig build -Dtarget=aarch64-macos -Doptimize=ReleaseFast
+        run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -p out
 
+      # Records whether signing actually happened, so the release notes and the
+      # channel manifest can state the truth instead of asserting it.
       - name: Sign & notarize
-        if: ${{ env.APPLE_CERTIFICATE != '' }}
+        id: sign
         run: |
+          set -euo pipefail
+          if [ -z "${APPLE_CERTIFICATE}" ]; then
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No APPLE_CERTIFICATE secret — shipping UNSIGNED, un-notarized macOS binaries."
+            exit 0
+          fi
+
           KEYCHAIN="build-$(uuidgen).keychain"
           KEYCHAIN_PASS="$(uuidgen)"
           security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
@@ -63,86 +87,42 @@ jobs:
             -T /usr/bin/codesign -T /usr/bin/productsign
           security list-keychain -d user -s "$KEYCHAIN"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
-          for BIN in zig-out/bin/*; do
+
+          for BIN in out/bin/*; do
             codesign --sign "Developer ID Application: $APPLE_TEAM_ID" \
               --options runtime --timestamp --force "$BIN"
           done
-          zip -j /tmp/kuri-macos-arm.zip zig-out/bin/*
-          xcrun notarytool submit /tmp/kuri-macos-arm.zip \
+
+          zip -j "/tmp/kuri-${{ matrix.target }}.zip" out/bin/*
+          # --timeout so a stalled submission fails in minutes, not at the job cap.
+          xcrun notarytool submit "/tmp/kuri-${{ matrix.target }}.zip" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait
-          for BIN in zig-out/bin/*; do xcrun stapler staple "$BIN" || true; done
+            --wait --timeout 30m
+
+          # Bare Mach-O executables cannot be stapled (only bundles/pkgs/dmgs);
+          # Gatekeeper verifies these online. Best-effort, never fatal.
+          for BIN in out/bin/*; do xcrun stapler staple "$BIN" || true; done
+
           security delete-keychain "$KEYCHAIN"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
 
       - name: Package
         run: |
           VERSION="${GITHUB_REF_NAME}"
           mkdir -p dist
-          tar -czf "dist/kuri-${VERSION}-aarch64-macos.tar.gz" -C zig-out/bin .
+          tar -czf "dist/kuri-${VERSION}-${{ matrix.target }}.tar.gz" -C out/bin .
       - uses: actions/upload-artifact@v4
         with:
-          name: kuri-aarch64-macos
-          path: dist/*.tar.gz
-
-  # ── macOS x86_64: build + sign + notarize ───────────────────────────────────
-  build-macos-x86:
-    runs-on: macos-13
-    env:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.16.0
-      - name: Build
-        run: zig build -Dtarget=x86_64-macos -Doptimize=ReleaseFast
-
-      - name: Sign & notarize
-        if: ${{ env.APPLE_CERTIFICATE != '' }}
-        run: |
-          KEYCHAIN="build-$(uuidgen).keychain"
-          KEYCHAIN_PASS="$(uuidgen)"
-          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
-          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/cert.p12
-          security import /tmp/cert.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/productsign
-          security list-keychain -d user -s "$KEYCHAIN"
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
-          for BIN in zig-out/bin/*; do
-            codesign --sign "Developer ID Application: $APPLE_TEAM_ID" \
-              --options runtime --timestamp --force "$BIN"
-          done
-          zip -j /tmp/kuri-macos-x86.zip zig-out/bin/*
-          xcrun notarytool submit /tmp/kuri-macos-x86.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait
-          for BIN in zig-out/bin/*; do xcrun stapler staple "$BIN" || true; done
-          security delete-keychain "$KEYCHAIN"
-
-      - name: Package
-        run: |
-          VERSION="${GITHUB_REF_NAME}"
-          mkdir -p dist
-          tar -czf "dist/kuri-${VERSION}-x86_64-macos.tar.gz" -C zig-out/bin .
-      - uses: actions/upload-artifact@v4
-        with:
-          name: kuri-x86_64-macos
+          name: kuri-${{ matrix.target }}
           path: dist/*.tar.gz
 
   # ── Publish self-managed release channel ────────────────────────────────────
   publish-channel:
-    needs: [build-linux, build-macos-arm, build-macos-x86]
+    needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -153,6 +133,8 @@ jobs:
           merge-multiple: true
           path: dist
       - name: Publish stable channel
+        env:
+          MACOS_SIGNED: ${{ needs.build-macos.outputs.signed }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME}"
@@ -169,6 +151,7 @@ jobs:
 
           version = os.environ["GITHUB_REF_NAME"]
           commit = os.environ["GITHUB_SHA"]
+          notarized = os.environ.get("MACOS_SIGNED") == "true"
           root = Path("channel")
           version_dir = root / "stable" / version
           base = "https://raw.githubusercontent.com/justrach/kuri/release-channel/stable"
@@ -180,7 +163,7 @@ jobs:
                   "url": f"{base}/{version}/{path.name}",
                   "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
                   "size": path.stat().st_size,
-                  "notarized": target.endswith("macos"),
+                  "notarized": target.endswith("macos") and notarized,
               }
 
           manifest = {
@@ -223,8 +206,9 @@ jobs:
           git push origin HEAD:release-channel
 
   publish-github-release:
-    needs: [build-linux, build-macos-arm, build-macos-x86]
+    needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
@@ -237,7 +221,6 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME}"
-          SHA_FILE="dist/kuri-${VERSION}-sha256sums.txt"
 
           python3 - <<'PY'
           from pathlib import Path
@@ -255,15 +238,27 @@ jobs:
           next_match = re.search(r"^## \[", changelog[match.end():], re.MULTILINE)
           end = len(changelog) if not next_match else match.end() + next_match.start()
           section = changelog[start:end].strip()
-          notes = "## " + os.environ["GITHUB_REF_NAME"] + "\\n\\n" + section.split("\\n", 1)[1].strip() + "\\n\\nmacOS assets in this release are signed and notarized.\\n"
+          body = section.split("\n", 1)[1].strip()
+
+          if os.environ.get("MACOS_SIGNED") == "true":
+              footer = "macOS assets in this release are signed and notarized."
+          else:
+              footer = (
+                  "> **Note** — macOS assets in this release are **not** signed or notarized. "
+                  "Gatekeeper will quarantine them; clear it with "
+                  "`xattr -d com.apple.quarantine <binary>`."
+              )
+
+          notes = "## " + os.environ["GITHUB_REF_NAME"] + "\n\n" + body + "\n\n" + footer + "\n"
           Path("dist/release-notes.md").write_text(notes)
 
           with Path(os.environ["SHA_FILE"]).open("w") as out:
               for path in sorted(Path("dist").glob("kuri-*.tar.gz")):
-                  out.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\\n")
+                  out.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
           PY
         env:
           SHA_FILE: dist/kuri-${{ github.ref_name }}-sha256sums.txt
+          MACOS_SIGNED: ${{ needs.build-macos.outputs.signed }}
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 zig-out/
 .zig-cache/
+zig-pkg/
+dist/
+out/
 __pycache__/
 *.pyc
 *.o

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to kuri are documented here.
 
+## [0.4.6] — 2026-07-25
+
+### Features — kuri-mobile iOS, driverless
+- **`ios uitree`** — dumps the running app's real accessibility tree (labels, identifiers, values, device-pixel bounds) with no XCUITest bundle and no on-device agent. Works by enabling `ApplicationAccessibilityEnabled` inside the simulated runtime, which populates Simulator.app's host-side AX hierarchy
+- **Tap by label** — `--label` targets an element by accessibility label, identifier or value (exact match, then substring) instead of raw coordinates
+- **Input** — `doubletap`, `longpress`, `swipe`/`scroll`/`pan`, `type`, and `key` with modifier support (`key return --cmd`)
+- **Hardware buttons** — `ios button home|lock|volup|voldown|action` driven through the host accessibility bridge
+- **Lifecycle & environment** — `ios background`, `ios privacy`, `ios ui`, `ios status-bar`, `ios log`, `ios list-devices`
+
+### Fixes
+- **Release pipeline never published** — `build-macos-x86` pinned `macos-13`, a runner label GitHub has retired. The job never got a runner, sat queued until the 24-hour job limit cancelled it, and skipped both publish jobs. Every tag from v0.3.3 to v0.4.5 died this way. macOS now cross-compiles both arches on one `macos-latest` runner, and every job has an explicit `timeout-minutes`
+- **Release notes generation crashed** — the notes/checksum script split on a literal `\n` (backslash-n) rather than a newline, raising `IndexError` on the first successful run. Never observed because the job had always been skipped
+- **kuri-mobile was never shipped** — the root build had no reference to it, so releases omitted the binary that `kuri` execs as a sibling. It is now a path dependency of the root build and lands in every tarball
+- **kuri-mobile did not build off native macOS** — an inferred error set collapsed to `MacOsOnly` on non-macOS targets, and cross-compiling to `x86_64-macos` could not find `ApplicationServices`. Both arches and both Linux arches now build
+- **Use-after-free in the accessibility walker** — `CFArrayGetValueAtIndex` follows CoreFoundation's Get Rule, so releasing the parent array freed elements still in use. This crashed `uitree` and made `ios button` intermittently fail. Elements are now retained at the match point
+- **Silent tool-resolution failures** — `ios list-devices` exited 0 printing nothing when `xcode-select` pointed at CommandLineTools. Developer tools are now resolved to absolute paths with checked exit status
+- **Version strings** — `kuri`, `kuri-browse` and `kuri-fetch` reported 0.4.1/0.4.0 regardless of the release they shipped in
+
+### Known limitations
+- macOS assets are unsigned and un-notarized until Apple credentials are configured as repository secrets
+- `tap`/`swipe`/`type`/`uitree` remain Simulator-only; real devices need XCUITest
+- `ios privacy` cannot reset camera authorization — `simctl privacy` has no camera service
+
 ## [0.4.5] — 2026-05-27
 
 ### Fixes

--- a/build.zig
+++ b/build.zig
@@ -170,4 +170,14 @@ pub fn build(b: *std.Build) void {
     }
     const agent_step = b.step("agent", "Run kuri-agent scriptable CLI");
     agent_step.dependOn(&run_agent.step);
+
+    // kuri-mobile: Android (adb wire protocol) + iOS (simctl / Simulator AX).
+    // `kuri` execs this as a sibling binary, so it has to land in the same
+    // install prefix — and therefore the same release tarball. Consumed as a
+    // path dependency so the Apple framework/SDK wiring stays in one place.
+    const mobile_dep = b.dependency("kuri_mobile", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(mobile_dep.artifact("kuri-mobile"));
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,12 @@
 .{
     .name = .kuri,
-    .version = "0.4.5",
+    .version = "0.4.6",
     .dependencies = .{
         .quickjs = .{
             .url = "https://github.com/mitchellh/zig-quickjs-ng/archive/main.tar.gz",
             .hash = "quickjs_ng-0.0.0-0cZnA8XHAwCc95T1GAebWrw-SGEwp1Y0fUAmilP8xGuS",
         },
+        .kuri_mobile = .{ .path = "kuri-mobile" },
     },
     .fingerprint = 0xb63ec72d77641494,
     .minimum_zig_version = "0.16.0",
@@ -14,5 +15,6 @@
         "build.zig.zon",
         "src",
         "js",
+        "kuri-mobile",
     },
 }

--- a/kuri-mobile/README.md
+++ b/kuri-mobile/README.md
@@ -46,7 +46,41 @@ zig build
 ./zig-out/bin/kuri-mobile ios tap   200 600
 ./zig-out/bin/kuri-mobile ios swipe 200 1500 200 500 400   # pan up; alias: pan/scroll
 ./zig-out/bin/kuri-mobile ios type  "hello world"
+
+# Accessibility tree — role, a11y identifier, label, device-pixel bounds
+./zig-out/bin/kuri-mobile ios uitree
+#   @e3 AXButton #com.apple.settings.general [General] @113,1200-1092,1345 *clickable
+
+# Act on labels instead of coordinates, so taps survive layout changes
+./zig-out/bin/kuri-mobile ios tap --label "General"
+
+# Hardware buttons and lifecycle transitions
+./zig-out/bin/kuri-mobile ios button home          # also: lock volup voldown action rotate
+./zig-out/bin/kuri-mobile ios background --for 3000 com.example.app
+
+# Hardware-keyboard shortcuts (Command-Return and friends)
+./zig-out/bin/kuri-mobile ios key return --cmd
+
+# Accessibility / appearance sweep axes
+./zig-out/bin/kuri-mobile ios ui appearance dark
+./zig-out/bin/kuri-mobile ios ui content-size increment    # Dynamic Type
+./zig-out/bin/kuri-mobile ios ui increase-contrast enabled
+
+# Deterministic screenshots + bounded log assertions
+./zig-out/bin/kuri-mobile ios status-bar override --time 9:41
+./zig-out/bin/kuri-mobile ios log --last 30s --predicate 'subsystem == "com.example.app"'
 ```
+
+### iOS Simulator accessibility tree
+
+Simulator.app bridges the running iOS app's a11y tree into the host macOS
+Accessibility hierarchy, but only once app accessibility is enabled inside
+the runtime. `uitree` turns it on (idempotently) before each dump, so this
+is transparent. Without it the device-screen `AXGroup` is present but
+childless — which looks exactly like "no bridge exists", and is why this
+was previously documented as XCUITest-only.
+
+Real devices remain XCUITest-only: there is no host process to inspect.
 
 The main `kuri` binary also forwards `kuri android …` and `kuri ios …`
 to this binary (it execvp's `kuri-mobile` from the same directory or
@@ -85,7 +119,9 @@ Compared to `mobile-device-mcp`:
 | Android launch / terminate / list-apps | ✅ via `monkey`/`am`/`pm` | ✅ |
 | iOS Simulator screenshot/launch  | ✅ via `simctl`        | ✅ |
 | iOS Simulator tap/swipe/pan/type | ✅ via CGEvent + AppleScript window targeting | ✅ via XCUITest |
-| iOS Simulator UI tree            | ❌ requires XCUITest (macOS AX of Simulator.app does not expose the iOS app's controls) | ✅ via XCUITest |
+| iOS Simulator UI tree            | ✅ via host AX + `ApplicationAccessibilityEnabled` (no XCUITest) | ✅ via XCUITest |
+| iOS Simulator tap-by-a11y-label  | ✅ `ios tap --label` (resolves through the a11y tree) | ✅ via XCUITest |
+| iOS Simulator hardware buttons   | ✅ Home/Lock/Volume/Action/Rotate via host AX | ✅ |
 | iOS real-device tap/swipe/uitree | ❌ requires XCUITest    | ✅ via XCUITest bundle |
 | `run_code` JS sandbox (Rhino/JSC)| ❌ requires on-device driver | ✅ |
 | MCP server (JSON-RPC stdio)      | ❌ not yet (CLI only)   | ✅ |

--- a/kuri-mobile/build.zig
+++ b/kuri-mobile/build.zig
@@ -1,5 +1,18 @@
 const std = @import("std");
 
+/// A native macOS build inherits the SDK search paths automatically, but
+/// cross-compiling to the *other* macOS arch does not — the linker then fails
+/// with "unable to find framework 'ApplicationServices'". Point it at the
+/// active SDK explicitly so `-Dtarget=x86_64-macos` works from Apple Silicon.
+fn linkAppleFrameworks(b: *std.Build, mod: *std.Build.Module, target: std.Build.ResolvedTarget) void {
+    if (target.result.os.tag != .macos) return;
+    mod.linkFramework("ApplicationServices", .{});
+    const sdk = std.zig.system.darwin.getSdk(b.allocator, b.graph.io, &target.result) orelse return;
+    mod.addSystemFrameworkPath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "System/Library/Frameworks" }) });
+    mod.addSystemIncludePath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "usr/include" }) });
+    mod.addLibraryPath(.{ .cwd_relative = b.pathJoin(&.{ sdk, "usr/lib" }) });
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -11,10 +24,8 @@ pub fn build(b: *std.Build) void {
         .link_libc = true,
     });
 
-    // CGEvent (tap/swipe) lives in ApplicationServices on macOS.
-    if (target.result.os.tag == .macos) {
-        root_mod.linkFramework("ApplicationServices", .{});
-    }
+    // CGEvent (tap/swipe) and AXUIElement live in ApplicationServices on macOS.
+    linkAppleFrameworks(b, root_mod, target);
 
     const exe = b.addExecutable(.{
         .name = "kuri-mobile",
@@ -34,9 +45,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = true,
     });
-    if (target.result.os.tag == .macos) {
-        test_mod.linkFramework("ApplicationServices", .{});
-    }
+    linkAppleFrameworks(b, test_mod, target);
     const unit_tests = b.addTest(.{ .root_module = test_mod });
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&b.addRunArtifact(unit_tests).step);

--- a/kuri-mobile/src/ios/cli.zig
+++ b/kuri-mobile/src/ios/cli.zig
@@ -7,7 +7,69 @@ const usbmux = @import("usbmux.zig");
 const devicectl = @import("devicectl.zig");
 const sim_input = @import("sim_input.zig");
 const sim_window = @import("sim_window.zig");
+const sim_ax = @import("sim_ax.zig");
+const xcode = @import("xcode.zig");
 const io = @import("../common/io.zig");
+const uitree = @import("../common/uitree.zig");
+
+/// Flags accepted before *or* after the subcommand's positional arguments,
+/// so `key return --cmd` and `key --cmd return` both work.
+const Opts = struct {
+    udid: ?[]const u8 = null,
+    /// Default to simulator. `--device` routes real-device commands through
+    /// devicectl and requires --udid.
+    simulator: bool = true,
+    mods: u64 = 0,
+    dur_ms: ?u64 = null,
+    last: ?[]const u8 = null,
+    predicate: ?[]const u8 = null,
+    /// Accessibility label / identifier to target instead of coordinates.
+    label: ?[]const u8 = null,
+};
+
+/// Consume a recognized flag at `rest[idx]`, returning how many tokens it
+/// used, or null if the token isn't a known flag.
+fn takeFlag(opts: *Opts, rest: []const []const u8, idx: usize) !?usize {
+    const tok = rest[idx];
+    if (!std.mem.startsWith(u8, tok, "--")) return null;
+    const name = tok[2..];
+
+    if (std.mem.eql(u8, name, "simulator")) {
+        opts.simulator = true;
+        return 1;
+    }
+    if (std.mem.eql(u8, name, "device")) {
+        opts.simulator = false;
+        return 1;
+    }
+    if (sim_input.lookupModifier(name)) |bit| {
+        opts.mods |= bit;
+        return 1;
+    }
+
+    // Value-taking flags.
+    const needs_value = std.mem.eql(u8, name, "udid") or
+        std.mem.eql(u8, name, "for") or
+        std.mem.eql(u8, name, "last") or
+        std.mem.eql(u8, name, "predicate") or
+        std.mem.eql(u8, name, "label");
+    if (!needs_value) return null;
+    if (idx + 1 >= rest.len) return error.MissingFlagValue;
+    const val = rest[idx + 1];
+
+    if (std.mem.eql(u8, name, "udid")) {
+        opts.udid = val;
+    } else if (std.mem.eql(u8, name, "for")) {
+        opts.dur_ms = try std.fmt.parseInt(u64, val, 10);
+    } else if (std.mem.eql(u8, name, "last")) {
+        opts.last = val;
+    } else if (std.mem.eql(u8, name, "predicate")) {
+        opts.predicate = val;
+    } else if (std.mem.eql(u8, name, "label")) {
+        opts.label = val;
+    }
+    return 2;
+}
 
 pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     if (args.len == 0) {
@@ -17,90 +79,102 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     const sub = args[0];
     const rest = args[1..];
 
+    // Split flags from positionals anywhere in the argument list.
+    const passes_through_flags = std.mem.eql(u8, sub, "status-bar") or
+        std.mem.eql(u8, sub, "status_bar");
+    var opts: Opts = .{};
+    var positional: std.ArrayList([]const u8) = .empty;
+    defer positional.deinit(gpa);
+
+    var idx: usize = 0;
+    while (idx < rest.len) {
+        const consumed = takeFlag(&opts, rest, idx) catch |err| switch (err) {
+            error.MissingFlagValue => return errMissing(rest[idx]),
+            else => return err,
+        };
+        if (consumed) |n| {
+            idx += n;
+        } else {
+            // `status-bar` forwards its own flags (--time, --batteryLevel, …)
+            // straight to simctl, so unrecognized flags are data here, not
+            // user error.
+            if (passes_through_flags) {
+                try positional.append(gpa, rest[idx]);
+                idx += 1;
+                continue;
+            }
+            if (std.mem.startsWith(u8, rest[idx], "--")) {
+                var arena_impl = std.heap.ArenaAllocator.init(gpa);
+                defer arena_impl.deinit();
+                io.printStderr(arena_impl.allocator(), "unknown flag: {s}\n", .{rest[idx]});
+                return 2;
+            }
+            try positional.append(gpa, rest[idx]);
+            idx += 1;
+        }
+    }
+    const cmd_args = positional.items;
+
     if (std.mem.eql(u8, sub, "list-devices") or std.mem.eql(u8, sub, "devices")) {
         return cmdListDevices(gpa);
     }
 
-    var udid_opt: ?[]const u8 = null;
-    // Default to simulator. Use --device for real-device commands; that path
-    // requires --udid and goes through devicectl.
-    var simulator: bool = true;
-    var idx: usize = 0;
-    while (idx < rest.len and std.mem.startsWith(u8, rest[idx], "--")) {
-        if (std.mem.eql(u8, rest[idx], "--udid")) {
-            if (idx + 1 >= rest.len) return errMissing("--udid");
-            udid_opt = rest[idx + 1];
-            idx += 2;
-        } else if (std.mem.eql(u8, rest[idx], "--simulator")) {
-            simulator = true;
-            idx += 1;
-        } else if (std.mem.eql(u8, rest[idx], "--device")) {
-            simulator = false;
-            idx += 1;
-        } else {
-            io.writeStderr("unknown flag\n");
-            return 2;
-        }
-    }
-    const cmd_args = rest[idx..];
-
     if (std.mem.eql(u8, sub, "launch")) {
         if (cmd_args.len < 1) return errMissing("bundle-id");
-        // Default behavior: target the booted sim if no --udid given.
         // Real-device launch always needs --udid (devicectl can't guess).
-        if (!simulator) {
-            const udid = udid_opt orelse return errMissing("--udid");
+        if (!opts.simulator) {
+            const udid = opts.udid orelse return errMissing("--udid");
             try devicectl.launch(gpa, udid, cmd_args[0]);
             return 0;
         }
-        const udid = udid_opt orelse try resolveBootedSim(gpa);
-        defer if (udid_opt == null) gpa.free(udid);
-        try simctl.Sim.init(udid).launch(gpa, cmd_args[0]);
+        const r = try resolveUdid(gpa, opts.udid);
+        defer r.deinit(gpa);
+        try simctl.Sim.init(r.udid).launch(gpa, cmd_args[0]);
         return 0;
     }
     if (std.mem.eql(u8, sub, "terminate")) {
         if (cmd_args.len < 1) return errMissing("bundle-id");
-        if (!simulator) {
-            const udid = udid_opt orelse return errMissing("--udid");
+        if (!opts.simulator) {
+            const udid = opts.udid orelse return errMissing("--udid");
             try devicectl.terminate(gpa, udid, cmd_args[0]);
             return 0;
         }
-        const udid = udid_opt orelse try resolveBootedSim(gpa);
-        defer if (udid_opt == null) gpa.free(udid);
-        try simctl.Sim.init(udid).terminate(gpa, cmd_args[0]);
+        const r = try resolveUdid(gpa, opts.udid);
+        defer r.deinit(gpa);
+        try simctl.Sim.init(r.udid).terminate(gpa, cmd_args[0]);
         return 0;
     }
     if (std.mem.eql(u8, sub, "openurl") or std.mem.eql(u8, sub, "navigate")) {
         if (cmd_args.len < 1) return errMissing("url");
-        const udid = udid_opt orelse try resolveBootedSim(gpa);
-        defer if (udid_opt == null) gpa.free(udid);
-        try simctl.Sim.init(udid).openUrl(gpa, cmd_args[0]);
+        const r = try resolveUdid(gpa, opts.udid);
+        defer r.deinit(gpa);
+        try simctl.Sim.init(r.udid).openUrl(gpa, cmd_args[0]);
         return 0;
     }
     if (std.mem.eql(u8, sub, "boot")) {
-        const udid = udid_opt orelse return errMissing("--udid");
+        const udid = opts.udid orelse return errMissing("--udid");
         try simctl.Sim.init(udid).boot(gpa);
         return 0;
     }
     if (std.mem.eql(u8, sub, "shutdown")) {
-        const udid = udid_opt orelse return errMissing("--udid");
+        const udid = opts.udid orelse return errMissing("--udid");
         try simctl.Sim.init(udid).shutdown(gpa);
         return 0;
     }
     if (std.mem.eql(u8, sub, "screenshot")) {
         const path = if (cmd_args.len >= 1) cmd_args[0] else "screenshot.png";
-        if (!simulator and udid_opt != null) {
+        if (!opts.simulator and opts.udid != null) {
             io.writeStderr("screenshot on real iOS devices requires XCUITest; not supported in v1. Use --simulator.\n");
             return 3;
         }
-        const udid = udid_opt orelse try resolveBootedSim(gpa);
-        defer if (udid_opt == null) gpa.free(udid);
-        try simctl.Sim.init(udid).screenshot(gpa, path);
+        const r = try resolveUdid(gpa, opts.udid);
+        defer r.deinit(gpa);
+        try simctl.Sim.init(r.udid).screenshot(gpa, path);
         return 0;
     }
     if (std.mem.eql(u8, sub, "list-apps")) {
-        const udid = udid_opt orelse return errMissing("--udid");
-        if (!simulator) {
+        const udid = opts.udid orelse return errMissing("--udid");
+        if (!opts.simulator) {
             io.writeStderr("list-apps on real device not supported in v1. Use --simulator.\n");
             return 3;
         }
@@ -110,24 +184,27 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
         return 0;
     }
 
-    if (std.mem.eql(u8, sub, "tap")) return cmdTap(gpa, udid_opt, simulator, cmd_args);
-    if (std.mem.eql(u8, sub, "doubletap") or std.mem.eql(u8, sub, "dbltap")) return cmdDoubleTap(gpa, udid_opt, simulator, cmd_args);
-    if (std.mem.eql(u8, sub, "longpress") or std.mem.eql(u8, sub, "long-press")) return cmdLongPress(gpa, udid_opt, simulator, cmd_args);
-    if (std.mem.eql(u8, sub, "swipe") or std.mem.eql(u8, sub, "scroll") or std.mem.eql(u8, sub, "pan")) return cmdSwipe(gpa, udid_opt, simulator, cmd_args);
-    if (std.mem.eql(u8, sub, "type")) return cmdType(gpa, udid_opt, simulator, cmd_args);
-    if (std.mem.eql(u8, sub, "uitree")) {
-        // Honest scope: macOS AX on Simulator.app only exposes window chrome,
-        // not the running iOS app's a11y tree. That bridge is XCUITest-only.
-        io.writeStderr("uitree on iOS requires XCUITest (driverless mode does not have a11y access to the iOS app). Use Accessibility Inspector or run via XCUITest.\n");
-        return 3;
-    }
+    if (std.mem.eql(u8, sub, "tap")) return cmdTap(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "doubletap") or std.mem.eql(u8, sub, "dbltap")) return cmdDoubleTap(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "longpress") or std.mem.eql(u8, sub, "long-press")) return cmdLongPress(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "swipe") or std.mem.eql(u8, sub, "scroll") or std.mem.eql(u8, sub, "pan")) return cmdSwipe(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "type")) return cmdType(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "key")) return cmdKey(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "button")) return cmdButton(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "background")) return cmdBackground(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "privacy")) return cmdPrivacy(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "ui")) return cmdUi(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "status-bar") or std.mem.eql(u8, sub, "status_bar")) return cmdStatusBar(gpa, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "log")) return cmdLog(gpa, opts, cmd_args);
+
+    if (std.mem.eql(u8, sub, "uitree")) return cmdUiTree(gpa, opts);
 
     try printUsage();
     return 1;
 }
 
 // --- tap / swipe / type implementations (Simulator only) -------------------
-// Coordinates are *device pixels* matching `xcrun simctl io ... screenshot`,
+// Coordinates are *device pixels* matching `simctl io ... screenshot`,
 // so the same numbers you'd plug into `adb shell input tap` work here.
 
 /// Returns null if OK, or an exit code if the command should bail without
@@ -177,53 +254,122 @@ fn prepSimAndPoint(
     return sim_window.deviceToScreen(win, px, dev_x, dev_y);
 }
 
-fn cmdTap(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
-    if (guardSim(simulator)) |code| return code;
-    if (args.len < 2) return errMissing("x y");
+/// Dump the running iOS app's accessibility tree.
+fn cmdUiTree(gpa: std.mem.Allocator, opts: Opts) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+
+    try sim_window.activate(gpa);
+    const els = sim_ax.dumpElements(gpa, r.udid) catch |err| switch (err) {
+        error.AccessibilityTreeEmpty => {
+            io.writeStderr(
+                \\the simulated screen exposes no accessibility elements.
+                \\
+                \\Usually one of:
+                \\  - no app is in the foreground (launch one first)
+                \\  - the app genuinely publishes no accessibility information
+                \\  - the runtime needs a moment after launch; retry
+                \\
+            );
+            return 3;
+        },
+        else => return err,
+    };
+    defer uitree.freeElements(gpa, els);
+
+    const text = try uitree.renderText(gpa, els);
+    defer gpa.free(text);
+    io.writeStdout(text);
+    return 0;
+}
+
+/// Find an element whose accessibility label, identifier or value matches
+/// `label`. Exact match first, then a substring fallback so callers don't
+/// have to reproduce long labels verbatim.
+fn findByLabel(els: []const uitree.Element, label: []const u8) ?uitree.Element {
+    for (els) |e| {
+        if (std.mem.eql(u8, e.desc, label) or
+            std.mem.eql(u8, e.id, label) or
+            std.mem.eql(u8, e.text, label)) return e;
+    }
+    for (els) |e| {
+        if (std.mem.indexOf(u8, e.desc, label) != null or
+            std.mem.indexOf(u8, e.text, label) != null) return e;
+    }
+    return null;
+}
+
+/// Tap whatever carries `label`, using the a11y tree's own frame. This is
+/// what makes a tap survive layout changes, unlike a hard-coded coordinate.
+fn tapByLabel(gpa: std.mem.Allocator, opts: Opts, label: []const u8) !u8 {
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+
+    try sim_window.activate(gpa);
+    const els = try sim_ax.dumpElements(gpa, r.udid);
+    defer uitree.freeElements(gpa, els);
+
+    const hit = findByLabel(els, label) orelse {
+        var arena_impl = std.heap.ArenaAllocator.init(gpa);
+        defer arena_impl.deinit();
+        io.printStderr(arena_impl.allocator(), "no element matching label: {s}\n", .{label});
+        return 4;
+    };
+    const c = uitree.centroid(hit) orelse return error.ElementHasNoBounds;
+    const p = try prepSimAndPoint(gpa, r.udid, @floatFromInt(c[0]), @floatFromInt(c[1]));
+    sim_input.tap(p);
+    return 0;
+}
+
+fn cmdTap(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
+    if (opts.label) |l| return tapByLabel(gpa, opts, l);
+    if (args.len < 2) return errMissing("x y (or --label <text>)");
     const x = try parseF64(args[0]);
     const y = try parseF64(args[1]);
-    const r = try resolveUdid(gpa, udid_opt);
+    const r = try resolveUdid(gpa, opts.udid);
     defer r.deinit(gpa);
     const p = try prepSimAndPoint(gpa, r.udid, x, y);
     sim_input.tap(p);
     return 0;
 }
 
-fn cmdDoubleTap(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
-    if (guardSim(simulator)) |code| return code;
+fn cmdDoubleTap(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
     if (args.len < 2) return errMissing("x y");
     const x = try parseF64(args[0]);
     const y = try parseF64(args[1]);
-    const r = try resolveUdid(gpa, udid_opt);
+    const r = try resolveUdid(gpa, opts.udid);
     defer r.deinit(gpa);
     const p = try prepSimAndPoint(gpa, r.udid, x, y);
     sim_input.doubleTap(p);
     return 0;
 }
 
-fn cmdLongPress(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
-    if (guardSim(simulator)) |code| return code;
+fn cmdLongPress(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
     if (args.len < 2) return errMissing("x y [hold_ms]");
     const x = try parseF64(args[0]);
     const y = try parseF64(args[1]);
     // iOS treats ~500ms as the threshold for "long press" / haptic touch.
     const hold: u64 = if (args.len >= 3) try std.fmt.parseInt(u64, args[2], 10) else 500;
-    const r = try resolveUdid(gpa, udid_opt);
+    const r = try resolveUdid(gpa, opts.udid);
     defer r.deinit(gpa);
     const p = try prepSimAndPoint(gpa, r.udid, x, y);
     sim_input.longPress(p, hold);
     return 0;
 }
 
-fn cmdSwipe(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
-    if (guardSim(simulator)) |code| return code;
+fn cmdSwipe(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
     if (args.len < 4) return errMissing("x1 y1 x2 y2 [duration_ms]");
     const x1 = try parseF64(args[0]);
     const y1 = try parseF64(args[1]);
     const x2 = try parseF64(args[2]);
     const y2 = try parseF64(args[3]);
     const dur: u64 = if (args.len >= 5) try std.fmt.parseInt(u64, args[4], 10) else 300;
-    const r = try resolveUdid(gpa, udid_opt);
+    const r = try resolveUdid(gpa, opts.udid);
     defer r.deinit(gpa);
     try sim_window.activate(gpa);
     const win = try sim_window.frontWindowRect(gpa);
@@ -234,10 +380,9 @@ fn cmdSwipe(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args
     return 0;
 }
 
-fn cmdType(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args: []const []const u8) !u8 {
-    if (guardSim(simulator)) |code| return code;
+fn cmdType(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
     if (args.len < 1) return errMissing("text");
-    _ = udid_opt;
     // Bring sim to front so keystrokes go to its focused field, then use
     // System Events `keystroke` for Unicode-safe input. This avoids having
     // to maintain a CGEvent keycode table.
@@ -272,6 +417,146 @@ fn cmdType(gpa: std.mem.Allocator, udid_opt: ?[]const u8, simulator: bool, args:
     return 0;
 }
 
+/// Modified key press — the primitive for hardware-keyboard shortcuts such
+/// as Command-Return, which plain `type` cannot express.
+fn cmdKey(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
+    if (args.len < 1) return errMissing("key-name");
+
+    var mods = opts.mods;
+    // Also accept modifiers written bare after the key name.
+    for (args[1..]) |a| {
+        const name = if (std.mem.startsWith(u8, a, "--")) a[2..] else a;
+        mods |= sim_input.lookupModifier(name) orelse 0;
+    }
+
+    const code = sim_input.lookupKey(args[0]) orelse {
+        var arena_impl = std.heap.ArenaAllocator.init(gpa);
+        defer arena_impl.deinit();
+        io.printStderr(arena_impl.allocator(), "unknown key: {s}\n", .{args[0]});
+        return 2;
+    };
+
+    try sim_window.activate(gpa);
+    sim_input.keyPress(code, mods);
+    return 0;
+}
+
+/// Simulator hardware/toolbar buttons via host AX.
+fn cmdButton(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
+    if (args.len < 1) return errMissing("button-name");
+    try sim_window.activate(gpa);
+    try sim_ax.press(gpa, args[0]);
+    return 0;
+}
+
+/// Background the app, optionally bringing it back — the lifecycle
+/// transition behind "suspend during an in-flight request" and
+/// "does state survive a brief background/foreground cycle" bugs.
+fn cmdBackground(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (guardSim(opts.simulator)) |code| return code;
+
+    try sim_window.activate(gpa);
+    try sim_ax.press(gpa, "home");
+
+    const hold = opts.dur_ms orelse 3000;
+    var ts: std.c.timespec = .{
+        .sec = @intCast(hold / 1000),
+        .nsec = @intCast((hold % 1000) * std.time.ns_per_ms),
+    };
+    _ = std.c.nanosleep(&ts, null);
+
+    // Relaunching by bundle id is how you foreground an already-running app;
+    // simctl launch attaches to the existing process rather than restarting.
+    if (args.len >= 1) {
+        const r = try resolveUdid(gpa, opts.udid);
+        defer r.deinit(gpa);
+        try simctl.Sim.init(r.udid).launch(gpa, args[0]);
+    }
+    return 0;
+}
+
+fn cmdPrivacy(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (args.len < 2) return errMissing("<grant|revoke|reset> <service> [bundle-id]");
+    const action = args[0];
+    const service = args[1];
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    if (simctl.isPrivacyUnsupported(service)) {
+        io.printStderr(arena,
+            \\simctl cannot control the '{s}' permission — Apple does not expose it.
+            \\
+            \\Supported services: microphone, photos, photos-add, location, contacts,
+            \\calendar, reminders, motion, media-library, siri, all.
+            \\
+            \\To reset camera or speech-recognition state, erase the device
+            \\(`kuri ios shutdown --udid U` then `simctl erase U`) or test on hardware.
+            \\
+        , .{service});
+        return 3;
+    }
+    if (!simctl.isPrivacyService(service)) {
+        io.printStderr(arena, "unknown privacy service: {s}\n", .{service});
+        return 2;
+    }
+
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+    const bundle: ?[]const u8 = if (args.len >= 3) args[2] else null;
+    try simctl.Sim.init(r.udid).privacy(gpa, action, service, bundle);
+    return 0;
+}
+
+/// Accessibility/appearance settings — the sweep axis for Dynamic Type and
+/// contrast checks. CLI uses dashes; simctl uses underscores.
+fn cmdUi(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("<appearance|content-size|increase-contrast> [value]");
+    const opt = if (std.mem.eql(u8, args[0], "content-size"))
+        "content_size"
+    else if (std.mem.eql(u8, args[0], "increase-contrast"))
+        "increase_contrast"
+    else
+        args[0];
+
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+    const value: ?[]const u8 = if (args.len >= 2) args[1] else null;
+    const out = try simctl.Sim.init(r.udid).ui(gpa, opt, value);
+    defer gpa.free(out);
+    io.writeStdout(out);
+    return 0;
+}
+
+/// Pin the status bar so screenshots are comparable across runs.
+fn cmdStatusBar(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+    const sim = simctl.Sim.init(r.udid);
+    if (args.len >= 1 and std.mem.eql(u8, args[0], "clear")) {
+        try sim.statusBarClear(gpa);
+        return 0;
+    }
+    // Everything after an optional leading "override" is passed through.
+    const extra = if (args.len >= 1 and std.mem.eql(u8, args[0], "override")) args[1..] else args;
+    try sim.statusBar(gpa, extra);
+    return 0;
+}
+
+/// Bounded os_log query — assertion-friendly, unlike a blocking stream.
+fn cmdLog(gpa: std.mem.Allocator, opts: Opts, args: []const []const u8) !u8 {
+    _ = args;
+    const r = try resolveUdid(gpa, opts.udid);
+    defer r.deinit(gpa);
+    const out = try simctl.Sim.init(r.udid).logShow(gpa, opts.last orelse "30s", opts.predicate);
+    defer gpa.free(out);
+    io.writeStdout(out);
+    return 0;
+}
+
 /// Find the single booted iOS Simulator. Returns owned UDID slice; caller frees.
 fn resolveBootedSim(gpa: std.mem.Allocator) ![]const u8 {
     const sims = try simctl.listDevices(gpa);
@@ -294,21 +579,48 @@ fn cmdListDevices(gpa: std.mem.Allocator) !u8 {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    // Simulators
-    const sims = simctl.listDevices(gpa) catch &[_]simctl.SimDevice{};
+    // Simulators. A failure here must be reported, not swallowed: an empty
+    // list and a broken toolchain are very different answers, and conflating
+    // them is what made a missing Xcode look like "no devices".
+    var sim_failed = false;
+    const sims = simctl.listDevices(gpa) catch |err| blk: {
+        sim_failed = true;
+        reportToolchainError(arena, err);
+        break :blk &[_]simctl.SimDevice{};
+    };
     defer simctl.freeSimDevices(gpa, sims);
     for (sims) |s| {
         io.printStdout(arena, "simulator\t{s}\t{s}\t{s}\n", .{ s.udid, s.state, s.name });
     }
 
-    // Real devices via usbmuxd
+    // Real devices via usbmuxd — independent of Xcode, so still worth trying.
     const reals = usbmux.listDevices(gpa) catch &[_]usbmux.Device{};
     defer usbmux.freeDevices(gpa, reals);
     for (reals) |r| {
         io.printStdout(arena, "device\t{s}\t{s}\tpid={d}\n", .{ r.udid, r.connection, r.product_id });
     }
 
+    // Nothing enumerated *and* the simulator side errored: report failure so
+    // scripts don't read this as a clean "no devices attached".
+    if (sim_failed and reals.len == 0) return 3;
     return 0;
+}
+
+fn reportToolchainError(arena: std.mem.Allocator, err: anyerror) void {
+    switch (err) {
+        error.XcodeNotFound => io.writeStderr(
+            \\error: no Xcode toolchain with `simctl` found.
+            \\
+            \\`xcode-select -p` may point at CommandLineTools, which has no simctl.
+            \\Fix with one of:
+            \\  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+            \\  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer kuri ios ...
+            \\
+        ),
+        // xcode.run already printed the tool's own diagnostic.
+        error.CommandFailed => {},
+        else => io.printStderr(arena, "error listing simulators: {s}\n", .{@errorName(err)}),
+    }
 }
 
 fn printUsage() !void {
@@ -327,17 +639,33 @@ fn printUsage() !void {
         \\  list-apps  --udid U --simulator
         \\
         \\Simulator-only input (macOS, device-pixel coords matching screenshot):
-        \\  tap       [--udid U] <x> <y>
+        \\  tap       [--udid U] <x> <y> | --label <text>
         \\  doubletap [--udid U] <x> <y>                          (alias: dbltap)
         \\  longpress [--udid U] <x> <y> [hold_ms]                (alias: long-press; default 500ms)
         \\  swipe     [--udid U] <x1> <y1> <x2> <y2> [duration_ms]   (alias: scroll, pan)
         \\  type      [--udid U] <text...>
+        \\  key       <name> [--cmd|--shift|--ctrl|--opt]         e.g. `key return --cmd`
+        \\                                                        names: return enter tab space
+        \\                                                               delete escape left right up down
+        \\
+        \\Accessibility tree (Simulator, no XCUITest needed):
+        \\  uitree                             flat element list: role, a11y id, label, bounds
+        \\                                     bounds are device pixels, matching tap/screenshot
+        \\
+        \\Hardware buttons (via Simulator's own accessibility tree):
+        \\  button    <home|lock|volup|voldown|action|rotate>
+        \\  background [--for MS] [bundle-id]  press Home, wait, then re-foreground
+        \\
+        \\Device state:
+        \\  privacy   <grant|revoke|reset> <service> [bundle-id]
+        \\  ui        <appearance|content-size|increase-contrast> [value]
+        \\  status-bar override --time 9:41 ... | status-bar clear
+        \\  log       [--last 30s] [--predicate 'subsystem == "com.example.app"']
         \\
         \\Not implemented in v1 (driverless mode):
-        \\  tap, swipe, type on real iOS devices            -> needs XCUITest
-        \\  uitree (simulator or device)                    -> needs XCUITest / Accessibility Inspector
-        \\  pinch / rotate / two-finger gestures            -> need CGEvent flags + multi-touch wiring
-        \\  hardware buttons (Home, Lock, Volume, Shake)    -> need osascript Simulator menu shortcuts
+        \\  tap, swipe, type, uitree on real iOS devices    -> need XCUITest (no host process to inspect)
+        \\  pinch / rotate / two-finger gestures            -> need multi-touch wiring
+        \\  camera & speech-recognition permissions         -> not exposed by simctl privacy
         \\
     );
 }

--- a/kuri-mobile/src/ios/sim_ax.zig
+++ b/kuri-mobile/src/ios/sim_ax.zig
@@ -1,0 +1,480 @@
+//! Simulator *hardware buttons* via the macOS Accessibility API.
+//!
+//! Simulator.app publishes its own chrome to the host AX tree: the bezel
+//! buttons (Action, Volume Up, Volume Down, Sleep/Wake) hang off the device
+//! window, and the toolbar carries Home, Rotate and Save Screen. Each one
+//! responds to `AXUIElementPerformAction(kAXPressAction)`, which gives us
+//! Home/Lock/Volume without an on-device driver.
+//!
+//! Note the boundary carefully, because it is easy to over-read: this
+//! exposes only Simulator.app's *own* controls. The running iOS app's a11y
+//! tree is NOT bridged into host AX — verified against Xcode 26.6, both on
+//! Simulator.app's pid and on the simulated app's host pid (a simulated app
+//! is a real host process, but AX on it yields a single empty node), and
+//! CoreSimulator no longer ships the accessibility bridge that idb once
+//! used. A real iOS UI tree still requires XCUITest. See `uitree` in cli.zig.
+//!
+//! macOS only. Requires Accessibility permission for the calling terminal
+//! (System Settings → Privacy & Security → Accessibility), the same grant
+//! that CGEvent-based tap/swipe already needs.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const io = @import("../common/io.zig");
+
+const Ref = ?*anyopaque;
+
+const kAXErrorSuccess: i32 = 0;
+const kCFStringEncodingUTF8: u32 = 0x08000100;
+
+extern "c" fn AXUIElementCreateApplication(pid: i32) Ref;
+extern "c" fn AXUIElementCopyAttributeValue(element: Ref, attribute: Ref, value: *Ref) i32;
+extern "c" fn AXUIElementPerformAction(element: Ref, action: Ref) i32;
+extern "c" fn AXIsProcessTrusted() bool;
+extern "c" fn CFStringCreateWithCString(alloc: Ref, cstr: [*:0]const u8, encoding: u32) Ref;
+extern "c" fn CFStringGetCString(theString: Ref, buffer: [*]u8, bufferSize: i64, encoding: u32) bool;
+extern "c" fn CFArrayGetCount(theArray: Ref) i64;
+extern "c" fn CFArrayGetValueAtIndex(theArray: Ref, idx: i64) Ref;
+extern "c" fn CFGetTypeID(cf: Ref) u64;
+extern "c" fn CFStringGetTypeID() u64;
+extern "c" fn CFArrayGetTypeID() u64;
+extern "c" fn CFRelease(cf: Ref) void;
+extern "c" fn CFRetain(cf: Ref) Ref;
+
+/// Elements fetched with `CFArrayGetValueAtIndex` follow CoreFoundation's
+/// Get Rule: they are owned by the array, not by us. Any element that
+/// outlives the array it came from must be retained first — otherwise
+/// releasing the array frees it and the caller reads freed memory.
+fn retained(el: Ref) Ref {
+    if (el == null) return null;
+    return CFRetain(el);
+}
+
+/// A pressable Simulator control, keyed by the CLI name we accept.
+pub const Button = struct {
+    /// CLI-facing name.
+    cli: []const u8,
+    /// The AXTitle or AXDescription Simulator.app publishes for it.
+    ax_label: []const u8,
+};
+
+/// Names verified against Xcode 26.6's Simulator. Bezel buttons carry an
+/// AXTitle; toolbar buttons carry only an AXDescription, so lookup checks
+/// both attributes rather than assuming one.
+pub const buttons = [_]Button{
+    .{ .cli = "home", .ax_label = "Home" },
+    .{ .cli = "lock", .ax_label = "Sleep/Wake" },
+    .{ .cli = "volup", .ax_label = "Volume Up" },
+    .{ .cli = "voldown", .ax_label = "Volume Down" },
+    .{ .cli = "action", .ax_label = "Action" },
+    .{ .cli = "rotate", .ax_label = "Rotate" },
+};
+
+pub fn lookup(name: []const u8) ?Button {
+    for (buttons) |b| {
+        if (std.mem.eql(u8, b.cli, name)) return b;
+    }
+    // Accept the on-screen label too ("Volume Up"), case-insensitively.
+    for (buttons) |b| {
+        if (std.ascii.eqlIgnoreCase(b.ax_label, name)) return b;
+    }
+    return null;
+}
+
+fn cfStr(s: [*:0]const u8) Ref {
+    return CFStringCreateWithCString(null, s, kCFStringEncodingUTF8);
+}
+
+/// Copy a string attribute into `out`, returning the populated slice.
+fn stringAttr(el: Ref, attr: [*:0]const u8, out: []u8) ?[]const u8 {
+    const key = cfStr(attr);
+    defer if (key != null) CFRelease(key);
+    var val: Ref = null;
+    if (AXUIElementCopyAttributeValue(el, key, &val) != kAXErrorSuccess) return null;
+    if (val == null) return null;
+    defer CFRelease(val);
+    if (CFGetTypeID(val) != CFStringGetTypeID()) return null;
+    if (!CFStringGetCString(val, out.ptr, @intCast(out.len), kCFStringEncodingUTF8)) return null;
+    return std.mem.sliceTo(out, 0);
+}
+
+fn matches(el: Ref, want: []const u8) bool {
+    var buf: [256]u8 = undefined;
+    if (stringAttr(el, "AXTitle", &buf)) |t| {
+        if (std.mem.eql(u8, t, want)) return true;
+    }
+    if (stringAttr(el, "AXDescription", &buf)) |d| {
+        if (std.mem.eql(u8, d, want)) return true;
+    }
+    return false;
+}
+
+/// Depth-first search for a control carrying `want` as title or description.
+/// The menu bar is skipped: it is enormous (every Recent Items entry) and
+/// never holds the controls we're after.
+fn find(el: Ref, want: []const u8, depth: u32) Ref {
+    if (depth > 8) return null;
+
+    var role_buf: [128]u8 = undefined;
+    if (stringAttr(el, "AXRole", &role_buf)) |role| {
+        if (std.mem.eql(u8, role, "AXMenuBar")) return null;
+    }
+
+    // Retain at the match point, not at the call site: as the recursion
+    // unwinds, every level releases its own children array, which would
+    // otherwise free this element before the caller ever sees it.
+    if (depth > 0 and matches(el, want)) return retained(el);
+
+    const kids_key = cfStr("AXChildren");
+    defer if (kids_key != null) CFRelease(kids_key);
+    var kids: Ref = null;
+    if (AXUIElementCopyAttributeValue(el, kids_key, &kids) != kAXErrorSuccess) return null;
+    if (kids == null) return null;
+    defer CFRelease(kids);
+    if (CFGetTypeID(kids) != CFArrayGetTypeID()) return null;
+
+    const n = CFArrayGetCount(kids);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const child = CFArrayGetValueAtIndex(kids, i);
+        if (find(child, want, depth + 1)) |hit| return hit;
+    }
+    return null;
+}
+
+/// `find` already returns a retained element; this is just the named entry
+/// point making the ownership contract obvious. Caller releases.
+fn findRetained(root: Ref, want: []const u8) Ref {
+    return find(root, want, 0);
+}
+
+/// PID of the running Simulator.app, or null if it isn't running.
+pub fn simulatorPid(gpa: std.mem.Allocator) !?i32 {
+    const r = try io.runCommand(gpa, &.{ "pgrep", "-x", "Simulator" }, 4096);
+    defer gpa.free(r.stdout);
+    const trimmed = std.mem.trim(u8, r.stdout, " \t\r\n");
+    if (trimmed.len == 0) return null;
+    // pgrep may list several; the first is fine — they share the AX tree.
+    var it = std.mem.splitScalar(u8, trimmed, '\n');
+    const first = std.mem.trim(u8, it.next() orelse return null, " \t\r");
+    return std.fmt.parseInt(i32, first, 10) catch null;
+}
+
+/// Press a Simulator hardware/toolbar button by CLI name.
+pub fn press(gpa: std.mem.Allocator, name: []const u8) !void {
+    if (builtin.os.tag != .macos) return error.MacOsOnly;
+
+    const btn = lookup(name) orelse return error.UnknownButton;
+
+    if (!AXIsProcessTrusted()) return error.AccessibilityNotTrusted;
+
+    const pid = (try simulatorPid(gpa)) orelse return error.SimulatorNotRunning;
+
+    const app = AXUIElementCreateApplication(pid);
+    if (app == null) return error.AccessibilityNotTrusted;
+    defer CFRelease(app);
+
+    const el = findRetained(app, btn.ax_label) orelse return error.ButtonNotFound;
+    defer CFRelease(el);
+
+    const action = cfStr("AXPress");
+    defer if (action != null) CFRelease(action);
+    if (AXUIElementPerformAction(el, action) != kAXErrorSuccess) return error.ButtonPressFailed;
+}
+
+test "lookup resolves cli names and on-screen labels" {
+    try std.testing.expectEqualStrings("Home", lookup("home").?.ax_label);
+    try std.testing.expectEqualStrings("Sleep/Wake", lookup("lock").?.ax_label);
+    try std.testing.expectEqualStrings("Volume Up", lookup("Volume Up").?.ax_label);
+    try std.testing.expectEqualStrings("Volume Up", lookup("volume up").?.ax_label);
+    try std.testing.expect(lookup("nope") == null);
+}
+
+// --- iOS accessibility tree -------------------------------------------------
+//
+// Simulator.app *does* bridge the running iOS app's accessibility tree into
+// the host AX hierarchy — but only once the simulated runtime has app
+// accessibility switched on. With it off, the device-screen AXGroup is
+// present but childless, which looks exactly like "no bridge exists".
+//
+// Verified on Xcode 26.6 from a clean `simctl erase` + boot: the AXGroup is
+// empty, and after `defaults write com.apple.Accessibility
+// ApplicationAccessibilityEnabled 1` inside the sim it fills with the app's
+// real elements (labels, values, frames). So a driverless uitree is possible
+// on the Simulator; no XCUITest bundle required.
+//
+// Real devices are still XCUITest-only — there is no host process to inspect.
+
+const uitree = @import("../common/uitree.zig");
+const sim_window = @import("sim_window.zig");
+const simctl = @import("simctl.zig");
+
+const kAXValueTypeCGPoint: u32 = 1;
+const kAXValueTypeCGSize: u32 = 2;
+
+const CGPointC = extern struct { x: f64, y: f64 };
+const CGSizeC = extern struct { w: f64, h: f64 };
+
+extern "c" fn AXValueGetValue(value: Ref, theType: u32, valuePtr: ?*anyopaque) bool;
+
+/// Turn on app accessibility inside the simulated runtime. Idempotent, and
+/// cheap enough to run before every dump rather than making callers
+/// remember a separate setup step.
+pub fn enableAppAccessibility(gpa: std.mem.Allocator, udid: []const u8) !void {
+    const out = try simctl.Sim.init(udid).spawnDefaultsWrite(
+        gpa,
+        "com.apple.Accessibility",
+        "ApplicationAccessibilityEnabled",
+        "1",
+    );
+    gpa.free(out);
+}
+
+fn pointAttr(el: Ref, attr: [*:0]const u8) ?CGPointC {
+    const key = cfStr(attr);
+    defer if (key != null) CFRelease(key);
+    var val: Ref = null;
+    if (AXUIElementCopyAttributeValue(el, key, &val) != kAXErrorSuccess) return null;
+    if (val == null) return null;
+    defer CFRelease(val);
+    var p: CGPointC = .{ .x = 0, .y = 0 };
+    if (!AXValueGetValue(val, kAXValueTypeCGPoint, &p)) return null;
+    return p;
+}
+
+fn sizeAttr(el: Ref, attr: [*:0]const u8) ?CGSizeC {
+    const key = cfStr(attr);
+    defer if (key != null) CFRelease(key);
+    var val: Ref = null;
+    if (AXUIElementCopyAttributeValue(el, key, &val) != kAXErrorSuccess) return null;
+    if (val == null) return null;
+    defer CFRelease(val);
+    var s: CGSizeC = .{ .w = 0, .h = 0 };
+    if (!AXValueGetValue(val, kAXValueTypeCGSize, &s)) return null;
+    return s;
+}
+
+fn boolAttr(el: Ref, attr: [*:0]const u8, default: bool) bool {
+    var buf: [32]u8 = undefined;
+    if (stringAttr(el, attr, &buf)) |s| {
+        if (std.mem.eql(u8, s, "0") or std.ascii.eqlIgnoreCase(s, "false")) return false;
+        if (std.mem.eql(u8, s, "1") or std.ascii.eqlIgnoreCase(s, "true")) return true;
+    }
+    return default;
+}
+
+/// Roles that represent something a user can act on. Used to set the
+/// `clickable` flag in the unified element list.
+fn isInteractive(role: []const u8) bool {
+    const roles = [_][]const u8{
+        "AXButton",   "AXLink",       "AXCheckBox", "AXRadioButton",
+        "AXTextField","AXTextArea",   "AXSlider",   "AXPopUpButton",
+        "AXMenuItem", "AXIncrementor","AXSwitch",   "AXSegmentedControl",
+    };
+    for (roles) |r| {
+        if (std.mem.eql(u8, r, role)) return true;
+    }
+    return false;
+}
+
+const Ctx = struct {
+    gpa: std.mem.Allocator,
+    list: *std.ArrayList(uitree.Element),
+    win: sim_window.WindowRect,
+    px: sim_window.PixelSize,
+    ref: u32 = 0,
+};
+
+fn collect(ctx: *Ctx, el: Ref, depth: u32) !void {
+    if (depth > 40) return;
+
+    var role_buf: [128]u8 = undefined;
+    const role = stringAttr(el, "AXRole", &role_buf) orelse "";
+
+    var text_buf: [512]u8 = undefined;
+    var desc_buf: [512]u8 = undefined;
+    var id_buf: [256]u8 = undefined;
+    const text = stringAttr(el, "AXValue", &text_buf) orelse "";
+    // iOS accessibilityLabel surfaces as AXDescription; AXTitle is rarer but
+    // does appear, so fall back to it rather than dropping the label.
+    var title_buf: [512]u8 = undefined;
+    const desc = stringAttr(el, "AXDescription", &desc_buf) orelse
+        (stringAttr(el, "AXTitle", &title_buf) orelse "");
+    // accessibilityIdentifier — the stable hook tests should prefer.
+    const id = stringAttr(el, "AXIdentifier", &id_buf) orelse "";
+
+    var bounds: ?uitree.Bounds = null;
+    if (pointAttr(el, "AXPosition")) |p| {
+        if (sizeAttr(el, "AXSize")) |s| {
+            const tl = sim_window.screenToDevice(ctx.win, ctx.px, p.x, p.y);
+            const br = sim_window.screenToDevice(ctx.win, ctx.px, p.x + s.w, p.y + s.h);
+            bounds = .{
+                .x1 = @intFromFloat(tl[0]),
+                .y1 = @intFromFloat(tl[1]),
+                .x2 = @intFromFloat(br[0]),
+                .y2 = @intFromFloat(br[1]),
+            };
+        }
+    }
+
+    const e: uitree.Element = .{
+        .ref = ctx.ref,
+        .class = try ctx.gpa.dupe(u8, role),
+        .text = try ctx.gpa.dupe(u8, text),
+        .id = try ctx.gpa.dupe(u8, id),
+        .desc = try ctx.gpa.dupe(u8, desc),
+        .bounds = bounds,
+        .clickable = isInteractive(role),
+        .enabled = boolAttr(el, "AXEnabled", true),
+    };
+
+    // Same rule as the Android walker: keep anything with a label, an
+    // identifier, or an action; drop pure layout wrappers.
+    if (e.text.len != 0 or e.desc.len != 0 or e.id.len != 0 or e.clickable) {
+        try ctx.list.append(ctx.gpa, e);
+        ctx.ref += 1;
+    } else {
+        ctx.gpa.free(e.class);
+        ctx.gpa.free(e.text);
+        ctx.gpa.free(e.id);
+        ctx.gpa.free(e.desc);
+    }
+
+    const kids_key = cfStr("AXChildren");
+    defer if (kids_key != null) CFRelease(kids_key);
+    var kids: Ref = null;
+    if (AXUIElementCopyAttributeValue(el, kids_key, &kids) != kAXErrorSuccess) return;
+    if (kids == null) return;
+    defer CFRelease(kids);
+    if (CFGetTypeID(kids) != CFArrayGetTypeID()) return;
+
+    const n = CFArrayGetCount(kids);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        try collect(ctx, CFArrayGetValueAtIndex(kids, i), depth + 1);
+    }
+}
+
+/// Locate the AXGroup that hosts the simulated screen's content.
+///
+/// The device window also carries Simulator's own chrome (bezel buttons, the
+/// toolbar, device-name labels). The iOS app lives in the one AXGroup child
+/// that actually has children — which is precisely why an un-bridged
+/// simulator looks empty rather than absent.
+fn deviceScreenGroup(window: Ref) ?Ref {
+    const kids_key = cfStr("AXChildren");
+    defer if (kids_key != null) CFRelease(kids_key);
+    var kids: Ref = null;
+    if (AXUIElementCopyAttributeValue(window, kids_key, &kids) != kAXErrorSuccess) return null;
+    if (kids == null) return null;
+    defer CFRelease(kids);
+    if (CFGetTypeID(kids) != CFArrayGetTypeID()) return null;
+
+    const n = CFArrayGetCount(kids);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const child = CFArrayGetValueAtIndex(kids, i);
+        var rb: [128]u8 = undefined;
+        const role = stringAttr(child, "AXRole", &rb) orelse continue;
+        if (!std.mem.eql(u8, role, "AXGroup")) continue;
+
+        var gk: Ref = null;
+        const kk = cfStr("AXChildren");
+        defer if (kk != null) CFRelease(kk);
+        if (AXUIElementCopyAttributeValue(child, kk, &gk) != kAXErrorSuccess) continue;
+        if (gk == null) continue;
+        defer CFRelease(gk);
+        if (CFGetTypeID(gk) != CFArrayGetTypeID()) continue;
+        if (CFArrayGetCount(gk) > 0) return retained(child);
+    }
+    return null;
+}
+
+fn firstWindow(app: Ref) ?Ref {
+    const kids_key = cfStr("AXChildren");
+    defer if (kids_key != null) CFRelease(kids_key);
+    var kids: Ref = null;
+    if (AXUIElementCopyAttributeValue(app, kids_key, &kids) != kAXErrorSuccess) return null;
+    if (kids == null) return null;
+    defer CFRelease(kids);
+    if (CFGetTypeID(kids) != CFArrayGetTypeID()) return null;
+
+    const n = CFArrayGetCount(kids);
+    var i: i64 = 0;
+    while (i < n) : (i += 1) {
+        const child = CFArrayGetValueAtIndex(kids, i);
+        var rb: [128]u8 = undefined;
+        const role = stringAttr(child, "AXRole", &rb) orelse continue;
+        if (std.mem.eql(u8, role, "AXWindow")) return retained(child);
+    }
+    return null;
+}
+
+/// Declared explicitly rather than inferred: on non-macOS the comptime guard
+/// below eliminates the body, which would narrow an inferred set to just
+/// `MacOsOnly` and break callers that handle the richer macOS failures.
+pub const DumpError = std.mem.Allocator.Error || error{
+    MacOsOnly,
+    AccessibilityNotTrusted,
+    AccessibilityTreeEmpty,
+    SimulatorNotRunning,
+    PipeCreateFailed,
+    ForkFailed,
+    XcodeNotFound,
+    CommandFailed,
+    InvalidCharacter,
+    BadRect,
+    NoSpaceLeft,
+    NameTooLong,
+    OpenFailed,
+    ShortRead,
+    NotPng,
+    NoIhdr,
+};
+
+/// Dump the running iOS app's accessibility tree as unified elements.
+/// Bounds are device pixels, matching `ios screenshot` and `ios tap`.
+pub fn dumpElements(
+    gpa: std.mem.Allocator,
+    udid: []const u8,
+) DumpError![]uitree.Element {
+    if (builtin.os.tag != .macos) return error.MacOsOnly;
+    if (!AXIsProcessTrusted()) return error.AccessibilityNotTrusted;
+
+    try enableAppAccessibility(gpa, udid);
+
+    const pid = (try simulatorPid(gpa)) orelse return error.SimulatorNotRunning;
+    const app = AXUIElementCreateApplication(pid);
+    if (app == null) return error.AccessibilityNotTrusted;
+    defer CFRelease(app);
+
+    const window = firstWindow(app) orelse return error.SimulatorNotRunning;
+    defer CFRelease(window);
+    const group = deviceScreenGroup(window) orelse return error.AccessibilityTreeEmpty;
+    defer CFRelease(group);
+
+    const win = try sim_window.frontWindowRect(gpa);
+    const px = try sim_window.devicePixelSize(gpa, udid);
+
+    var list: std.ArrayList(uitree.Element) = .empty;
+    errdefer {
+        for (list.items) |e| {
+            gpa.free(e.class);
+            gpa.free(e.text);
+            gpa.free(e.id);
+            gpa.free(e.desc);
+        }
+        list.deinit(gpa);
+    }
+
+    var ctx: Ctx = .{ .gpa = gpa, .list = &list, .win = win, .px = px };
+    try collect(&ctx, group, 0);
+    return try list.toOwnedSlice(gpa);
+}
+
+test "isInteractive covers the common iOS control roles" {
+    try std.testing.expect(isInteractive("AXButton"));
+    try std.testing.expect(isInteractive("AXTextField"));
+    try std.testing.expect(!isInteractive("AXGroup"));
+    try std.testing.expect(!isInteractive("AXStaticText"));
+}

--- a/kuri-mobile/src/ios/sim_input.zig
+++ b/kuri-mobile/src/ios/sim_input.zig
@@ -107,3 +107,93 @@ pub fn swipe(a: CGPoint, b: CGPoint, duration_ms: u64) void {
     }
     postMouse(kCGEventLeftMouseUp, b);
 }
+
+// --- Keyboard ---------------------------------------------------------------
+// `type` (in cli.zig) routes plain text through System Events `keystroke`,
+// which is Unicode-safe and needs no keycode table. That path cannot express
+// modified keys, so hardware-keyboard shortcuts — Command-Return being the
+// motivating case — go through CGEvent with an explicit virtual keycode and
+// modifier flag set.
+
+extern "c" fn CGEventCreateKeyboardEvent(
+    source: CGEventSourceRef,
+    virtualKey: u16,
+    keyDown: bool,
+) CGEventRef;
+extern "c" fn CGEventSetFlags(event: CGEventRef, flags: u64) void;
+
+/// CGEventFlags bits (CGEventTypes.h).
+pub const mod_shift: u64 = 0x00020000;
+pub const mod_control: u64 = 0x00040000;
+pub const mod_option: u64 = 0x00080000;
+pub const mod_command: u64 = 0x00100000;
+
+pub const NamedKey = struct { name: []const u8, code: u16 };
+
+/// Virtual keycodes from Carbon's Events.h. Only the keys that matter for
+/// driving an iOS app are listed; extend as needed.
+pub const named_keys = [_]NamedKey{
+    .{ .name = "return", .code = 36 },
+    .{ .name = "enter", .code = 76 },
+    .{ .name = "tab", .code = 48 },
+    .{ .name = "space", .code = 49 },
+    .{ .name = "delete", .code = 51 },
+    .{ .name = "escape", .code = 53 },
+    .{ .name = "left", .code = 123 },
+    .{ .name = "right", .code = 124 },
+    .{ .name = "down", .code = 125 },
+    .{ .name = "up", .code = 126 },
+};
+
+pub fn lookupKey(name: []const u8) ?u16 {
+    for (named_keys) |k| {
+        if (std.ascii.eqlIgnoreCase(k.name, name)) return k.code;
+    }
+    return null;
+}
+
+/// Map a modifier name to its CGEventFlags bit. Accepts the common aliases
+/// so `--cmd`, `--command` and `--meta` all work.
+pub fn lookupModifier(name: []const u8) ?u64 {
+    const table = .{
+        .{ "cmd", mod_command },     .{ "command", mod_command }, .{ "meta", mod_command },
+        .{ "shift", mod_shift },     .{ "ctrl", mod_control },    .{ "control", mod_control },
+        .{ "opt", mod_option },      .{ "option", mod_option },   .{ "alt", mod_option },
+    };
+    inline for (table) |entry| {
+        if (std.ascii.eqlIgnoreCase(entry[0], name)) return entry[1];
+    }
+    return null;
+}
+
+fn postKey(code: u16, flags: u64, down: bool) void {
+    const ev = CGEventCreateKeyboardEvent(null, code, down);
+    if (ev == null) return;
+    if (flags != 0) CGEventSetFlags(ev, flags);
+    CGEventPost(kCGHIDEventTap, ev);
+    CFRelease(@ptrCast(ev));
+}
+
+/// Press and release `code` with `flags` held. Flags are applied to both the
+/// down and up events so the receiving app sees a consistent modifier state.
+pub fn keyPress(code: u16, flags: u64) void {
+    if (builtin.os.tag != .macos) return;
+    postKey(code, flags, true);
+    sleepMs(30);
+    postKey(code, flags, false);
+}
+
+test "lookupKey is case-insensitive and covers Return" {
+    try std.testing.expectEqual(@as(u16, 36), lookupKey("return").?);
+    try std.testing.expectEqual(@as(u16, 36), lookupKey("RETURN").?);
+    try std.testing.expectEqual(@as(u16, 53), lookupKey("escape").?);
+    try std.testing.expect(lookupKey("f13") == null);
+}
+
+test "lookupModifier accepts aliases" {
+    try std.testing.expectEqual(mod_command, lookupModifier("cmd").?);
+    try std.testing.expectEqual(mod_command, lookupModifier("Command").?);
+    try std.testing.expectEqual(mod_option, lookupModifier("alt").?);
+    try std.testing.expectEqual(mod_control, lookupModifier("ctrl").?);
+    try std.testing.expect(lookupModifier("hyper") == null);
+}

--- a/kuri-mobile/src/ios/sim_window.zig
+++ b/kuri-mobile/src/ios/sim_window.zig
@@ -19,6 +19,7 @@
 const std = @import("std");
 const io = @import("../common/io.zig");
 const sim_input = @import("sim_input.zig");
+const xcode = @import("xcode.zig");
 
 pub const WindowRect = struct { x: f64, y: f64, w: f64, h: f64 };
 
@@ -80,10 +81,8 @@ pub fn devicePixelSize(gpa: std.mem.Allocator, udid: []const u8) !PixelSize {
     const stamp: i64 = @intCast(std.c.getpid());
     const path = try std.fmt.bufPrint(&path_buf, "/tmp/kuri-mobile-sim-{d}.png", .{stamp});
 
-    const r = try io.runCommand(gpa, &.{
-        "xcrun", "simctl", "io", udid, "screenshot", path,
-    }, 1024);
-    gpa.free(r.stdout);
+    const shot = try xcode.run(gpa, "simctl", &.{ "io", udid, "screenshot", path }, 1024);
+    gpa.free(shot);
 
     // Read first 24 bytes: 8-byte PNG signature + 4 chunk len + 4 "IHDR"
     // + 4 width + 4 height (big-endian).
@@ -124,6 +123,35 @@ pub fn deviceToScreen(
         .x = win.x + dev_x * scale_x,
         .y = win.y + TITLE_BAR_PTS + dev_y * scale_y,
     };
+}
+
+/// Inverse of `deviceToScreen`: convert a macOS screen point (what the
+/// Accessibility API reports for an element's frame) back into the device
+/// pixel grid, so uitree bounds line up with `ios tap` coordinates and with
+/// the screenshot.
+pub fn screenToDevice(
+    win: WindowRect,
+    px: PixelSize,
+    screen_x: f64,
+    screen_y: f64,
+) [2]f64 {
+    const content_h = win.h - TITLE_BAR_PTS;
+    const scale_x = win.w / @as(f64, @floatFromInt(px.w));
+    const scale_y = content_h / @as(f64, @floatFromInt(px.h));
+    if (scale_x == 0 or scale_y == 0) return .{ 0, 0 };
+    return .{
+        (screen_x - win.x) / scale_x,
+        (screen_y - win.y - TITLE_BAR_PTS) / scale_y,
+    };
+}
+
+test "screenToDevice round-trips deviceToScreen" {
+    const win = WindowRect{ .x = 100, .y = 50, .w = 400, .h = 828 };
+    const px = PixelSize{ .w = 1200, .h = 2400 };
+    const s = deviceToScreen(win, px, 640, 1500);
+    const d = screenToDevice(win, px, s.x, s.y);
+    try std.testing.expectApproxEqAbs(@as(f64, 640), d[0], 0.001);
+    try std.testing.expectApproxEqAbs(@as(f64, 1500), d[1], 0.001);
 }
 
 test "parseRect basic" {

--- a/kuri-mobile/src/ios/simctl.zig
+++ b/kuri-mobile/src/ios/simctl.zig
@@ -1,7 +1,11 @@
-//! iOS Simulator driver via `xcrun simctl`.
+//! iOS Simulator driver via `simctl`.
+//!
+//! Invoked through xcode.zig by absolute path rather than `xcrun`, and every
+//! call checks its exit status — see xcode.zig for why that matters.
 
 const std = @import("std");
 const io = @import("../common/io.zig");
+const xcode = @import("xcode.zig");
 
 pub const Sim = struct {
     udid: []const u8,
@@ -11,43 +15,152 @@ pub const Sim = struct {
     }
 
     pub fn screenshot(self: Sim, gpa: std.mem.Allocator, path: []const u8) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "io", self.udid, "screenshot", path }, 64 * 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "io", self.udid, "screenshot", path }, 64 * 1024 * 1024);
+        gpa.free(out);
     }
 
     pub fn launch(self: Sim, gpa: std.mem.Allocator, bundle_id: []const u8) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "launch", self.udid, bundle_id }, 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "launch", self.udid, bundle_id }, 1024 * 1024);
+        gpa.free(out);
     }
 
     pub fn terminate(self: Sim, gpa: std.mem.Allocator, bundle_id: []const u8) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "terminate", self.udid, bundle_id }, 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "terminate", self.udid, bundle_id }, 1024 * 1024);
+        gpa.free(out);
     }
 
     pub fn listApps(self: Sim, gpa: std.mem.Allocator) ![]u8 {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "listapps", self.udid }, 16 * 1024 * 1024);
-        return r.stdout;
+        return xcode.run(gpa, "simctl", &.{ "listapps", self.udid }, 16 * 1024 * 1024);
     }
 
     /// Open a URL in the default handler (https/http → Safari).
     /// This is the "navigate" primitive on iOS Simulator — it's how
     /// you tell Safari to load a page without typing in the address bar.
     pub fn openUrl(self: Sim, gpa: std.mem.Allocator, url: []const u8) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "openurl", self.udid, url }, 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "openurl", self.udid, url }, 1024 * 1024);
+        gpa.free(out);
     }
 
     pub fn boot(self: Sim, gpa: std.mem.Allocator) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "boot", self.udid }, 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "boot", self.udid }, 1024 * 1024);
+        gpa.free(out);
     }
 
     pub fn shutdown(self: Sim, gpa: std.mem.Allocator) !void {
-        const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "shutdown", self.udid }, 1024 * 1024);
-        gpa.free(r.stdout);
+        const out = try xcode.run(gpa, "simctl", &.{ "shutdown", self.udid }, 1024 * 1024);
+        gpa.free(out);
+    }
+
+    // --- Permissions --------------------------------------------------------
+
+    /// Grant / revoke / reset a TCC permission for a bundle id.
+    pub fn privacy(
+        self: Sim,
+        gpa: std.mem.Allocator,
+        action: []const u8,
+        service: []const u8,
+        bundle_id: ?[]const u8,
+    ) !void {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(gpa);
+        try argv.appendSlice(gpa, &.{ "privacy", self.udid, action, service });
+        if (bundle_id) |b| try argv.append(gpa, b);
+        const out = try xcode.run(gpa, "simctl", argv.items, 1024 * 1024);
+        gpa.free(out);
+    }
+
+    // --- Accessibility / appearance ----------------------------------------
+
+    /// `simctl ui <udid> <option> [value]`. With no value this prints the
+    /// current setting, which is what makes it usable as an assertion.
+    pub fn ui(self: Sim, gpa: std.mem.Allocator, option: []const u8, value: ?[]const u8) ![]u8 {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(gpa);
+        try argv.appendSlice(gpa, &.{ "ui", self.udid, option });
+        if (value) |v| try argv.append(gpa, v);
+        return xcode.run(gpa, "simctl", argv.items, 1024 * 1024);
+    }
+
+    /// Pin the status bar so screenshots are byte-comparable across runs.
+    pub fn statusBar(self: Sim, gpa: std.mem.Allocator, extra: []const []const u8) !void {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(gpa);
+        try argv.appendSlice(gpa, &.{ "status_bar", self.udid, "override" });
+        try argv.appendSlice(gpa, extra);
+        const out = try xcode.run(gpa, "simctl", argv.items, 1024 * 1024);
+        gpa.free(out);
+    }
+
+    pub fn statusBarClear(self: Sim, gpa: std.mem.Allocator) !void {
+        const out = try xcode.run(gpa, "simctl", &.{ "status_bar", self.udid, "clear" }, 1024 * 1024);
+        gpa.free(out);
+    }
+
+    /// `simctl spawn <udid> defaults write <domain> <key> -int <value>`.
+    /// Used to flip runtime-side settings that have no simctl verb — notably
+    /// app accessibility, which gates the host-visible a11y tree.
+    pub fn spawnDefaultsWrite(
+        self: Sim,
+        gpa: std.mem.Allocator,
+        domain: []const u8,
+        key: []const u8,
+        int_value: []const u8,
+    ) ![]u8 {
+        return xcode.run(gpa, "simctl", &.{
+            "spawn", self.udid, "defaults", "write", domain, key, "-int", int_value,
+        }, 1024 * 1024);
+    }
+
+    // --- Diagnostics --------------------------------------------------------
+
+    /// Retrospective os_log query against the simulator.
+    ///
+    /// Deliberately `log show --last`, not `log stream`: a bounded query
+    /// terminates, so it can back an assertion ("did the app request a
+    /// haptic in the last 30s?"). A stream would block until killed.
+    pub fn logShow(
+        self: Sim,
+        gpa: std.mem.Allocator,
+        last: []const u8,
+        predicate: ?[]const u8,
+    ) ![]u8 {
+        var argv: std.ArrayList([]const u8) = .empty;
+        defer argv.deinit(gpa);
+        try argv.appendSlice(gpa, &.{
+            "spawn", self.udid, "log", "show", "--last", last, "--style", "compact",
+        });
+        if (predicate) |p| try argv.appendSlice(gpa, &.{ "--predicate", p });
+        return xcode.run(gpa, "simctl", argv.items, 64 * 1024 * 1024);
     }
 };
+
+/// TCC services `simctl privacy` accepts, as of Xcode 26.6.
+pub const privacy_services = [_][]const u8{
+    "all",        "calendar",    "contacts-limited", "contacts",
+    "location",   "location-always", "photos-add",  "photos",
+    "media-library", "microphone", "motion",        "reminders",
+    "siri",
+};
+
+/// Services people reach for that `simctl privacy` genuinely does not
+/// implement. Worth naming explicitly: silently passing `camera` through to
+/// simctl produces a confusing failure, and camera permission is exactly
+/// what a first-use camera-authorization bug needs to reset.
+pub const privacy_unsupported = [_][]const u8{ "camera", "speech-recognition", "speech" };
+
+pub fn isPrivacyService(name: []const u8) bool {
+    for (privacy_services) |s| {
+        if (std.mem.eql(u8, s, name)) return true;
+    }
+    return false;
+}
+
+pub fn isPrivacyUnsupported(name: []const u8) bool {
+    for (privacy_unsupported) |s| {
+        if (std.mem.eql(u8, s, name)) return true;
+    }
+    return false;
+}
 
 pub const SimDevice = struct {
     udid: []const u8,
@@ -56,10 +169,10 @@ pub const SimDevice = struct {
 };
 
 pub fn listDevices(gpa: std.mem.Allocator) ![]SimDevice {
-    const r = try io.runCommand(gpa, &.{ "xcrun", "simctl", "list", "devices", "--json" }, 16 * 1024 * 1024);
-    defer gpa.free(r.stdout);
+    const stdout = try xcode.run(gpa, "simctl", &.{ "list", "devices", "--json" }, 16 * 1024 * 1024);
+    defer gpa.free(stdout);
 
-    var parsed = try std.json.parseFromSlice(std.json.Value, gpa, r.stdout, .{});
+    var parsed = try std.json.parseFromSlice(std.json.Value, gpa, stdout, .{});
     defer parsed.deinit();
 
     var list: std.ArrayList(SimDevice) = .empty;
@@ -106,4 +219,14 @@ fn freeFromList(gpa: std.mem.Allocator, list: *std.ArrayList(SimDevice)) void {
         gpa.free(d.state);
     }
     list.deinit(gpa);
+}
+
+test "privacy service classification" {
+    try std.testing.expect(isPrivacyService("microphone"));
+    try std.testing.expect(isPrivacyService("photos"));
+    try std.testing.expect(!isPrivacyService("camera"));
+    // camera is the one people most expect to work, so it must be
+    // classified as explicitly-unsupported rather than merely unknown.
+    try std.testing.expect(isPrivacyUnsupported("camera"));
+    try std.testing.expect(!isPrivacyUnsupported("microphone"));
 }

--- a/kuri-mobile/src/ios/xcode.zig
+++ b/kuri-mobile/src/ios/xcode.zig
@@ -1,0 +1,178 @@
+//! Locating and invoking the active Xcode toolchain.
+//!
+//! Everything iOS-side used to shell out to bare `xcrun`, which resolves
+//! through `xcode-select`. On a machine where `xcode-select -p` points at
+//! /Library/Developer/CommandLineTools — a common state, and the default
+//! after installing CLT — there is no `simctl` there, so `xcrun` fails with
+//! "unable to find utility". Because `runCommand` only reports *captured
+//! output* and never the exit status, that failure surfaced as an empty
+//! stdout, which `listDevices` then parsed into zero devices. The user saw
+//! `kuri ios list-devices` exit 0 with no output: a harness silently
+//! reporting "no devices" when the real answer is "Xcode isn't selected".
+//!
+//! So we resolve a developer directory that actually carries `simctl` and
+//! invoke its tools by absolute path, bypassing `xcrun` entirely. Exit
+//! statuses are checked, and failures carry the tool's own diagnostic.
+
+const std = @import("std");
+const io = @import("../common/io.zig");
+
+/// Resolved once per process; a CLI run never needs to re-probe.
+///
+/// Held in a static buffer rather than an allocation on purpose: the value
+/// lives for the whole process, so an allocated cache is a leak by
+/// construction, and the DebugAllocator would print a stack trace on every
+/// single command. Nothing to free, nothing to report.
+var cached_buf: [4096]u8 = undefined;
+var cached_len: usize = 0;
+var cached_set: bool = false;
+
+fn getEnv(name: [*:0]const u8) ?[]const u8 {
+    const v = std.c.getenv(name) orelse return null;
+    return std.mem.span(v);
+}
+
+/// Existence probe via `open`, matching the libc-only idiom the rest of
+/// kuri-mobile uses (Zig 0.16 pared back the std.fs surface we'd want).
+fn fileExists(path: []const u8) bool {
+    var buf: [4096]u8 = undefined;
+    if (path.len >= buf.len) return false;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    const fd = std.c.open(buf[0..path.len :0], .{ .ACCMODE = .RDONLY }, @as(std.c.mode_t, 0));
+    if (fd < 0) return false;
+    _ = std.c.close(fd);
+    return true;
+}
+
+/// A developer dir only counts if it actually carries `simctl`. This is the
+/// exact check that distinguishes a real Xcode.app from CommandLineTools.
+fn carriesSimctl(gpa: std.mem.Allocator, dir: []const u8) bool {
+    const p = std.fmt.allocPrint(gpa, "{s}/usr/bin/simctl", .{dir}) catch return false;
+    defer gpa.free(p);
+    return fileExists(p);
+}
+
+fn cache(dir: []const u8) ![]const u8 {
+    if (dir.len > cached_buf.len) return error.XcodeNotFound;
+    @memcpy(cached_buf[0..dir.len], dir);
+    cached_len = dir.len;
+    cached_set = true;
+    return cached_buf[0..cached_len];
+}
+
+/// Resolve a developer directory containing a usable `simctl`.
+pub fn developerDir(gpa: std.mem.Allocator) ![]const u8 {
+    if (cached_set) return cached_buf[0..cached_len];
+
+    // 1. An explicit DEVELOPER_DIR override always wins.
+    if (getEnv("DEVELOPER_DIR")) |d| {
+        if (carriesSimctl(gpa, d)) return cache(d);
+    }
+
+    // 2. Whatever xcode-select points at — accepted only if it has simctl,
+    //    which is what rejects a CommandLineTools-only selection.
+    if (io.runCommand(gpa, &.{ "xcode-select", "-p" }, 4096)) |r| {
+        defer gpa.free(r.stdout);
+        const trimmed = std.mem.trim(u8, r.stdout, " \t\r\n");
+        if (trimmed.len > 0 and carriesSimctl(gpa, trimmed)) return cache(trimmed);
+    } else |_| {}
+
+    // 3. Fall back to a normally-installed Xcode, so the common
+    //    "CLT is selected but Xcode.app is right there" case just works.
+    const candidates = [_][]const u8{
+        "/Applications/Xcode.app/Contents/Developer",
+        "/Applications/Xcode-beta.app/Contents/Developer",
+    };
+    for (candidates) |cand| {
+        if (carriesSimctl(gpa, cand)) return cache(cand);
+    }
+
+    return error.XcodeNotFound;
+}
+
+/// Absolute path to a tool in the resolved toolchain. Caller frees.
+pub fn toolPath(gpa: std.mem.Allocator, tool: []const u8) ![]const u8 {
+    const dir = try developerDir(gpa);
+    return std.fmt.allocPrint(gpa, "{s}/usr/bin/{s}", .{ dir, tool });
+}
+
+/// Decode a waitpid status into an exit code.
+fn exitCode(term: i32) i32 {
+    return (term >> 8) & 0xFF;
+}
+
+fn buildArgv(
+    gpa: std.mem.Allocator,
+    path: []const u8,
+    argv: []const []const u8,
+) !std.ArrayList([]const u8) {
+    var full: std.ArrayList([]const u8) = .empty;
+    errdefer full.deinit(gpa);
+    try full.append(gpa, path);
+    try full.appendSlice(gpa, argv);
+    return full;
+}
+
+/// Run an Xcode tool and check its exit status. Returns captured output on
+/// success; on failure prints the tool's own diagnostic and returns
+/// error.CommandFailed. `runCommand` merges stderr into stdout, so that
+/// captured text *is* the diagnostic.
+pub fn run(
+    gpa: std.mem.Allocator,
+    tool: []const u8,
+    argv: []const []const u8,
+    max_output: usize,
+) ![]u8 {
+    const path = try toolPath(gpa, tool);
+    defer gpa.free(path);
+
+    var full = try buildArgv(gpa, path, argv);
+    defer full.deinit(gpa);
+
+    const r = try io.runCommand(gpa, full.items, max_output);
+    const code = exitCode(r.term);
+    if (code != 0) {
+        defer gpa.free(r.stdout);
+        var arena_impl = std.heap.ArenaAllocator.init(gpa);
+        defer arena_impl.deinit();
+        io.printStderr(arena_impl.allocator(), "{s} failed (exit {d}): {s}\n", .{
+            tool,
+            code,
+            std.mem.trim(u8, r.stdout, " \t\r\n"),
+        });
+        return error.CommandFailed;
+    }
+    return r.stdout;
+}
+
+/// Like `run`, but a non-zero exit is reported to the caller instead of
+/// being treated as fatal. Used where failure is a legitimate outcome
+/// (e.g. terminating an app that isn't running).
+pub fn tryRun(
+    gpa: std.mem.Allocator,
+    tool: []const u8,
+    argv: []const []const u8,
+    max_output: usize,
+) !struct { stdout: []u8, code: i32 } {
+    const path = try toolPath(gpa, tool);
+    defer gpa.free(path);
+
+    var full = try buildArgv(gpa, path, argv);
+    defer full.deinit(gpa);
+
+    const r = try io.runCommand(gpa, full.items, max_output);
+    return .{ .stdout = r.stdout, .code = exitCode(r.term) };
+}
+
+test "exitCode decodes waitpid status" {
+    // waitpid encodes the exit status in the high byte.
+    try std.testing.expectEqual(@as(i32, 0), exitCode(0));
+    try std.testing.expectEqual(@as(i32, 1), exitCode(1 << 8));
+    try std.testing.expectEqual(@as(i32, 72), exitCode(72 << 8));
+}
+
+test "fileExists distinguishes real and missing paths" {
+    try std.testing.expect(fileExists("/usr/bin/true"));
+    try std.testing.expect(!fileExists("/nonexistent/kuri/xcode/probe"));
+}

--- a/kuri-mobile/src/main.zig
+++ b/kuri-mobile/src/main.zig
@@ -83,8 +83,21 @@ fn reportError(err: anyerror) noreturn {
         error.AdbCommandFailed => "adb returned FAIL — see the warning log above for details.",
         error.AdbProtocolError => "unexpected response from adb server (protocol error).",
         error.UnexpectedEof => "adb connection closed mid-message.",
-        error.UnknownButton => "unknown button name; see `kuri-mobile android` for the supported list.",
-        error.NoBootedSimulator => "no booted iOS Simulator found. Run `xcrun simctl boot <UDID>` first or pass --udid.",
+        error.UnknownButton => "unknown button name; run the platform subcommand with no args for the supported list.",
+        error.NoBootedSimulator => "no booted iOS Simulator found. Run `kuri-mobile ios boot --udid <UDID>` first or pass --udid.",
+        error.XcodeNotFound =>
+            \\no Xcode toolchain with `simctl` found. `xcode-select -p` may point at
+            \\CommandLineTools, which does not ship simctl. Fix with either:
+            \\  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+            \\  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer kuri-mobile ios ...
+        ,
+        // xcode.run already printed the failing tool's own diagnostic above.
+        error.CommandFailed => "the Xcode tool reported a failure (see the message above).",
+        error.AccessibilityNotTrusted => "macOS Accessibility permission is required to drive the Simulator. Grant it to your terminal in System Settings -> Privacy & Security -> Accessibility.",
+        error.SimulatorNotRunning => "Simulator.app is not running. Boot a simulator first (`kuri-mobile ios boot --udid <UDID>`).",
+        error.ButtonNotFound => "that button is not present in the current Simulator window (some buttons only appear for certain device types).",
+        error.ButtonPressFailed => "the Simulator rejected the button press.",
+        error.MacOsOnly => "iOS commands are macOS-only.",
         else => "",
     };
     var arena_impl = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -103,4 +116,9 @@ test {
     _ = @import("android/driver.zig");
     _ = @import("common/uitree.zig");
     _ = @import("ios/usbmux.zig");
+    _ = @import("ios/xcode.zig");
+    _ = @import("ios/simctl.zig");
+    _ = @import("ios/sim_ax.zig");
+    _ = @import("ios/sim_input.zig");
+    _ = @import("ios/sim_window.zig");
 }

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -4,7 +4,7 @@ const markdown = @import("crawler/markdown.zig");
 const validator = @import("crawler/validator.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.0";
+const version = "0.4.6";
 const user_agent = "kuri-browse/" ++ version;
 
 pub fn main(init: std.process.Init.Minimal) !void {

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -5,7 +5,7 @@ const markdown = @import("crawler/markdown.zig");
 const js_engine = @import("js_engine.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.0";
+const version = "0.4.6";
 
 pub fn main(init: std.process.Init.Minimal) !void {
     var gpa_impl: std.heap.DebugAllocator(.{}) = .init;

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,7 @@ const launcher = @import("chrome/launcher.zig");
 const api_token = @import("server/api_token.zig");
 const lifecycle = @import("lifecycle.zig");
 
-const version = "0.4.1";
+const version = "0.4.6";
 
 const CliAction = enum {
     run,


### PR DESCRIPTION
## Why

The release pipeline has not published a GitHub Release since v0.3.3. Every tag from v0.4.0 to v0.4.5 shows `cancelled` after exactly 24h. Three independent causes, all in code paths that had never executed:

1. **Dead runner label.** `build-macos-x86` pinned `macos-13`, which GitHub retired. The job never got a runner (`runner_name: ""`, zero steps), sat queued until the 24h job limit cancelled it, and since both publish jobs `needs:` it, they were skipped. This is why releases v0.4.1–v0.4.4 were uploaded by hand.
2. **Release notes crash.** The notes/checksum script split on a literal `\n` (backslash-n) instead of a newline — YAML block scalars do no escape processing — raising `IndexError` on its first successful run. Verified by local repro.
3. **kuri-mobile was never shipped.** The root build had no reference to it, so no release tarball ever contained the binary `kuri` execs as a sibling.

## What changed

- macOS builds both arches on one `macos-latest` runner. Zig cross-compiles `x86_64-macos` from arm64 and `codesign` is architecture-agnostic, so one live runner covers both. Each matrix leg installs to its own prefix so tarballs can't pick up the other arch.
- Every job has an explicit `timeout-minutes`; `notarytool submit` gets `--timeout 30m`. A hang now fails in minutes, not at the 24h cap.
- `kuri-mobile` is a path dependency of the root build and installs into the same prefix, so it ships in every tarball on all four targets.
- Signing/notarization is no longer *asserted*. The repo has no Apple secrets today, so the sign step records whether it actually ran; release notes and the channel manifest's `notarized` flag now reflect reality instead of hardcoding true.
- kuri-mobile now builds off native macOS: an inferred error set collapsed to `MacOsOnly` on non-macOS targets, and cross-compiling to `x86_64-macos` couldn't resolve `ApplicationServices`.
- iOS: driverless `uitree`, tap-by-`--label`, `doubletap`/`longpress`/`swipe`/`type`/`key` with modifiers, hardware `button`, and a use-after-free fix in the accessibility walker (CoreFoundation Get Rule).

## Verification

All four release targets build and every suite passes on Zig 0.16.0:

| target | build | `kuri-mobile` in tarball |
|---|---|---|
| aarch64-macos | pass | yes |
| x86_64-macos | pass | yes |
| x86_64-linux | pass | yes |
| aarch64-linux | pass | yes |

`zig build test`, `test-fetch`, `test-browse`, and kuri-mobile's suite all exit 0. Both workflow Python scripts were extracted from the YAML and executed against the real changelog in signed and unsigned modes.

## Not addressed

macOS assets will ship **unsigned** — the repo has zero Actions secrets and no notarization credentials exist locally. Adding `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD` turns signing back on with no further code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gzdKWXk7UbHm5TtSGqYBJ