### PR TITLE
release: v0.4.8 — Android tool parity, shared registry, 63 commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to kuri are documented here.
 
+## [0.4.8] — 2026-07-25
+
+### Features — kuri-mobile Android reaches parity
+- **`android tools`** — Android now has the same meta tool iOS gained in 0.4.7. Both render from one shared module (`common/toolinfo.zig`), so the two platforms describe themselves identically and an agent can consume `ios tools --json` and `android tools --json` with a single parser. Combined surface is 63 commands (36 iOS, 27 Android)
+- **`wait-for-ui` / `find`** — the same polling and query primitives as iOS, backed by the uiautomator hierarchy. `find` exits non-zero on no match so it works directly as an assertion; `wait-for-ui` uses a wall-clock deadline rather than counting sleeps
+- **`batch`** — several actions over one adb session (`tap:120,400 type:hi press:enter wait:500 label:Done`), so serial resolution happens once instead of per command
+- **`gesture`/`drag` and `touch`** — multi-point paths via `input motionevent` (Android 11+). `input swipe` only ever interpolates between two points, so shaped drags were previously impossible
+- **Lifecycle & state** — `uninstall`, `clear` (wipe app data), `openurl`/`navigate`, `keyevent` (raw keycodes), `current-activity`, `logcat` (bounded `-d` read), `screen-info`, `getprop`, `dumpsys`
+- **More key names** — `recents`, `wakeup`, `sleep`, `search`, `camera`, `escape`, `backspace`, `notification`
+
+### Internal
+- Tool-registry rendering moved to `common/toolinfo.zig`. Shared invariant tests (`verifyTable`, `verifyJson`) run against both platform tables, so a new entry is checked for a summary, a known category, globally unique name/aliases, and JSON round-trip wherever it is added
+- Android shell commands that carry user text (package names, URLs, log filters, dumpsys sections) are now single-quote escaped, so a value containing shell metacharacters cannot break out of the constructed command
+- iOS tool entries carry an explicit `scope` rather than relying on a per-platform default
+
+### Not implemented
+- `android install` and `android record-video` need the adb SYNC protocol (file push/pull), which this client does not implement. Both are called out in the help text rather than left to fail confusingly
+
 ## [0.4.7] — 2026-07-25
 
 ### Toolchain

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .kuri,
-    .version = "0.4.7",
+    .version = "0.4.8",
     .dependencies = .{
         .quickjs = .{
             .url = "https://github.com/mitchellh/zig-quickjs-ng/archive/main.tar.gz",

--- a/kuri-mobile/README.md
+++ b/kuri-mobile/README.md
@@ -37,6 +37,12 @@ zig build
 ./zig-out/bin/kuri-mobile android tap 540 1200
 ./zig-out/bin/kuri-mobile android screenshot screen.png
 ./zig-out/bin/kuri-mobile android uitree
+./zig-out/bin/kuri-mobile android wait-for-ui --label "Sign in" --timeout 10000
+./zig-out/bin/kuri-mobile android find --label "Settings"
+./zig-out/bin/kuri-mobile android batch tap:120,400 type:hi press:enter wait:500
+./zig-out/bin/kuri-mobile android gesture 100,900 300,600 500,900 --for 600
+./zig-out/bin/kuri-mobile android current-activity
+./zig-out/bin/kuri-mobile android logcat --last 200 --predicate MyTag
 
 ./zig-out/bin/kuri-mobile ios list-devices
 ./zig-out/bin/kuri-mobile ios screenshot --udid <UDID> --simulator out.png
@@ -100,7 +106,12 @@ the help text use, so it cannot drift out of date:
 ```sh
 ./zig-out/bin/kuri-mobile ios tools           # grouped, human-readable
 ./zig-out/bin/kuri-mobile ios tools --json    # name/aliases/args/flags/scope, for agents
+./zig-out/bin/kuri-mobile android tools --json
 ```
+
+Both platforms render from `common/toolinfo.zig`, so they describe themselves
+identically and one parser handles either. 63 commands total — 36 iOS, 27
+Android.
 
 Each entry carries a `scope` of `simulator`, `device` or `simulator+device`, so
 a caller can tell "not supported here" apart from "not configured yet" without

--- a/kuri-mobile/build.zig.zon
+++ b/kuri-mobile/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .kuri_mobile,
-    .version = "0.4.7",
+    .version = "0.4.8",
     .dependencies = .{},
     .fingerprint = 0x41cfa5929f72d020,
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",

--- a/kuri-mobile/src/android/cli.zig
+++ b/kuri-mobile/src/android/cli.zig
@@ -4,7 +4,20 @@ const std = @import("std");
 const adb = @import("adb.zig");
 const driver_mod = @import("driver.zig");
 const uitree = @import("../common/uitree.zig");
+const tools = @import("tools.zig");
 const io = @import("../common/io.zig");
+
+/// Flags accepted before the subcommand's positionals.
+const Opts = struct {
+    serial: ?[]const u8 = null,
+    label: ?[]const u8 = null,
+    timeout_ms: ?u64 = null,
+    dur_ms: ?u64 = null,
+    last: ?[]const u8 = null,
+    predicate: ?[]const u8 = null,
+    absent: bool = false,
+    json: bool = false,
+};
 
 pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     if (args.len == 0) {
@@ -15,22 +28,66 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     const sub = args[0];
     const rest = args[1..];
 
+    var opts: Opts = .{};
+    var positional: std.ArrayList([]const u8) = .empty;
+    defer positional.deinit(gpa);
+
+    var idx: usize = 0;
+    while (idx < rest.len) {
+        const tok = rest[idx];
+        if (!std.mem.startsWith(u8, tok, "--")) {
+            try positional.append(gpa, tok);
+            idx += 1;
+            continue;
+        }
+        const name = tok[2..];
+        if (std.mem.eql(u8, name, "absent")) {
+            opts.absent = true;
+            idx += 1;
+            continue;
+        }
+        if (std.mem.eql(u8, name, "json")) {
+            opts.json = true;
+            idx += 1;
+            continue;
+        }
+        if (idx + 1 >= rest.len) return errMissing(tok);
+        const val = rest[idx + 1];
+        if (std.mem.eql(u8, name, "serial")) {
+            opts.serial = val;
+        } else if (std.mem.eql(u8, name, "label")) {
+            opts.label = val;
+        } else if (std.mem.eql(u8, name, "timeout")) {
+            opts.timeout_ms = try std.fmt.parseInt(u64, val, 10);
+        } else if (std.mem.eql(u8, name, "for")) {
+            opts.dur_ms = try std.fmt.parseInt(u64, val, 10);
+        } else if (std.mem.eql(u8, name, "last")) {
+            opts.last = val;
+        } else if (std.mem.eql(u8, name, "predicate")) {
+            opts.predicate = val;
+        } else {
+            var arena_impl = std.heap.ArenaAllocator.init(gpa);
+            defer arena_impl.deinit();
+            io.printStderr(arena_impl.allocator(), "unknown flag: {s}\n", .{tok});
+            return 2;
+        }
+        idx += 2;
+    }
+    const cmd_args = positional.items;
+
+    // Commands that must work with no device attached are dispatched before
+    // serial resolution, which would otherwise fail with DeviceNotFound.
+    if (std.mem.eql(u8, sub, "tools")) {
+        const text = if (opts.json) try tools.renderJson(gpa) else try tools.renderText(gpa);
+        defer gpa.free(text);
+        io.writeStdout(text);
+        return 0;
+    }
     if (std.mem.eql(u8, sub, "list-devices") or std.mem.eql(u8, sub, "devices")) {
         return cmdListDevices(gpa);
     }
 
-    var serial_opt: ?[]const u8 = null;
-    var idx: usize = 0;
-    while (idx < rest.len and std.mem.startsWith(u8, rest[idx], "--")) : (idx += 2) {
-        if (std.mem.eql(u8, rest[idx], "--serial")) {
-            if (idx + 1 >= rest.len) return errMissing("--serial");
-            serial_opt = rest[idx + 1];
-        } else {
-            io.writeStderr("unknown flag\n");
-            return 2;
-        }
-    }
-    const cmd_args = rest[idx..];
+    const serial_opt = opts.serial;
 
     const serial = serial_opt orelse try resolveDefaultSerial(gpa);
     defer if (serial_opt == null) gpa.free(serial);
@@ -49,8 +106,258 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !u8 {
     if (std.mem.eql(u8, sub, "terminate")) return cmdTerminate(gpa, &d, cmd_args);
     if (std.mem.eql(u8, sub, "list-apps")) return cmdListApps(gpa, &d);
 
+    if (std.mem.eql(u8, sub, "doubletap")) return cmdDoubleTap(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "longpress")) return cmdLongPress(gpa, &d, cmd_args);
+
+    if (std.mem.eql(u8, sub, "uninstall")) {
+        if (cmd_args.len < 1) return errMissing("package");
+        try d.uninstallApp(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "clear")) {
+        if (cmd_args.len < 1) return errMissing("package");
+        try d.clearApp(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "openurl") or std.mem.eql(u8, sub, "navigate")) {
+        if (cmd_args.len < 1) return errMissing("url");
+        try d.openUrl(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "keyevent")) {
+        if (cmd_args.len < 1) return errMissing("KEYCODE_* or number");
+        try d.keyevent(gpa, cmd_args[0]);
+        return 0;
+    }
+    if (std.mem.eql(u8, sub, "current-activity")) return emit(gpa, try d.currentActivity(gpa));
+    if (std.mem.eql(u8, sub, "screen-info")) return emit(gpa, try d.screenInfo(gpa));
+    if (std.mem.eql(u8, sub, "logcat")) {
+        return emit(gpa, try d.logcat(gpa, opts.last orelse "200", opts.predicate));
+    }
+    if (std.mem.eql(u8, sub, "getprop")) {
+        if (cmd_args.len < 1) return errMissing("property name");
+        return emit(gpa, try d.getProp(gpa, cmd_args[0]));
+    }
+    if (std.mem.eql(u8, sub, "dumpsys")) {
+        if (cmd_args.len < 1) return errMissing("section");
+        return emit(gpa, try d.dumpsys(gpa, cmd_args[0]));
+    }
+
+    if (std.mem.eql(u8, sub, "touch")) return cmdTouch(gpa, &d, cmd_args);
+    if (std.mem.eql(u8, sub, "gesture") or std.mem.eql(u8, sub, "drag")) return cmdGesture(gpa, &d, opts, cmd_args);
+    if (std.mem.eql(u8, sub, "find")) return cmdFind(gpa, &d, opts);
+    if (std.mem.eql(u8, sub, "wait-for-ui")) return cmdWaitForUi(gpa, &d, opts);
+    if (std.mem.eql(u8, sub, "batch")) return cmdBatch(gpa, &d, cmd_args);
+
     try printUsage();
     return 1;
+}
+
+/// Print an owned buffer and free it — the shape most read-only commands take.
+fn emit(gpa: std.mem.Allocator, buf: []u8) u8 {
+    defer gpa.free(buf);
+    io.writeStdout(buf);
+    return 0;
+}
+
+/// Fetch and parse the uiautomator hierarchy. Caller frees with
+/// `uitree.freeElements`.
+fn snapshot(gpa: std.mem.Allocator, d: *driver_mod.Driver) ![]uitree.Element {
+    const xml = try d.uitreeXml(gpa);
+    defer gpa.free(xml);
+    return try uitree.parseAndroidXml(gpa, xml);
+}
+
+/// Exact match on text/id/desc first, then a substring fallback, so callers
+/// don't have to reproduce long labels verbatim. Mirrors the iOS behaviour.
+fn findByLabel(els: []const uitree.Element, label: []const u8) ?uitree.Element {
+    for (els) |e| {
+        if (std.mem.eql(u8, e.text, label) or
+            std.mem.eql(u8, e.id, label) or
+            std.mem.eql(u8, e.desc, label)) return e;
+    }
+    for (els) |e| {
+        if (std.mem.indexOf(u8, e.text, label) != null or
+            std.mem.indexOf(u8, e.desc, label) != null or
+            std.mem.indexOf(u8, e.id, label) != null) return e;
+    }
+    return null;
+}
+
+fn parsePoint(tok: []const u8) !struct { x: i32, y: i32 } {
+    const comma = std.mem.indexOfScalar(u8, tok, ',') orelse return error.BadPoint;
+    return .{
+        .x = try std.fmt.parseInt(i32, tok[0..comma], 10),
+        .y = try std.fmt.parseInt(i32, tok[comma + 1 ..], 10),
+    };
+}
+
+fn cmdTouch(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 3) return errMissing("<down|up|move> <x> <y>");
+    const phase = if (std.mem.eql(u8, args[0], "down"))
+        "DOWN"
+    else if (std.mem.eql(u8, args[0], "up"))
+        "UP"
+    else if (std.mem.eql(u8, args[0], "move"))
+        "MOVE"
+    else {
+        io.writeStderr("unknown touch phase (want down|move|up)\n");
+        return 2;
+    };
+    try d.motionEvent(gpa, phase, try std.fmt.parseInt(i32, args[1], 10), try std.fmt.parseInt(i32, args[2], 10));
+    return 0;
+}
+
+fn cmdGesture(gpa: std.mem.Allocator, d: *driver_mod.Driver, opts: Opts, args: []const []const u8) !u8 {
+    if (args.len < 2) return errMissing("<x1,y1> <x2,y2> [x3,y3 ...]");
+    var pts: std.ArrayList([2]i32) = .empty;
+    defer pts.deinit(gpa);
+    for (args) |tok| {
+        const p = parsePoint(tok) catch {
+            var arena_impl = std.heap.ArenaAllocator.init(gpa);
+            defer arena_impl.deinit();
+            io.printStderr(arena_impl.allocator(), "expected x,y — got: {s}\n", .{tok});
+            return 2;
+        };
+        try pts.append(gpa, .{ p.x, p.y });
+    }
+    // Spread the requested duration across the legs of the path.
+    const total = opts.dur_ms orelse 400;
+    const step: u32 = @intCast(@max(total / @max(pts.items.len - 1, 1), 16));
+    try d.gesture(gpa, pts.items, step);
+    return 0;
+}
+
+fn cmdFind(gpa: std.mem.Allocator, d: *driver_mod.Driver, opts: Opts) !u8 {
+    const label = opts.label orelse return errMissing("--label <text>");
+    const els = try snapshot(gpa, d);
+    defer uitree.freeElements(gpa, els);
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var hits: usize = 0;
+    for (els) |e| {
+        const m = std.mem.indexOf(u8, e.text, label) != null or
+            std.mem.indexOf(u8, e.desc, label) != null or
+            std.mem.indexOf(u8, e.id, label) != null;
+        if (!m) continue;
+        hits += 1;
+        if (uitree.centroid(e)) |c| {
+            io.printStdout(arena, "{s}\tid={s}\ttext={s}\ttap={d},{d}\n", .{ e.class, e.id, e.text, c[0], c[1] });
+        } else {
+            io.printStdout(arena, "{s}\tid={s}\ttext={s}\ttap=-\n", .{ e.class, e.id, e.text });
+        }
+    }
+    // Non-zero on no match so `find` works directly as a test assertion.
+    if (hits == 0) {
+        io.printStderr(arena, "no element matching label: {s}\n", .{label});
+        return 4;
+    }
+    return 0;
+}
+
+/// Poll the hierarchy until an element appears (or disappears with --absent).
+/// Deadline is wall-clock: each poll costs a uiautomator dump, so counting
+/// sleeps would overshoot the requested timeout substantially.
+fn cmdWaitForUi(gpa: std.mem.Allocator, d: *driver_mod.Driver, opts: Opts) !u8 {
+    const label = opts.label orelse return errMissing("--label <text>");
+    const timeout = opts.timeout_ms orelse 10_000;
+    const deadline = io.monotonicMs() + @as(i64, @intCast(timeout));
+
+    while (true) {
+        const present = blk: {
+            const els = snapshot(gpa, d) catch break :blk false;
+            defer uitree.freeElements(gpa, els);
+            break :blk findByLabel(els, label) != null;
+        };
+        if (present != opts.absent) return 0;
+        if (io.monotonicMs() >= deadline) break;
+        io.sleepMs(250);
+    }
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    io.printStderr(arena_impl.allocator(), "timed out after {d}ms waiting for '{s}' to {s}\n", .{
+        timeout,
+        label,
+        if (opts.absent) "disappear" else "appear",
+    });
+    return 4;
+}
+
+/// Several actions over one adb client. The win is session setup: serial
+/// resolution happens once for the whole sequence instead of per command.
+fn cmdBatch(gpa: std.mem.Allocator, d: *driver_mod.Driver, args: []const []const u8) !u8 {
+    if (args.len < 1) return errMissing("<action> [action ...]  e.g. tap:120,400 type:hi press:enter");
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    for (args, 0..) |spec, step| {
+        const colon = std.mem.indexOfScalar(u8, spec, ':') orelse {
+            io.printStderr(arena, "step {d}: expected verb:args — got '{s}'\n", .{ step + 1, spec });
+            return 2;
+        };
+        const verb = spec[0..colon];
+        const rest = spec[colon + 1 ..];
+
+        if (std.mem.eql(u8, verb, "wait")) {
+            io.sleepMs(try std.fmt.parseInt(u64, rest, 10));
+            continue;
+        }
+        if (std.mem.eql(u8, verb, "type")) {
+            try d.typeText(gpa, rest);
+            continue;
+        }
+        if (std.mem.eql(u8, verb, "press")) {
+            try d.pressButton(gpa, rest);
+            continue;
+        }
+        if (std.mem.eql(u8, verb, "key")) {
+            try d.keyevent(gpa, rest);
+            continue;
+        }
+        if (std.mem.eql(u8, verb, "label")) {
+            const els = try snapshot(gpa, d);
+            defer uitree.freeElements(gpa, els);
+            const hit = findByLabel(els, rest) orelse {
+                io.printStderr(arena, "step {d}: no element matching label '{s}'\n", .{ step + 1, rest });
+                return 4;
+            };
+            const c = uitree.centroid(hit) orelse return error.ElementHasNoBounds;
+            try d.tap(gpa, c[0], c[1]);
+            continue;
+        }
+
+        var nums: std.ArrayList(i32) = .empty;
+        defer nums.deinit(gpa);
+        var it = std.mem.splitScalar(u8, rest, ',');
+        while (it.next()) |n| {
+            if (n.len == 0) continue;
+            try nums.append(gpa, std.fmt.parseInt(i32, n, 10) catch {
+                io.printStderr(arena, "step {d}: '{s}' is not a number\n", .{ step + 1, n });
+                return 2;
+            });
+        }
+        const v = nums.items;
+
+        if (std.mem.eql(u8, verb, "tap") and v.len >= 2) {
+            try d.tap(gpa, v[0], v[1]);
+        } else if (std.mem.eql(u8, verb, "doubletap") and v.len >= 2) {
+            try d.doubleTap(gpa, v[0], v[1]);
+        } else if (std.mem.eql(u8, verb, "longpress") and v.len >= 2) {
+            try d.longPress(gpa, v[0], v[1], if (v.len >= 3) @intCast(v[2]) else 500);
+        } else if (std.mem.eql(u8, verb, "swipe") and v.len >= 4) {
+            try d.swipe(gpa, v[0], v[1], v[2], v[3], if (v.len >= 5) @intCast(v[4]) else 300);
+        } else {
+            io.printStderr(arena, "step {d}: unknown or malformed action '{s}'\n", .{ step + 1, spec });
+            return 2;
+        }
+    }
+    return 0;
 }
 
 fn errMissing(name: []const u8) u8 {
@@ -177,26 +484,32 @@ fn cmdListApps(gpa: std.mem.Allocator, d: *driver_mod.Driver) !u8 {
     return 0;
 }
 
+/// Rendered from the same table `android tools` serves, so a command can
+/// never exist in the dispatcher but go missing from the help.
 fn printUsage() !void {
     io.writeStderr(
         \\kuri-mobile android <cmd> [args]
         \\
-        \\Commands:
-        \\  list-devices
-        \\  tap <x> <y>
-        \\  double-tap <x> <y>
-        \\  long-press <x> <y> [ms]
-        \\  swipe <x1> <y1> <x2> <y2> [ms]      (alias: scroll, pan)
-        \\  type <text...>
-        \\  press <button>          # home|back|menu|enter|tab|space|del|volumeUp|volumeDown|power|dpad{Up,Down,Left,Right,Center}
-        \\  screenshot [path.png]
-        \\  uitree
-        \\  launch <package>
-        \\  terminate <package>
-        \\  list-apps
+        \\Global flags: --serial <id>  --label <text>  --timeout MS  --for MS
+        \\              --last N  --predicate <text>  --absent  --json
+        \\--serial auto-picks the single attached device when omitted.
+        \\Run `kuri-mobile android tools --json` for the machine-readable surface.
         \\
-        \\Global flags:
-        \\  --serial <id>           # target device (auto-picks single attached device)
+        \\
+    );
+
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const text = tools.renderText(gpa_impl.allocator()) catch return;
+    defer gpa_impl.allocator().free(text);
+    io.writeStderr(text);
+
+    io.writeStderr(
+        \\press names: home back menu enter tab space del recents wakeup sleep
+        \\             volumeUp volumeDown power dpad{Up,Down,Left,Right,Center}
+        \\
+        \\Not supported: install (needs the adb SYNC protocol, not implemented)
+        \\               record-video (needs file pull off the device)
         \\
     );
 }

--- a/kuri-mobile/src/android/driver.zig
+++ b/kuri-mobile/src/android/driver.zig
@@ -124,6 +124,123 @@ pub const Driver = struct {
     pub fn listApps(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
         return try self.shell(gpa, "pm list packages");
     }
+
+    /// `shell` formats into a fixed 1 KiB buffer, which is fine for commands we
+    /// build ourselves but not for ones carrying user text (log filters,
+    /// dumpsys sections). This variant sizes the request to the command.
+    fn shellAlloc(self: *Driver, gpa: std.mem.Allocator, cmd: []const u8) ![]u8 {
+        const svc = try std.fmt.allocPrint(gpa, "shell:{s}", .{cmd});
+        defer gpa.free(svc);
+        return try self.client.deviceExec(self.serial, svc);
+    }
+
+    /// Escape a value destined for a single-quoted `sh` word on the device, so
+    /// a package name or URL containing shell metacharacters cannot break out
+    /// of the command we are constructing.
+    fn quote(gpa: std.mem.Allocator, s: []const u8) ![]u8 {
+        var out: std.ArrayList(u8) = .empty;
+        errdefer out.deinit(gpa);
+        try out.append(gpa, '\'');
+        for (s) |c| {
+            if (c == '\'') try out.appendSlice(gpa, "'\\''") else try out.append(gpa, c);
+        }
+        try out.append(gpa, '\'');
+        return out.toOwnedSlice(gpa);
+    }
+
+    fn runQuoted(
+        self: *Driver,
+        gpa: std.mem.Allocator,
+        comptime fmt: []const u8,
+        arg: []const u8,
+    ) ![]u8 {
+        const q = try quote(gpa, arg);
+        defer gpa.free(q);
+        const cmd = try std.fmt.allocPrint(gpa, fmt, .{q});
+        defer gpa.free(cmd);
+        return try self.shellAlloc(gpa, cmd);
+    }
+
+    // --- app lifecycle ------------------------------------------------------
+
+    pub fn uninstallApp(self: *Driver, gpa: std.mem.Allocator, pkg: []const u8) !void {
+        gpa.free(try self.runQuoted(gpa, "pm uninstall {s}", pkg));
+    }
+
+    /// Wipe an app's data without reinstalling — the cheap way back to a
+    /// first-launch state.
+    pub fn clearApp(self: *Driver, gpa: std.mem.Allocator, pkg: []const u8) !void {
+        gpa.free(try self.runQuoted(gpa, "pm clear {s}", pkg));
+    }
+
+    /// Open a URL through the standard VIEW intent — the Android counterpart
+    /// of `ios openurl`.
+    pub fn openUrl(self: *Driver, gpa: std.mem.Allocator, url: []const u8) !void {
+        gpa.free(try self.runQuoted(gpa, "am start -a android.intent.action.VIEW -d {s}", url));
+    }
+
+    // --- observation --------------------------------------------------------
+
+    /// Package/activity currently holding focus. Useful as a navigation
+    /// assertion that needs no accessibility tree.
+    pub fn currentActivity(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
+        return try self.shell(gpa, "dumpsys window displays | grep -E 'mCurrentFocus|mFocusedApp'");
+    }
+
+    /// Bounded logcat read. `-d` dumps and exits rather than streaming, so
+    /// this terminates and can back an assertion.
+    pub fn logcat(self: *Driver, gpa: std.mem.Allocator, lines: []const u8, filter: ?[]const u8) ![]u8 {
+        const ql = try quote(gpa, lines);
+        defer gpa.free(ql);
+        const cmd = if (filter) |f| blk: {
+            const qf = try quote(gpa, f);
+            defer gpa.free(qf);
+            break :blk try std.fmt.allocPrint(gpa, "logcat -d -t {s} | grep -F -- {s}", .{ ql, qf });
+        } else try std.fmt.allocPrint(gpa, "logcat -d -t {s}", .{ql});
+        defer gpa.free(cmd);
+        return try self.shellAlloc(gpa, cmd);
+    }
+
+    pub fn getProp(self: *Driver, gpa: std.mem.Allocator, name: []const u8) ![]u8 {
+        return try self.runQuoted(gpa, "getprop {s}", name);
+    }
+
+    pub fn dumpsys(self: *Driver, gpa: std.mem.Allocator, section: []const u8) ![]u8 {
+        return try self.runQuoted(gpa, "dumpsys {s}", section);
+    }
+
+    /// Physical screen size and density — the numbers that turn a uitree
+    /// bound into a tap coordinate.
+    pub fn screenInfo(self: *Driver, gpa: std.mem.Allocator) ![]u8 {
+        return try self.shell(gpa, "wm size; wm density");
+    }
+
+    // --- raw input ----------------------------------------------------------
+
+    /// Raw keycode, for keys outside the friendly `press` table.
+    pub fn keyevent(self: *Driver, gpa: std.mem.Allocator, code: []const u8) !void {
+        gpa.free(try self.runQuoted(gpa, "input keyevent {s}", code));
+    }
+
+    /// A single touch phase via `input motionevent` (Android 11+). This is
+    /// what makes multi-point paths possible: `input swipe` only ever
+    /// interpolates between two points.
+    pub fn motionEvent(self: *Driver, gpa: std.mem.Allocator, phase: []const u8, x: i32, y: i32) !void {
+        var buf: [128]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "input motionevent {s} {d} {d}", .{ phase, x, y });
+        gpa.free(try self.shell(gpa, cmd));
+    }
+
+    /// Drag along an arbitrary path by emitting DOWN / MOVE… / UP.
+    pub fn gesture(self: *Driver, gpa: std.mem.Allocator, pts: []const [2]i32, step_ms: u32) !void {
+        if (pts.len < 2) return error.BadPoint;
+        try self.motionEvent(gpa, "DOWN", pts[0][0], pts[0][1]);
+        for (pts[1..]) |p| {
+            _ = usleep(step_ms * 1000);
+            try self.motionEvent(gpa, "MOVE", p[0], p[1]);
+        }
+        try self.motionEvent(gpa, "UP", pts[pts.len - 1][0], pts[pts.len - 1][1]);
+    }
 };
 
 fn mapButton(name: []const u8) ?[]const u8 {
@@ -144,6 +261,15 @@ fn mapButton(name: []const u8) ?[]const u8 {
         .{ "dpadLeft", "KEYCODE_DPAD_LEFT" },
         .{ "dpadRight", "KEYCODE_DPAD_RIGHT" },
         .{ "dpadCenter", "KEYCODE_DPAD_CENTER" },
+        .{ "recents", "KEYCODE_APP_SWITCH" },
+        .{ "appSwitch", "KEYCODE_APP_SWITCH" },
+        .{ "wakeup", "KEYCODE_WAKEUP" },
+        .{ "sleep", "KEYCODE_SLEEP" },
+        .{ "search", "KEYCODE_SEARCH" },
+        .{ "camera", "KEYCODE_CAMERA" },
+        .{ "escape", "KEYCODE_ESCAPE" },
+        .{ "backspace", "KEYCODE_DEL" },
+        .{ "notification", "KEYCODE_NOTIFICATION" },
     };
     for (table) |p| if (std.mem.eql(u8, p[0], name)) return p[1];
     return null;

--- a/kuri-mobile/src/android/tools.zig
+++ b/kuri-mobile/src/android/tools.zig
@@ -1,0 +1,250 @@
+//! Single source of truth for the `android` command surface.
+//!
+//! Mirrors ios/tools.zig; rendering is shared via common/toolinfo.zig so the
+//! two platforms describe themselves identically and an agent can consume
+//! `android tools --json` and `ios tools --json` with one parser.
+//!
+//! Almost everything here rides the adb wire protocol's `shell:` service, so
+//! unlike iOS there is no simulator/device split — an emulator and a handset
+//! answer the same commands. Scopes are `.both` accordingly.
+
+const std = @import("std");
+const toolinfo = @import("../common/toolinfo.zig");
+
+pub const Tool = toolinfo.Tool;
+pub const Scope = toolinfo.Scope;
+
+pub const all = [_]Tool{
+    // --- discovery / lifecycle ---------------------------------------------
+    .{
+        .name = "tools",
+        .args = "[--json]",
+        .summary = "list every android command, its arguments and where it can run",
+        .category = "meta",
+        .scope = .both,
+    },
+    .{
+        .name = "list-devices",
+        .aliases = &.{"devices"},
+        .summary = "list attached devices and emulators with their adb state",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "launch",
+        .args = "<package>",
+        .summary = "launch an app via its LAUNCHER intent",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "terminate",
+        .args = "<package>",
+        .summary = "force-stop an app",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "list-apps",
+        .summary = "list installed package names",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "uninstall",
+        .args = "<package>",
+        .summary = "remove an installed app",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "clear",
+        .args = "<package>",
+        .summary = "wipe an app's data — the cheap way back to a first-launch state",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+    .{
+        .name = "openurl",
+        .aliases = &.{"navigate"},
+        .args = "<url>",
+        .summary = "open a URL through the standard VIEW intent",
+        .category = "lifecycle",
+        .scope = .both,
+    },
+
+    // --- observation --------------------------------------------------------
+    .{
+        .name = "screenshot",
+        .args = "[path.png]",
+        .summary = "capture a PNG of the screen",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "uitree",
+        .summary = "dump the uiautomator hierarchy as a flat element list with bounds",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "find",
+        .flags = &.{"--label"},
+        .summary = "print elements matching a label/id, with tap-ready centroids",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "wait-for-ui",
+        .flags = &.{ "--label", "--timeout", "--absent" },
+        .summary = "block until an element appears (or disappears with --absent)",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "current-activity",
+        .summary = "package/activity holding focus — a navigation assertion needing no tree",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "logcat",
+        .flags = &.{ "--last", "--predicate" },
+        .summary = "bounded logcat read (-d, so it terminates and can back an assertion)",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "screen-info",
+        .summary = "physical size and density — turns uitree bounds into tap coordinates",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "getprop",
+        .args = "<name>",
+        .summary = "read a system property",
+        .category = "observe",
+        .scope = .both,
+    },
+    .{
+        .name = "dumpsys",
+        .args = "<section>",
+        .summary = "raw dumpsys for a service (battery, notification, power, …)",
+        .category = "observe",
+        .scope = .both,
+    },
+
+    // --- input --------------------------------------------------------------
+    .{
+        .name = "tap",
+        .args = "<x> <y>",
+        .flags = &.{"--label"},
+        .summary = "tap a point, or an element by label",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "double-tap",
+        .aliases = &.{"doubletap"},
+        .args = "<x> <y>",
+        .summary = "double tap",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "long-press",
+        .aliases = &.{"longpress"},
+        .args = "<x> <y> [hold_ms]",
+        .summary = "press and hold (default 500ms)",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "swipe",
+        .aliases = &.{ "scroll", "pan" },
+        .args = "<x1> <y1> <x2> <y2> [duration_ms]",
+        .summary = "drag between two points",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "gesture",
+        .aliases = &.{"drag"},
+        .args = "<x1,y1> <x2,y2> [x3,y3 ...]",
+        .flags = &.{"--for"},
+        .summary = "drag along a multi-point path via input motionevent (Android 11+)",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "touch",
+        .args = "<down|up|move> <x> <y>",
+        .summary = "raw motionevent phase, for gestures the built-ins don't cover",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "type",
+        .args = "<text...>",
+        .summary = "type text into the focused field",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "press",
+        .args = "<home|back|menu|enter|recents|…>",
+        .summary = "press a named hardware/navigation key",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "keyevent",
+        .args = "<KEYCODE_* or number>",
+        .summary = "send a raw keycode, for keys outside the named table",
+        .category = "input",
+        .scope = .both,
+    },
+    .{
+        .name = "batch",
+        .args = "<action> [action ...]",
+        .summary = "run several actions over one adb session, e.g. tap:120,400 type:hi press:enter",
+        .category = "input",
+        .scope = .both,
+    },
+};
+
+const categories = [_]toolinfo.Category{
+    .{ .key = "meta", .title = "Discovery" },
+    .{ .key = "lifecycle", .title = "Device & app lifecycle" },
+    .{ .key = "observe", .title = "Observation" },
+    .{ .key = "input", .title = "Input" },
+};
+
+pub fn lookup(name: []const u8) ?Tool {
+    return toolinfo.lookup(&all, name);
+}
+
+pub fn renderText(gpa: std.mem.Allocator) ![]u8 {
+    return toolinfo.renderText(gpa, &all, &categories);
+}
+
+pub fn renderJson(gpa: std.mem.Allocator) ![]u8 {
+    return toolinfo.renderJson(gpa, .android, &all);
+}
+
+test "lookup resolves canonical names and aliases" {
+    try std.testing.expect(lookup("tap") != null);
+    try std.testing.expectEqualStrings("swipe", lookup("scroll").?.name);
+    try std.testing.expectEqualStrings("gesture", lookup("drag").?.name);
+    try std.testing.expectEqualStrings("openurl", lookup("navigate").?.name);
+    try std.testing.expect(lookup("definitely-not-a-command") == null);
+}
+
+test "table satisfies the shared invariants" {
+    try toolinfo.verifyTable(&all, &categories);
+}
+
+test "json round-trips with every tool present" {
+    try toolinfo.verifyJson(.android, &all);
+}

--- a/kuri-mobile/src/common/toolinfo.zig
+++ b/kuri-mobile/src/common/toolinfo.zig
@@ -1,0 +1,201 @@
+//! Shared machinery for the per-platform tool registries.
+//!
+//! `ios/tools.zig` and `android/tools.zig` each own a table describing their
+//! command surface; everything about *rendering* that table — the grouped help
+//! text and the JSON an agent consumes — lives here so the two platforms
+//! cannot drift into describing themselves differently.
+
+const std = @import("std");
+
+/// Where a command can actually run. Agents use this to avoid attempting
+/// things that are structurally impossible rather than merely unconfigured.
+pub const Scope = enum {
+    /// Simulator / emulator only.
+    virtual,
+    /// Physical device only.
+    device,
+    /// Both.
+    both,
+
+    pub fn text(self: Scope, platform: Platform) []const u8 {
+        return switch (self) {
+            .virtual => switch (platform) {
+                .ios => "simulator",
+                .android => "emulator",
+            },
+            .device => "device",
+            .both => switch (platform) {
+                .ios => "simulator+device",
+                .android => "emulator+device",
+            },
+        };
+    }
+};
+
+pub const Platform = enum { ios, android };
+
+pub const Tool = struct {
+    name: []const u8,
+    /// Accepted alternative spellings, dispatched identically.
+    aliases: []const []const u8 = &.{},
+    /// Positional argument shape, for help rendering.
+    args: []const u8 = "",
+    /// Flags this command reads beyond the global ones.
+    flags: []const []const u8 = &.{},
+    summary: []const u8,
+    category: []const u8,
+    scope: Scope = .both,
+};
+
+pub const Category = struct { key: []const u8, title: []const u8 };
+
+/// Resolve a user-typed subcommand to its canonical tool, honouring aliases.
+pub fn lookup(table: []const Tool, name: []const u8) ?Tool {
+    for (table) |t| {
+        if (std.mem.eql(u8, t.name, name)) return t;
+        for (t.aliases) |a| {
+            if (std.mem.eql(u8, a, name)) return t;
+        }
+    }
+    return null;
+}
+
+/// Human-readable listing, grouped by category.
+pub fn renderText(
+    gpa: std.mem.Allocator,
+    table: []const Tool,
+    cats: []const Category,
+) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(gpa);
+    for (cats) |c| {
+        try out.appendSlice(gpa, c.title);
+        try out.appendSlice(gpa, ":\n");
+        for (table) |t| {
+            if (!std.mem.eql(u8, t.category, c.key)) continue;
+            var line: std.ArrayList(u8) = .empty;
+            defer line.deinit(gpa);
+            try line.appendSlice(gpa, "  ");
+            try line.appendSlice(gpa, t.name);
+            if (t.args.len != 0) {
+                try line.append(gpa, ' ');
+                try line.appendSlice(gpa, t.args);
+            }
+            // Pad so summaries line up without a comptime format width.
+            while (line.items.len < 48) try line.append(gpa, ' ');
+            try out.appendSlice(gpa, line.items);
+            try out.appendSlice(gpa, t.summary);
+            try out.append(gpa, '\n');
+            if (t.aliases.len != 0) {
+                try out.appendSlice(gpa, "      aliases: ");
+                for (t.aliases, 0..) |a, i| {
+                    if (i != 0) try out.appendSlice(gpa, ", ");
+                    try out.appendSlice(gpa, a);
+                }
+                try out.append(gpa, '\n');
+            }
+        }
+        try out.append(gpa, '\n');
+    }
+    return out.toOwnedSlice(gpa);
+}
+
+fn appendJsonString(gpa: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
+    try out.append(gpa, '"');
+    for (s) |ch| switch (ch) {
+        '"' => try out.appendSlice(gpa, "\\\""),
+        '\\' => try out.appendSlice(gpa, "\\\\"),
+        '\n' => try out.appendSlice(gpa, "\\n"),
+        '\r' => try out.appendSlice(gpa, "\\r"),
+        '\t' => try out.appendSlice(gpa, "\\t"),
+        else => {
+            if (ch < 0x20) {
+                var buf: [6]u8 = undefined;
+                const hex = try std.fmt.bufPrint(&buf, "\\u{x:0>4}", .{ch});
+                try out.appendSlice(gpa, hex);
+            } else try out.append(gpa, ch);
+        },
+    };
+    try out.append(gpa, '"');
+}
+
+fn appendJsonArray(gpa: std.mem.Allocator, out: *std.ArrayList(u8), items: []const []const u8) !void {
+    try out.append(gpa, '[');
+    for (items, 0..) |it, i| {
+        if (i != 0) try out.append(gpa, ',');
+        try appendJsonString(gpa, out, it);
+    }
+    try out.append(gpa, ']');
+}
+
+/// Machine-readable listing. This is the contract an agent reads to discover
+/// what it may call, so every field needed to build an invocation is present.
+pub fn renderJson(
+    gpa: std.mem.Allocator,
+    platform: Platform,
+    table: []const Tool,
+) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(gpa);
+    try out.appendSlice(gpa, "{\"platform\":");
+    try appendJsonString(gpa, &out, @tagName(platform));
+    try out.appendSlice(gpa, ",\"tools\":[");
+    for (table, 0..) |t, i| {
+        if (i != 0) try out.append(gpa, ',');
+        try out.appendSlice(gpa, "{\"name\":");
+        try appendJsonString(gpa, &out, t.name);
+        try out.appendSlice(gpa, ",\"aliases\":");
+        try appendJsonArray(gpa, &out, t.aliases);
+        try out.appendSlice(gpa, ",\"args\":");
+        try appendJsonString(gpa, &out, t.args);
+        try out.appendSlice(gpa, ",\"flags\":");
+        try appendJsonArray(gpa, &out, t.flags);
+        try out.appendSlice(gpa, ",\"category\":");
+        try appendJsonString(gpa, &out, t.category);
+        try out.appendSlice(gpa, ",\"scope\":");
+        try appendJsonString(gpa, &out, t.scope.text(platform));
+        try out.appendSlice(gpa, ",\"summary\":");
+        try appendJsonString(gpa, &out, t.summary);
+        try out.append(gpa, '}');
+    }
+    try out.appendSlice(gpa, "]}\n");
+    return out.toOwnedSlice(gpa);
+}
+
+/// Shared invariants every platform table must satisfy. Called from each
+/// platform's tests so a new entry is checked wherever it is added.
+pub fn verifyTable(table: []const Tool, cats: []const Category) !void {
+    for (table, 0..) |a, i| {
+        try std.testing.expect(a.name.len != 0);
+        try std.testing.expect(a.summary.len != 0);
+
+        var known = false;
+        for (cats) |c| {
+            if (std.mem.eql(u8, c.key, a.category)) known = true;
+        }
+        try std.testing.expect(known);
+
+        // Names and aliases must be globally unique, or dispatch is ambiguous.
+        for (table, 0..) |b, j| {
+            if (i == j) continue;
+            try std.testing.expect(!std.mem.eql(u8, a.name, b.name));
+            for (b.aliases) |al| try std.testing.expect(!std.mem.eql(u8, a.name, al));
+        }
+    }
+}
+
+/// Every tool in the table must survive a JSON round-trip.
+pub fn verifyJson(platform: Platform, table: []const Tool) !void {
+    const gpa = std.testing.allocator;
+    const json = try renderJson(gpa, platform, table);
+    defer gpa.free(json);
+    const parsed = try std.json.parseFromSlice(std.json.Value, gpa, json, .{});
+    defer parsed.deinit();
+    const tools = parsed.value.object.get("tools").?.array;
+    try std.testing.expectEqual(table.len, tools.items.len);
+    for (tools.items) |t| {
+        try std.testing.expect(t.object.get("name") != null);
+        try std.testing.expect(t.object.get("scope") != null);
+        try std.testing.expect(t.object.get("summary") != null);
+    }
+}

--- a/kuri-mobile/src/ios/tools.zig
+++ b/kuri-mobile/src/ios/tools.zig
@@ -5,41 +5,15 @@
 //! the point: a command that gains a flag but not a help line is the usual
 //! way a CLI's documentation goes quietly stale, and an agent reading
 //! `ios tools --json` to decide what it can call cannot afford that drift.
+//!
+//! Rendering lives in common/toolinfo.zig so iOS and Android describe
+//! themselves identically.
 
 const std = @import("std");
+const toolinfo = @import("../common/toolinfo.zig");
 
-/// Where a command can actually run. Agents use this to avoid attempting
-/// things that are structurally impossible rather than merely unconfigured.
-pub const Scope = enum {
-    /// iOS Simulator only — needs the host-side Simulator.app window or a
-    /// simctl verb that has no real-device equivalent.
-    sim,
-    /// Works against a physical device (usually via devicectl/usbmuxd).
-    device,
-    /// Both simulator and real device.
-    both,
-
-    pub fn text(self: Scope) []const u8 {
-        return switch (self) {
-            .sim => "simulator",
-            .device => "device",
-            .both => "simulator+device",
-        };
-    }
-};
-
-pub const Tool = struct {
-    name: []const u8,
-    /// Accepted alternative spellings, dispatched identically.
-    aliases: []const []const u8 = &.{},
-    /// Positional argument shape, for help rendering.
-    args: []const u8 = "",
-    /// Flags this command reads beyond the global ones.
-    flags: []const []const u8 = &.{},
-    summary: []const u8,
-    category: []const u8,
-    scope: Scope = .sim,
-};
+pub const Tool = toolinfo.Tool;
+pub const Scope = toolinfo.Scope;
 
 pub const all = [_]Tool{
     // --- discovery / lifecycle ---------------------------------------------
@@ -62,35 +36,41 @@ pub const all = [_]Tool{
         .flags = &.{"--udid"},
         .summary = "boot a simulator",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "shutdown",
         .flags = &.{"--udid"},
         .summary = "shut down a simulator",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "erase",
         .flags = &.{"--udid"},
         .summary = "erase a simulator back to factory state (shuts it down first)",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "open-sim",
         .summary = "launch Simulator.app and bring it to the front",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "install",
         .args = "<path.app>",
         .summary = "install a built .app bundle onto the simulator",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "uninstall",
         .args = "<bundle-id>",
         .summary = "remove an installed app",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "launch",
@@ -113,6 +93,7 @@ pub const all = [_]Tool{
         .flags = &.{"--udid"},
         .summary = "list installed apps and their bundle ids",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "openurl",
@@ -120,6 +101,7 @@ pub const all = [_]Tool{
         .args = "<url>",
         .summary = "open a URL in its default handler (https -> Safari)",
         .category = "lifecycle",
+        .scope = .virtual,
     },
     .{
         .name = "background",
@@ -127,6 +109,7 @@ pub const all = [_]Tool{
         .flags = &.{"--for"},
         .summary = "press Home, wait, then re-foreground the app",
         .category = "lifecycle",
+        .scope = .virtual,
     },
 
     // --- observation --------------------------------------------------------
@@ -136,23 +119,27 @@ pub const all = [_]Tool{
         .flags = &.{"--udid"},
         .summary = "capture a PNG of the simulator screen",
         .category = "observe",
+        .scope = .virtual,
     },
     .{
         .name = "uitree",
         .summary = "dump the app's accessibility tree (role, id, label, device-pixel bounds)",
         .category = "observe",
+        .scope = .virtual,
     },
     .{
         .name = "find",
         .flags = &.{"--label"},
         .summary = "print elements matching a label/identifier, with tap-ready centroids",
         .category = "observe",
+        .scope = .virtual,
     },
     .{
         .name = "wait-for-ui",
         .flags = &.{ "--label", "--timeout", "--absent" },
         .summary = "block until an element appears (or disappears with --absent)",
         .category = "observe",
+        .scope = .virtual,
     },
     .{
         .name = "record-video",
@@ -160,12 +147,14 @@ pub const all = [_]Tool{
         .flags = &.{"--for"},
         .summary = "record the screen for a bounded duration",
         .category = "observe",
+        .scope = .virtual,
     },
     .{
         .name = "log",
         .flags = &.{ "--last", "--predicate" },
         .summary = "bounded os_log query (terminates, so it can back an assertion)",
         .category = "observe",
+        .scope = .virtual,
     },
 
     // --- input --------------------------------------------------------------
@@ -175,6 +164,7 @@ pub const all = [_]Tool{
         .flags = &.{"--label"},
         .summary = "tap a point, or an element by accessibility label",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "doubletap",
@@ -183,6 +173,7 @@ pub const all = [_]Tool{
         .flags = &.{"--label"},
         .summary = "double tap",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "longpress",
@@ -191,6 +182,7 @@ pub const all = [_]Tool{
         .flags = &.{"--label"},
         .summary = "press and hold (default 500ms)",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "swipe",
@@ -198,6 +190,7 @@ pub const all = [_]Tool{
         .args = "<x1> <y1> <x2> <y2> [duration_ms]",
         .summary = "drag between two points",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "gesture",
@@ -206,18 +199,21 @@ pub const all = [_]Tool{
         .flags = &.{"--for"},
         .summary = "drag along a multi-point path (arcs, L-shapes, signatures)",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "touch",
         .args = "<down|up|move> <x> <y>",
         .summary = "raw touch primitive; compose gestures the built-ins don't cover",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "type",
         .args = "<text...>",
         .summary = "type Unicode text into the focused field",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "key",
@@ -225,24 +221,28 @@ pub const all = [_]Tool{
         .flags = &.{ "--cmd", "--shift", "--ctrl", "--opt" },
         .summary = "press a named key with optional modifiers (e.g. `key return --cmd`)",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "key-sequence",
         .args = "<name> [name ...]",
         .summary = "press several named keys in order",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "button",
         .args = "<home|lock|volup|voldown|action|rotate>",
         .summary = "press a hardware button via the Simulator's own a11y tree",
         .category = "input",
+        .scope = .virtual,
     },
     .{
         .name = "batch",
         .args = "<action> [action ...]",
         .summary = "run several actions in one process, e.g. tap:120,400 type:hi key:return",
         .category = "input",
+        .scope = .virtual,
     },
 
     // --- device state -------------------------------------------------------
@@ -251,12 +251,14 @@ pub const all = [_]Tool{
         .args = "<grant|revoke|reset> <service> [bundle-id]",
         .summary = "set a TCC permission (camera is not exposed by simctl)",
         .category = "state",
+        .scope = .virtual,
     },
     .{
         .name = "ui",
         .args = "<appearance|content-size|increase-contrast> [value]",
         .summary = "appearance and Dynamic Type settings; prints current value if omitted",
         .category = "state",
+        .scope = .virtual,
     },
     .{
         .name = "status-bar",
@@ -264,38 +266,31 @@ pub const all = [_]Tool{
         .args = "override --time 9:41 ... | clear",
         .summary = "pin the status bar so screenshots are comparable across runs",
         .category = "state",
+        .scope = .virtual,
     },
     .{
         .name = "set-location",
         .args = "<lat> <lon>",
         .summary = "set the simulated GPS location",
         .category = "state",
+        .scope = .virtual,
     },
     .{
         .name = "reset-location",
         .summary = "clear the simulated GPS location",
         .category = "state",
+        .scope = .virtual,
     },
     .{
         .name = "keyboard",
         .args = "<on|off>",
         .summary = "connect/disconnect the hardware keyboard (affects whether the software keyboard shows)",
         .category = "state",
+        .scope = .virtual,
     },
 };
 
-/// Resolve a user-typed subcommand to its canonical tool, honouring aliases.
-pub fn lookup(name: []const u8) ?Tool {
-    for (all) |t| {
-        if (std.mem.eql(u8, t.name, name)) return t;
-        for (t.aliases) |a| {
-            if (std.mem.eql(u8, a, name)) return t;
-        }
-    }
-    return null;
-}
-
-const categories = [_]struct { key: []const u8, title: []const u8 }{
+const categories = [_]toolinfo.Category{
     .{ .key = "meta", .title = "Discovery" },
     .{ .key = "lifecycle", .title = "Device & app lifecycle" },
     .{ .key = "observe", .title = "Observation" },
@@ -303,147 +298,38 @@ const categories = [_]struct { key: []const u8, title: []const u8 }{
     .{ .key = "state", .title = "Device state" },
 };
 
-/// Human-readable listing, grouped by category.
+
+pub fn lookup(name: []const u8) ?Tool {
+    return toolinfo.lookup(&all, name);
+}
+
 pub fn renderText(gpa: std.mem.Allocator) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(gpa);
-    for (categories) |c| {
-        try out.appendSlice(gpa, c.title);
-        try out.appendSlice(gpa, ":\n");
-        for (all) |t| {
-            if (!std.mem.eql(u8, t.category, c.key)) continue;
-            var line: std.ArrayList(u8) = .empty;
-            defer line.deinit(gpa);
-            try line.appendSlice(gpa, "  ");
-            try line.appendSlice(gpa, t.name);
-            if (t.args.len != 0) {
-                try line.append(gpa, ' ');
-                try line.appendSlice(gpa, t.args);
-            }
-            // Pad so the summaries line up without a format-width literal.
-            while (line.items.len < 48) try line.append(gpa, ' ');
-            try out.appendSlice(gpa, line.items);
-            try out.appendSlice(gpa, t.summary);
-            try out.append(gpa, '\n');
-            if (t.aliases.len != 0) {
-                try out.appendSlice(gpa, "      aliases: ");
-                for (t.aliases, 0..) |a, i| {
-                    if (i != 0) try out.appendSlice(gpa, ", ");
-                    try out.appendSlice(gpa, a);
-                }
-                try out.append(gpa, '\n');
-            }
-        }
-        try out.append(gpa, '\n');
-    }
-    return out.toOwnedSlice(gpa);
+    return toolinfo.renderText(gpa, &all, &categories);
 }
 
-fn appendJsonString(gpa: std.mem.Allocator, out: *std.ArrayList(u8), s: []const u8) !void {
-    try out.append(gpa, '"');
-    for (s) |ch| switch (ch) {
-        '"' => try out.appendSlice(gpa, "\\\""),
-        '\\' => try out.appendSlice(gpa, "\\\\"),
-        '\n' => try out.appendSlice(gpa, "\\n"),
-        '\r' => try out.appendSlice(gpa, "\\r"),
-        '\t' => try out.appendSlice(gpa, "\\t"),
-        else => {
-            if (ch < 0x20) {
-                var buf: [6]u8 = undefined;
-                const hex = try std.fmt.bufPrint(&buf, "\\u{x:0>4}", .{ch});
-                try out.appendSlice(gpa, hex);
-            } else try out.append(gpa, ch);
-        },
-    };
-    try out.append(gpa, '"');
-}
-
-fn appendJsonArray(gpa: std.mem.Allocator, out: *std.ArrayList(u8), items: []const []const u8) !void {
-    try out.append(gpa, '[');
-    for (items, 0..) |it, i| {
-        if (i != 0) try out.append(gpa, ',');
-        try appendJsonString(gpa, out, it);
-    }
-    try out.append(gpa, ']');
-}
-
-/// Machine-readable listing. This is the contract an agent reads to discover
-/// what it may call, so every field a caller needs to build an invocation
-/// (name, aliases, positional shape, flags, scope) is present.
 pub fn renderJson(gpa: std.mem.Allocator) ![]u8 {
-    var out: std.ArrayList(u8) = .empty;
-    errdefer out.deinit(gpa);
-    try out.appendSlice(gpa, "{\"platform\":\"ios\",\"tools\":[");
-    for (all, 0..) |t, i| {
-        if (i != 0) try out.append(gpa, ',');
-        try out.appendSlice(gpa, "{\"name\":");
-        try appendJsonString(gpa, &out, t.name);
-        try out.appendSlice(gpa, ",\"aliases\":");
-        try appendJsonArray(gpa, &out, t.aliases);
-        try out.appendSlice(gpa, ",\"args\":");
-        try appendJsonString(gpa, &out, t.args);
-        try out.appendSlice(gpa, ",\"flags\":");
-        try appendJsonArray(gpa, &out, t.flags);
-        try out.appendSlice(gpa, ",\"category\":");
-        try appendJsonString(gpa, &out, t.category);
-        try out.appendSlice(gpa, ",\"scope\":");
-        try appendJsonString(gpa, &out, t.scope.text());
-        try out.appendSlice(gpa, ",\"summary\":");
-        try appendJsonString(gpa, &out, t.summary);
-        try out.append(gpa, '}');
-    }
-    try out.appendSlice(gpa, "]}\n");
-    return out.toOwnedSlice(gpa);
+    return toolinfo.renderJson(gpa, .ios, &all);
 }
 
 test "lookup resolves canonical names and aliases" {
     try std.testing.expect(lookup("tap") != null);
     try std.testing.expectEqualStrings("swipe", lookup("scroll").?.name);
-    try std.testing.expectEqualStrings("swipe", lookup("pan").?.name);
     try std.testing.expectEqualStrings("doubletap", lookup("dbltap").?.name);
     try std.testing.expectEqualStrings("gesture", lookup("drag").?.name);
     try std.testing.expect(lookup("definitely-not-a-command") == null);
 }
 
-test "every tool has a summary and a known category" {
-    for (all) |t| {
-        try std.testing.expect(t.name.len != 0);
-        try std.testing.expect(t.summary.len != 0);
-        var known = false;
-        for (categories) |c| {
-            if (std.mem.eql(u8, c.key, t.category)) known = true;
-        }
-        try std.testing.expect(known);
-    }
+test "table satisfies the shared invariants" {
+    try toolinfo.verifyTable(&all, &categories);
 }
 
-test "tool names and aliases are unique across the table" {
-    for (all, 0..) |a, i| {
-        for (all, 0..) |b, j| {
-            if (i == j) continue;
-            try std.testing.expect(!std.mem.eql(u8, a.name, b.name));
-            for (b.aliases) |al| try std.testing.expect(!std.mem.eql(u8, a.name, al));
-        }
-    }
-}
-
-test "renderJson emits parseable JSON covering every tool" {
-    const gpa = std.testing.allocator;
-    const json = try renderJson(gpa);
-    defer gpa.free(json);
-    const parsed = try std.json.parseFromSlice(std.json.Value, gpa, json, .{});
-    defer parsed.deinit();
-    const tools = parsed.value.object.get("tools").?.array;
-    try std.testing.expectEqual(all.len, tools.items.len);
-    try std.testing.expect(tools.items[0].object.get("name") != null);
-    try std.testing.expect(tools.items[0].object.get("scope") != null);
+test "json round-trips with every tool present" {
+    try toolinfo.verifyJson(.ios, &all);
 }
 
 test "renderText mentions every tool name" {
     const gpa = std.testing.allocator;
     const text = try renderText(gpa);
     defer gpa.free(text);
-    for (all) |t| {
-        try std.testing.expect(std.mem.indexOf(u8, text, t.name) != null);
-    }
+    for (all) |t| try std.testing.expect(std.mem.indexOf(u8, text, t.name) != null);
 }

--- a/kuri-mobile/src/main.zig
+++ b/kuri-mobile/src/main.zig
@@ -53,7 +53,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         return;
     }
     if (std.mem.eql(u8, sub, "--version")) {
-        try writeStdout("kuri-mobile 0.4.7\n");
+        try writeStdout("kuri-mobile 0.4.8\n");
         return;
     }
 
@@ -131,4 +131,6 @@ test {
     _ = @import("ios/sim_input.zig");
     _ = @import("ios/sim_window.zig");
     _ = @import("ios/tools.zig");
+    _ = @import("android/tools.zig");
+    _ = @import("common/toolinfo.zig");
 }

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -4,7 +4,7 @@ const markdown = @import("crawler/markdown.zig");
 const validator = @import("crawler/validator.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.7";
+const version = "0.4.8";
 const user_agent = "kuri-browse/" ++ version;
 
 pub fn main(init: std.process.Init.Minimal) !void {

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -5,7 +5,7 @@ const markdown = @import("crawler/markdown.zig");
 const js_engine = @import("js_engine.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.7";
+const version = "0.4.8";
 
 pub fn main(init: std.process.Init.Minimal) !void {
     var gpa_impl: std.heap.DebugAllocator(.{}) = .init;

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,7 @@ const launcher = @import("chrome/launcher.zig");
 const api_token = @import("server/api_token.zig");
 const lifecycle = @import("lifecycle.zig");
 
-const version = "0.4.7";
+const version = "0.4.8";
 
 const CliAction = enum {
     run,


### PR DESCRIPTION
## What

Android gets the meta tool iOS gained in 0.4.7, plus the primitives that made the iOS surface actually usable by an agent. **Android goes 14 → 27 commands; combined surface is 63 (36 iOS, 27 Android).**

Both platforms now render their registry from a single `common/toolinfo.zig`, so they describe themselves identically and one parser consumes either `ios tools --json` or `android tools --json`.

## New Android commands

| Category | Commands |
|---|---|
| Discovery | `tools` (+`--json`) |
| Observation | `find`, `wait-for-ui`, `current-activity`, `logcat`, `screen-info`, `getprop`, `dumpsys` |
| Input | `gesture`/`drag`, `touch`, `keyevent`, `batch` |
| Lifecycle | `uninstall`, `clear`, `openurl`/`navigate` |

Plus eight more named keys (`recents`, `wakeup`, `sleep`, `search`, `camera`, `escape`, `backspace`, `notification`).

`gesture` uses `input motionevent` (Android 11+) — `input swipe` only ever interpolates between two points, so shaped drags were previously impossible. `wait-for-ui` uses a wall-clock deadline, carrying over the fix from 0.4.7 rather than repeating the bug.

## Security fix

Android shell commands that carry user text — package names, URLs, log filters, dumpsys sections — are now single-quote escaped. Previously a value containing shell metacharacters could break out of the command being constructed and execute arbitrary shell on the device.

## Testing

Invariants live in `toolinfo.verifyTable` / `verifyJson` and run against **both** platform tables, so a new entry is automatically checked for a summary, a known category, globally unique name/aliases, and a JSON round-trip — wherever it was added.

All four release targets build; `zig build test`, `test-fetch`, `test-browse` and kuri-mobile's suite exit 0.

Verified live: `android tools` and `android tools --json` (27 tools, valid JSON, dispatched before serial resolution so they work with no device attached), `ios tools --json` (36 tools; scopes now explicit — 32 simulator, 4 simulator+device).

**Not verified live:** everything requiring an attached Android device — no device or emulator is connected here, and `adb` isn't running. Those paths are covered by compile and unit tests only. iOS input commands remain untested live because they hijack the cursor.

## Not implemented

`android install` and `android record-video` need the adb SYNC protocol (file push/pull), which this client doesn't implement. Both are stated in the help text rather than left to fail confusingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gzdKWXk7UbHm5TtSGqYBJ