### PR TITLE
ci: publish install.sh from the repo instead of the channel copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,14 @@ jobs:
           mkdir -p "$CHANNEL_DIR"
           cp dist/*.tar.gz "$CHANNEL_DIR/"
 
+          # Publish the installer from the repository rather than leaving the
+          # channel copy to be remembered by hand. These drifted for four
+          # releases: install.sh in the repo gained kuri-mobile, the copy
+          # people actually `curl` did not, so every install produced a kuri
+          # whose `android`/`ios` subcommands could not exec their sibling
+          # binary. The file users run must be generated from the tagged tree.
+          cp install.sh channel/stable/install.sh
+
           python3 - <<'PY'
           from pathlib import Path
           import datetime


### PR DESCRIPTION
`stable/install.sh` on `release-channel` is hand-maintained and `release.yml` never writes it, so the two drifted.

The repo's installer gained `kuri-mobile` in v0.4.12; the copy users actually `curl` did not — so the fix could not reach anyone. Every install still produced a `kuri` whose `android`/`ios` subcommands die with `failed to exec 'kuri-mobile'`, because `build.zig` requires that binary to sit in the same prefix.

The channel copy has been corrected by hand for v0.4.12 already; this stops it recurring. Takes effect on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gzdKWXk7UbHm5TtSGqYBJ