### PR TITLE
release: v0.4.13 — routes that fabricated their answers

### DIFF
--- a/.claude/skills/kuri-ios/SKILL.md
+++ b/.claude/skills/kuri-ios/SKILL.md
@@ -10,6 +10,16 @@ Drive iOS Simulators (and, where possible, real iPhones) through the
 `kuri-mobile/src/ios/` and the main `kuri` binary forwards
 `kuri ios …` to the `kuri-mobile` binary.
 
+> ⚠️ **Host cursor & keyboard warning.** On the Simulator, `tap`, `doubletap`,
+> `longpress`, `swipe`/`pan`, and `type` post **real CGEvents into the macOS
+> WindowServer** — they physically move your mouse pointer and seize keyboard
+> focus for the duration of the gesture. Do **not** run them while you are using
+> the machine, or from an unattended/background job; a stray click lands wherever
+> the pointer happens to be. Cursor-free, always-safe commands: `list-devices`,
+> `boot`, `shutdown`, `openurl`, `launch`, `terminate`, `list-apps`,
+> `screenshot`. An isolated input backend that bypasses the host pointer is
+> tracked in issues #180 and #183.
+
 ## When to use this skill
 
 - Boot an iOS Simulator, open Safari to a URL, screenshot the result.

--- a/.claude/skills/kuri-mobile/SKILL.md
+++ b/.claude/skills/kuri-mobile/SKILL.md
@@ -11,6 +11,12 @@ Inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp)
 reimplemented in Zig with no Bun, Node, Gradle, or Xcode in the
 build path.
 
+> ⚠️ **iOS Simulator input seizes the host cursor.** `kuri ios tap/swipe/type`
+> (plus doubletap/longpress) post real CGEvents into the macOS WindowServer, so
+> they move your physical mouse and grab keyboard focus. Don't run them while
+> you're working or from a background job. `kuri android` input runs on-device
+> via adb and does **not** touch the host cursor. Tracked: #180, #183.
+
 **Use the platform-specific skills** for actual work:
 
 - **`kuri-ios`** — iOS Simulator (boot, openurl, launch, terminate,

--- a/.claude/skills/kuri-server/SKILL.md
+++ b/.claude/skills/kuri-server/SKILL.md
@@ -94,6 +94,8 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 
 ## Key endpoints
 
+**Design limit — paused CDP events need a live command to make progress.** Chrome delivers most async CDP events (screencast frames, exposed-binding calls, network records, tracing completion, download signals, dialog opens) only while some command is in flight on the same CDP socket; nothing else reads it. Endpoints that consume a ring/collector (`/screencast/stop`, `/expose/calls`, `/network?mode=list`, `/response/body?url=...`, `/trace/stop`, `/wait/download`, `/dialog/auto`) explicitly drain the socket (`drainWsEvents`/`waitForEvent`) before reading, so a normal call sequence self-heals on the very next request. A caller that goes fully idle between calls won't see new events arrive on their own — this is a documented limitation, not a bug, and does not need (or want) a background thread to paper over it.
+
 ### Navigation & page control
 | Endpoint | Description |
 |---|---|
@@ -106,6 +108,8 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 | `GET /reload?tab_id=X` | Reload page |
 | `GET /wait?tab_id=X&selector=CSS` | Wait for element to appear |
 | `GET /stop?tab_id=X` | Stop page loading |
+| `GET /mainframe?tab_id=X` | Get the main frame's `frameId`/`loaderId`/`url` via `Page.getFrameTree` |
+| `GET /frame?tab_id=X&name=N` (or `&url=U`) | Find a frame anywhere in the recursively-walked frame tree — not just the top document's direct `<iframe>` children — by name or url substring, then evaluate `{title,url}` inside that frame's own isolated-world execution context (`Page.createIsolatedWorld`). Works across nested and cross-origin frames still attached to this CDP session; `502` if `Page.createIsolatedWorld` fails (e.g. a true out-of-process subframe not attached to this session) |
 
 ### Reading the page
 | Endpoint | Description |
@@ -116,9 +120,11 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 | `GET /text?tab_id=X` | Page text content |
 | `GET /evaluate?tab_id=X&expression=JS` | Run JavaScript |
 | `GET /screenshot?tab_id=X` | Base64 screenshot |
+| `GET /screenshot/annotated?tab_id=X&ref=eN` | Screenshot with the referenced element highlighted |
 | `GET /markdown?tab_id=X` | Page as markdown |
 | `GET /links?tab_id=X` | All hyperlinks |
 | `GET /get?tab_id=X&type=title` | Get title/url/html/text/value |
+| `GET /vitals?tab_id=X` | Core Web Vitals (LCP/CLS/FID/TTFB/FCP/domInteractive) via buffered `performance.getEntriesByType`. CLS uses the real windowed max-session-gap algorithm (gap <1s between shifts, session ≤5s) instead of a naive lifetime running sum. `lcp_measured`/`cls_measured`/`fid_measured` flags distinguish a genuine `0` from "hasn't happened yet" |
 
 ### Interacting
 | Endpoint | Description |
@@ -128,10 +134,30 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 | `GET /action?tab_id=X&ref=eN&action=select&value=V` | Select option |
 | `GET /action?tab_id=X&ref=eN&action=hover` | Hover element |
 | `GET /action?tab_id=X&ref=eN&action=focus` | Focus element |
-| `GET /keyboard/type?tab_id=X&text=hello` | Type text |
+| `GET /keyboard/type?tab_id=X&text=hello` | Type text, one Unicode codepoint at a time (safe for accents/emoji/CJK) |
 | `GET /keydown?tab_id=X&key=Enter` | Press key |
 | `GET /scrollintoview?tab_id=X&ref=eN` | Scroll to element |
-| `GET /drag?tab_id=X&src=eN&tgt=eM` | Drag and drop |
+| `GET /drag?tab_id=X&src=eN&tgt=eM` | Drag and drop — fires the full `dragstart`/`drag` then `dragenter`/`dragover`/`drop` then `dragend` sequence across both elements |
+| `GET /dispatch?tab_id=X&ref=eN&type=click` | Dispatch a real DOM event by type — `click`/`submit` trigger the browser's native action (link navigation, form submission); mouse types (`mousedown`, `mouseover`, ...) dispatch a `MouseEvent`; pointer types (`pointerdown`, `pointerup`, `pointermove`, `pointerover`, `pointerout`, `pointerenter`, `pointerleave`, `pointercancel`) dispatch a `PointerEvent` with `clientX`/`clientY` computed from the element's `getBoundingClientRect()` center and `pointerId:1, pointerType:'mouse', isPrimary:true`; keyboard types (`keydown`, `keyup`, `keypress`) dispatch a `KeyboardEvent`; everything else dispatches a plain `Event` |
+
+### Downloads
+| Endpoint | Description |
+|---|---|
+| `GET /download?tab_id=X&url=U&dir=/path` | Sets `Page.setDownloadBehavior` (download directory defaults to `/tmp/kuri-downloads`, overridable via `?dir=`) then triggers the download via a synthetic anchor click. A `Page.setDownloadBehavior` failure now surfaces as a real `502` instead of being silently swallowed |
+| `GET /wait/download?tab_id=X&timeout=30000&dir=/path` | Waits for a real `Page.downloadWillBegin` event (fires exactly once per download) instead of returning a canned success. Confirms a download *started*; per-download guid/path/completion state isn't exposed yet — surfacing it would need `client.zig` to expose matched-event payloads to callers, out of scope for this router-level fix. `{"ok":true,"detected":true,...}` on success, `{"ok":false,"detected":false,...}` on timeout |
+
+### Inspector
+| Endpoint | Description |
+|---|---|
+| `GET /inspect?tab_id=X` | Sends real `Inspector.enable` (a `502` now surfaces if the CDP call itself errors, previously swallowed). CDP's `Inspector` domain has no synchronous introspection counterpart — the response is an honest note saying so, not a fabricated "DevTools enabled"; there is no further state to retrieve from this endpoint |
+
+### Debugging (console & errors)
+| Endpoint | Description |
+|---|---|
+| `GET /console?tab_id=X` | Console messages (log/info/warn/error/debug) captured since the last call; read-and-clear. Honors `X-Kuri-Session`, so `tab_id` is optional when a session tab is set. |
+| `GET /errors?tab_id=X` | Uncaught errors + unhandled promise rejections; read-and-clear. Same session behavior. |
+
+Both return the raw CDP wrapper — unwrap with `jq -r '.result.result.value' | jq '.'`. A collector script is injected on every navigation, so console output and errors are captured from page load. Caveat: messages emitted on a brand-new tab's *first* document, before the collector installs, are not captured — navigate or reload once and every subsequent load captures fully.
 
 ### Network & cookies
 | Endpoint | Description |
@@ -140,10 +166,46 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 | `GET /cookies/set?tab_id=X` | Set cookies (POST body) |
 | `GET /cookies/delete?tab_id=X&name=N` | Delete cookie |
 | `GET /headers?tab_id=X` | Set extra HTTP headers (POST body) |
+| `GET /set/credentials?tab_id=X&username=U&password=P` | Set a preemptive HTTP Basic `Authorization` header for the tab (works for servers that accept preemptive Basic auth; does not answer real `Fetch.authRequired` challenges — nothing in this codebase does yet) |
+| `GET /network?tab_id=X&mode=enable\|disable` | Enable/disable the CDP `Network` domain for the tab (default `mode=enable`). `mode=disable` also clears the local network-request ring |
+| `GET /network?tab_id=X&mode=list&url=SUBSTRING` | Lightweight bounded (200-record) traffic view — `request_id`/`url`/`method`/`mime_type`/`timestamp` only, no headers/timing/bodies. Never touches enable/disable state. For full capture use `/har/start` + `/har/stop` |
+| `GET /response/body?tab_id=X&request_id=ID` (or `&url=SUBSTRING`) | Real `Network.getResponseBody` for a request already observed via `/network?mode=enable`. Resolves `request_id` directly, or by substring match against recorded traffic (needs `mode=enable` active and the request already observed). Replaces the old `fetch(url)`-from-the-page workaround; surfaces CDP-level errors (e.g. "No resource with given identifier") as `502` instead of masking them. `400` if neither param given, `404` if no match |
 | `GET /har/start?tab_id=X` | Start recording network traffic |
 | `GET /har/stop?tab_id=X` | Stop + get HAR JSON |
 | `GET /har/replay?tab_id=X&filter=api&format=all` | Get API map with code snippets |
 | `GET /har/status?tab_id=X` | Check recording status |
+
+### Network interception (Fetch domain)
+| Endpoint | Description |
+|---|---|
+| `GET/POST /intercept/start?tab_id=X&patterns=*.png,*.jpg` | `Fetch.enable` with the given comma-separated CDP glob patterns (Chrome's own `urlPattern` syntax). Default — and what an all-blank list falls back to — is `*` (match everything). Response echoes what was actually enabled: `{"status":"ok","message":"Fetch.enable sent","tab_id":"...","patterns":["*.png","*.jpg"]}` |
+| `GET/POST /intercept/stop?tab_id=X` | `Fetch.disable`, then clears both the local rule table and the paused-request ring |
+| `GET /intercept/rules?tab_id=X` | List the local rule table: `{"rules":[{"url_pattern":"...","action":"continue\|abort\|fulfill","status":N,"content_type":"...","body":"...","error_reason":"..."}],"count":N}` |
+| `POST /intercept/rules?tab_id=X` | Add a rule. JSON body: `{"url_pattern":"substring or *","action":"continue\|abort\|fulfill","status":200,"body":"...","content_type":"...","error_reason":"..."}` (`pattern` also accepted as an alias for `url_pattern`) |
+| `POST /intercept/rules/clear?tab_id=X` | Drop all rules only — leaves interception and the paused-request ring untouched (unlike `/intercept/stop`, which clears both) |
+| `GET /intercept/requests?tab_id=X` | Paused requests if interception is active, otherwise a Resource Timing fallback — see below |
+
+All six honor `X-Kuri-Session` in place of `tab_id`.
+
+**Two different matching engines — don't confuse them.** `/intercept/start`'s `patterns` param maps onto real CDP `Fetch.enable` glob patterns (Chrome's own `urlPattern` syntax, e.g. `api.*.com` matches as a glob). `/intercept/rules`'s `url_pattern` does **not** — rules match by plain substring containment against the request URL, in the order added; `"*"` is special-cased only as a whole-pattern catch-all, not as a mid-string wildcard (`"api.*.com"` is matched literally, asterisk included). `Fetch.authRequired` (real 401/407 auth challenges) is not answered anywhere in this codebase yet — only request pausing is handled.
+
+`GET /intercept/requests?tab_id=X` branches on whether interception is currently active for the tab (tracked precisely by `/intercept/start`/`/intercept/stop`, not inferred from request count). Active: `{"source":"intercepted","requests":[{"request_id","url","method","resource_type","action":"continue|abort|fulfill","status","timestamp"}],"count":N}` — the real ring of paused requests; an empty array is a valid answer if nothing has paused yet. Inactive: falls back to the pre-existing Resource Timing API `Runtime.evaluate` call, byte-for-byte unchanged, with `"source":"resource_timing"` spliced into the raw CDP envelope so old code parsing `.result.result.value` keeps working while new code can check `.source`.
+
+### JS bindings (`window.<name>()` → host)
+| Endpoint | Description |
+|---|---|
+| `GET /expose?tab_id=X&name=N` | `Runtime.enable` + `Runtime.addBinding`. (`Runtime.enable` was previously missing here, so `Runtime.bindingCalled` could never be delivered and the endpoint silently could never work — fixed.) Response includes `"retrieve_calls_at":"/expose/calls?tab_id=X&name=N"` |
+| `GET /expose/calls?tab_id=X&name=N&clear=true` | Drains the socket and returns page→host calls captured on the binding since it was added, optionally filtered by `name`, optionally draining the ring with `clear=true` so repeated polling doesn't see the same calls twice |
+
+### Dialogs
+| Endpoint | Description |
+|---|---|
+| `GET /dialog/auto?tab_id=X&mode=accept` | Auto-accept `alert`/`confirm`/`prompt` dialogs going forward |
+| `GET /dialog/auto?tab_id=X&mode=dismiss` | Auto-dismiss dialogs going forward |
+| `GET /dialog/auto?tab_id=X&mode=accept&text=hello` | `text` supplies the value returned to `window.prompt()` |
+| `GET /dialog/auto?tab_id=X&mode=off` | Turn the auto-responder back off (`mode=disable` also works) without touching any dialog that's currently open |
+
+Response: `{"ok":true,"mode":"accept|dismiss|off"}`. Honors `X-Kuri-Session`. `mode=accept`/`mode=dismiss` now also arms the CDP-level auto-responder in the client itself, so `Page.javascriptDialogOpening` is actually answered between HTTP calls — previously this endpoint only touched page-local JS globals and left native dialogs outside those calls to hang the tab.
 
 ### Bot protection
 | Endpoint | Description |
@@ -152,6 +214,25 @@ zig build run -- screenshot https://example.com --out example.jpg --compress --k
 | Response when blocked | `{"blocked":true,"blocker":"akamai","fallback":{"suggestions":[...]}}` |
 | Stealth | Auto-applied on startup (UA rotation, webdriver hide, WebGL/canvas spoof) |
 | Proxy | Set `KURI_PROXY=socks5://...` env var |
+
+### Screencast, video & tracing
+| Endpoint | Description |
+|---|---|
+| `GET /screencast/start?tab_id=X&format=jpeg\|png&quality=0-100` | Real `Page.startScreencast`. `format`/`quality` are validated, not interpolated raw into the outgoing CDP command; clears any stale frames left over from a previous session first |
+| `GET /screencast/stop?tab_id=X&frames=latest\|all\|none` | Drains the socket before *and* after `Page.stopScreencast` to catch frames that raced the stop ack. `frames=latest` (default): just the single newest frame. `frames=all`: every held frame inline (safe — the ring already bounds this to ≤32 MiB / 30 frames). `frames=none`: counts only |
+| `GET /video/start`, `GET /video/stop` | Same shared core as `/screencast/*` — **not a second capability**. kuri has no video encoder (no ffmpeg/libav dependency); these are honest wrappers with `status:"video_started"`/`"video_stopped"` and an explicit `"note"` field stating no `.mp4`/`.webm` is produced. Encode client-side from the returned frames if you need a video file |
+| `GET /trace/start?tab_id=X&categories=...` | `Tracing.start` with `transferMode:"ReturnAsStream"` (required — without it there is no stream for `/trace/stop` to read back) |
+| `GET /trace/stop?tab_id=X` | `Tracing.end`, waits for `Tracing.tracingComplete`, then streams the trace to `~/.kuri/traces/trace-<tab_id>-<millis>.json` in 1 MiB chunks (512 MiB safety cap) instead of buffering the whole thing in memory. `{"ok":true,"status":"trace_complete","path":"...","bytes":N,"data_loss":bool,"trace_format":"..."}`; `"status":"trace_complete_no_stream"` if the trace completed with no stream (e.g. an empty trace); `504` if `Tracing.tracingComplete` is never observed |
+
+### React introspection
+| Endpoint | Description |
+|---|---|
+| `GET /react/tree?tab_id=X&max_nodes=500&max_depth=40&include_host_text=false` | Real fiber walk classified via `Symbol.for('react.*')` — never gated on `__REACT_DEVTOOLS_GLOBAL_HOOK__` already existing. Bounded server-side (`max_nodes` hard-capped at 3000, `max_depth` at 150); truncation is explicit (`truncated`, `moreChildren`, `nodeCount` in the payload). No React on the page → `{"react":false}` |
+| `GET /react/inspect?tab_id=X&ref=eN` (or `&id=...` from a prior tree/suspense call, or `&selector=CSS`) | Props/state/hooks via a depth-, array-, string-, and value-budget-capped safe serializer with a cycle guard. Functions, DOM nodes, and circular references are stubbed, never followed |
+| `GET /react/renders?tab_id=X` | Real bounded (200-entry) commit log fed by an `onCommitFiberRoot` hook stub — not the React Profiler API (no start/stopProfiling, no interaction traces). Requires a page reload *after* kuri attaches before it starts populating; `hookAttachedBeforeInit` plus a `note` field say so explicitly rather than silently returning nothing |
+| `GET /react/suspense?tab_id=X&max_nodes=500` | Finds `Symbol.for('react.suspense')` boundaries across *all* roots (not just the first), reporting `{id, path, showingFallback}` per boundary |
+
+All four degrade identically to `{"react":false}` when no React is on the page — never an error. Fiber/suspense `id`s are single-slot per tab and last-call-wins (fibers aren't stable across re-renders), so an `id` from `/react/tree` or `/react/suspense` is only valid until the next call to either on that tab. No iframe/OOPIF walking (same v1 boundary as `/frame`/`/mainframe`). Pre-Fiber React (≤15) is indistinguishable from "no React."
 
 ## HAR replay workflow (bypass browser for API calls)
 
@@ -183,9 +264,28 @@ curl -s 'https://target.com/api/v4/data' \
   -H 'X-CSRFToken: xyz'
 ```
 
+## Endpoints that require an explicit `tab_id`
+
+Every endpoint that operates on exactly one tab resolves it from `X-Kuri-Session` (or an explicit `tab_id`/`session` query param) the same way `/console` does — a full audit of the route table found 113 direct `requireEffectiveTabId` call sites plus 9 more via the inline session/tab_id resolver already used by `/console`, `/errors`, and all `/intercept/*`. A handful of routes are intentionally exempt because "the current tab for this session" isn't the right concept for them:
+
+| Route(s) | Why it's exempt |
+|---|---|
+| `/health` | No tab concept — server-wide status/version |
+| `/tabs`, `/discover`, `/session/list` | List **all** tabs, not one |
+| `/browdie` | Static response, no tab/bridge param at all |
+| `/session/save`, `/session/load` | Export/import state for potentially many tabs |
+| `/auth/profile/list`, `/auth/profile/delete` | Read/delete profiles on disk by name; no bridge/tab param |
+| `/auth/extract` | Reads cookies directly from a local browser's on-disk SQLite DB; no live CDP tab involved |
+| `/tab/new`, `/window/new` | **Create** a new tab — there is no pre-existing tab_id to resolve |
+| `/tab/current` | Its `tab_id` param means "the tab to become current for this session" — the inverse of resolving a current tab; session resolution here would be circular |
+| `/close` | Dual-mode by design: resolves one tab via the session when possible, explicitly falls back to "close every tab" otherwise |
+| `/batch` | A single request fans out over a JSON body of sub-operations, each carrying its own per-op `tab_id` |
+
+Everything not in this list honors `X-Kuri-Session`.
+
 ## Tips for agents
 
-1. **Prefer session headers** — set `X-Kuri-Session` and let the server remember the current tab.
+1. **Prefer session headers** — set `X-Kuri-Session` and let the server remember the current tab. This covers nearly every `tab_id=X` endpoint above — cookies, storage, HAR, emulation, keyboard input, tracing, network interception, downloads, screencast/video, exposed bindings, React introspection, and dialog auto-response all resolve the session the same way `/console`/`/errors` do. See "Endpoints that require an explicit `tab_id`" above for the intentional exceptions.
 2. **Use `/page/info` between steps** — it is the cheapest live state check for URL/title/ready state.
 3. **Use compact interactive snapshots** — `filter=interactive&format=compact` gives refs like `e0`, `e1` plus useful `state` such as `checked=false`, `disabled`, or `expanded=false` at lower token cost.
 4. **Bot detection is automatic** — if navigate returns `{"blocked":true}`, read the `fallback.suggestions`.
@@ -193,3 +293,4 @@ curl -s 'https://target.com/api/v4/data' \
 6. **Cookies transfer** — use `/cookies` to get browser session cookies, then make direct `curl` calls.
 7. **Refs persist per snapshot only** — take a new snapshot after any navigation or meaningful DOM change.
 8. **Native browser experiment is separate** — `kuri-browser` is useful for parity work and benchmarks. Its `serve-cdp` router is minimal, screenshots still use the Kuri/CDP fallback, and native layout/paint is not implemented.
+9. **Idle tabs don't self-update** — screencast frames, exposed-binding calls, network records, and trace/download completion only get pulled off the CDP socket while some command is in flight. If you go fully idle between calls, make one more call (even the same read) to let the server catch up; see the design-limit note under "Key endpoints" above.

--- a/.devin/skills/kuri-ios/SKILL.md
+++ b/.devin/skills/kuri-ios/SKILL.md
@@ -10,6 +10,16 @@ Drive iOS Simulators (and, where possible, real iPhones) through the
 `kuri-mobile/src/ios/` and the main `kuri` binary forwards
 `kuri ios …` to the `kuri-mobile` binary.
 
+> ⚠️ **Host cursor & keyboard warning.** On the Simulator, `tap`, `doubletap`,
+> `longpress`, `swipe`/`pan`, and `type` post **real CGEvents into the macOS
+> WindowServer** — they physically move your mouse pointer and seize keyboard
+> focus for the duration of the gesture. Do **not** run them while you are using
+> the machine, or from an unattended/background job; a stray click lands wherever
+> the pointer happens to be. Cursor-free, always-safe commands: `list-devices`,
+> `boot`, `shutdown`, `openurl`, `launch`, `terminate`, `list-apps`,
+> `screenshot`. An isolated input backend that bypasses the host pointer is
+> tracked in issues #180 and #183.
+
 ## When to use this skill
 
 - Boot an iOS Simulator, open Safari to a URL, screenshot the result.

--- a/.devin/skills/kuri-mobile/SKILL.md
+++ b/.devin/skills/kuri-mobile/SKILL.md
@@ -11,6 +11,12 @@ Inspired by [`mobile-device-mcp`](https://github.com/srmorete/mobile-device-mcp)
 reimplemented in Zig with no Bun, Node, Gradle, or Xcode in the
 build path.
 
+> ⚠️ **iOS Simulator input seizes the host cursor.** `kuri ios tap/swipe/type`
+> (plus doubletap/longpress) post real CGEvents into the macOS WindowServer, so
+> they move your physical mouse and grab keyboard focus. Don't run them while
+> you're working or from a background job. `kuri android` input runs on-device
+> via adb and does **not** touch the host cursor. Tracked: #180, #183.
+
 **Use the platform-specific skills** for actual work:
 
 - **`kuri-ios`** — iOS Simulator (boot, openurl, launch, terminate,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to kuri are documented here.
 
+## [0.4.13] — 2026-07-26
+
+Seven HTTP routes answered with results they never obtained from the browser. Each returned `200` with a well-formed body, so no caller could distinguish "Chrome reported nothing" from "kuri never asked Chrome" — the failure mode that costs the most, because it looks exactly like success.
+
+### Fixes — routes that fabricated their answers
+
+- **`/react/tree` reported `{"react":false}` on every React page.** React double-buffers fibers, and the `__reactContainer$…` property is stamped on the host node at mount and keeps pointing at whichever fiber existed *then*. After the first commit that is the off-screen side of the pair, whose `.child` is `null` — so detection concluded there was no React at all. It now follows whichever side actually rendered, via `.alternate`. Confirmed against React 19.2.5, where the mount-time fiber has `hasChild:false` while its alternate has children; the route now returns a real tree with `FunctionComponent`, `Context.Consumer` and `HostComponent` nodes at their true depths
+- **`/trace/stop` returned an empty acknowledgement.** `Tracing.start` never asked for `transferMode: ReturnAsStream`, so Chrome kept the trace to itself and there was no stream handle to drain — the route reported success and wrote nothing, every time. `IO.read`/`IO.close` now drain the stream; a routine page load yields ~400 KB of real trace on disk
+- **`/network` returned a canned `{"status":"ok"}`.** No request was ever recorded. Now a bounded ring of real requests carrying url, method and MIME type
+- **`/mainframe` returned the same hard-coded string to every caller**, regardless of tab or page. Now the actual `frameId`, `loaderId` and `url` from `Page.getFrameTree`
+- **`/expose` bindings fired into the void.** The binding was registered with Chrome but its invocations were never captured, so `/expose/calls` stayed empty no matter how many times the page called it. Payloads are now recorded with the call
+- **`/screencast/stop` returned a canned ok** without ever reporting what it had captured. Now reports the real `frame_count`
+- **`/console` and `/errors` had regressed to returning empty** on any page, having lost their collector
+
+### Fixes — script injection
+
+- **`/evaluate` and `/evalhandle` JSON-escaped the expression twice.** The expression arrives already escaped; escaping it again turned a newline into `\n` and then `\\n`, which decodes back to a literal backslash-n *in the JavaScript source*. Chrome answered every multi-line or quote-containing expression with `SyntaxError: Invalid or unexpected token` — the two routes whose entire purpose is running arbitrary JS could not run any non-trivial JS. Escaped exactly once now
+- **`stealth.js` polluted every page's error stream.** The file was a top-level script containing `const originalQuery`, but it is injected twice by design — once via `Page.addScriptToEvaluateOnNewDocument`, once evaluated into the already-loaded page. Re-running it in the same global, which happens whenever tab discovery re-runs against a live tab, re-declared the const. The resulting `SyntaxError` aborted the whole re-injection *at parse time*, so none of the stealth measures after it applied, and it surfaced in the page's own error stream, meaning `/errors` reported a kuri-internal failure as if it were the page's. Now an IIFE behind an idempotence guard, which also stops the permissions wrapper being wrapped around itself. `/errors` on a clean page is `[]`
+
+### Fixes — memory safety
+
+- **The event rings handed out pointers into storage they were about to overwrite.** A snapshot borrowed the ring's own buffers, so the next event that wrapped the ring rewrote memory the caller was still reading — a use-after-free reachable from ordinary traffic. Every ring (`RequestRing`, `ScreencastRing`, `BindingCallRing`, `NetworkRing`) now dupes into a caller-supplied per-request arena, and the contract is stated once and referenced from each
+- **`extractObject`/`extractField` were blind to JSON escaping.** They scanned for the closing brace or quote without honouring `\"`, so a string value containing an escaped quote was truncated there, and a value with unbalanced literal braces — a GraphQL query sent over GET, for instance — ended the object early. Both now respect escapes, with regression tests for each case
+
+### Performance
+
+- **Route dispatch is ~13× faster.** `route()` was a linear chain of 148 `std.mem.eql` comparisons, so a route's cost depended on where it sat in the chain and every unknown path paid all 148. It is now a comptime `StaticStringMap` (bucketed by length) feeding an exhaustive switch: ~81ns → ~6ns on average, and ~150ns → ~15ns worst case. `zig build bench` now carries a permanent regression guard that dispatches all 148 routes, so a relapse to a linear chain shows up as a benchmark regression rather than a slow surprise
+- **`CdpClient` is 62 KiB per tab, down from 520 KiB — 88% smaller.** `ws_read_buf` was a 512 KiB inline array that only ever held the one-shot HTTP upgrade response and RFC 6455 control-frame scratch — message bodies go through `receiveMessageAlloc`, which allocates its own buffer and never touches it — so ~97% of it was headroom nothing in the codebase could reach; it is now 16 KiB. `ws_write_buf` had no readers anywhere and is gone, along with `WebSocketClient.write_buf`, since `writeFrame` builds frames in its own stack buffers
+
+### Tests
+
+378 unit tests in the main suite (plus 76 for `kuri-fetch` and 22 for `kuri-browse`), including a regression test for each fix above. Verified live against Chrome: intercept, dialogs, storage and clipboard routes show no regression from the dispatch rewrite.
+
 ## [0.4.12] — 2026-07-25
 
 A hotfix for two problems that made the *installed* product diverge from the built one.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .kuri,
-    .version = "0.4.12",
+    .version = "0.4.13",
     .dependencies = .{
         .quickjs = .{
             .url = "https://github.com/mitchellh/zig-quickjs-ng/archive/main.tar.gz",

--- a/kuri-mobile/build.zig.zon
+++ b/kuri-mobile/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .kuri_mobile,
-    .version = "0.4.12",
+    .version = "0.4.13",
     .dependencies = .{},
     .fingerprint = 0x41cfa5929f72d020,
     .minimum_zig_version = "0.17.0-dev.813+2153f8143",

--- a/kuri-mobile/src/main.zig
+++ b/kuri-mobile/src/main.zig
@@ -53,7 +53,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
         return;
     }
     if (std.mem.eql(u8, sub, "--version")) {
-        try writeStdout("kuri-mobile 0.4.12\n");
+        try writeStdout("kuri-mobile 0.4.13\n");
         return;
     }
 

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -7,6 +7,21 @@ const validator = @import("crawler/validator.zig");
 const bridge_mod = @import("bridge/bridge.zig");
 const middleware = @import("server/middleware.zig");
 const cdp_client = @import("cdp/client.zig");
+const router = @import("server/router.zig");
+
+/// Comptime string repeat. This Zig dev snapshot's tokenizer no longer emits
+/// a combined `**` token for the array/string repeat operator (`**` lexes as
+/// two separate `*` tokens, tripping the "ambiguous binary operator
+/// whitespace" check no matter how it's spaced) -- pre-existing breakage in
+/// this file, unrelated to router/CDP work, fixed here only so `zig build
+/// bench` runs at all.
+fn repeatStr(comptime s: []const u8, comptime n: usize) []const u8 {
+    comptime {
+        var result: []const u8 = "";
+        for (0..n) |_| result = result ++ s;
+        return result;
+    }
+}
 
 // ── Benchmark harness ──────────────────────────────────────────────────
 
@@ -62,7 +77,8 @@ const Bench = struct {
 };
 
 fn fmtDuration(ns: u64) [12]u8 {
-    var buf: [12]u8 = .{' '} ** 12;
+    var buf: [12]u8 = undefined;
+    @memset(&buf, ' ');
     if (ns < 1_000) {
         _ = std.fmt.bufPrint(&buf, "{d:>7}ns   ", .{ns}) catch {};
     } else if (ns < 1_000_000) {
@@ -78,10 +94,10 @@ fn fmtDuration(ns: u64) [12]u8 {
 // ── Benchmark data ─────────────────────────────────────────────────────
 
 const sample_html_small = "<html><head><title>Test</title></head><body><h1>Hello</h1><p>World</p></body></html>";
-const sample_html_medium = "<html><body>" ++ "<div class=\"item\"><h2>Title</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><a href=\"https://example.com\">Link</a></div>" ** 50 ++ "</body></html>";
+const sample_html_medium = "<html><body>" ++ repeatStr("<div class=\"item\"><h2>Title</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p><a href=\"https://example.com\">Link</a></div>", 50) ++ "</body></html>";
 
 fn makeLargeHtml() []const u8 {
-    return "<html><body>" ++ "<div class=\"item\"><h2>Title</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul><a href=\"https://example.com\">Link</a></div>" ** 200 ++ "</body></html>";
+    return "<html><body>" ++ comptime repeatStr("<div class=\"item\"><h2>Title</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul><a href=\"https://example.com\">Link</a></div>", 200) ++ "</body></html>";
 }
 
 fn makeA11yNodes() [200]a11y.A11yNode {
@@ -289,6 +305,60 @@ fn benchArenaAllocReset() void {
     }
 }
 
+// ── Route dispatch: the production `router.route_table`
+// (StaticStringMap(Route) + exhaustive switch in `route()`). Permanent
+// regression-guard benchmark -- if route dispatch ever regresses back to a
+// linear if/else-if chain, "all 148 routes/call" here will jump from
+// ~1µs back toward ~12µs (measured before/after during the StaticStringMap
+// migration; see the optimization task report for the full comparison
+// against the old chain).
+const bench_route_paths = [_][]const u8{
+    "/health",               "/tabs",                  "/page/info",             "/discover",          "/navigate",
+    "/snapshot",             "/action",                "/text",                  "/screenshot",        "/evaluate",
+    "/browdie",              "/har/start",             "/har/stop",              "/har/status",        "/har/replay",
+    "/close",                "/cookies",               "/cookies/clear",         "/cookies/set",       "/storage/local",
+    "/storage/session",      "/storage/local/clear",   "/storage/session/clear", "/get",               "/back",
+    "/forward",              "/reload",                "/diff/snapshot",         "/emulate",           "/geolocation",
+    "/upload",               "/session/save",          "/session/load",          "/auth/profile/save", "/auth/profile/load",
+    "/auth/profile/list",    "/auth/profile/delete",   "/auth/extract",          "/debug/enable",      "/debug/disable",
+    "/screenshot/annotated", "/screenshot/diff",       "/screencast/start",      "/screencast/stop",   "/video/start",
+    "/video/stop",           "/console",               "/intercept/start",       "/intercept/stop",    "/intercept/requests",
+    "/intercept/rules",      "/intercept/rules/clear", "/markdown",              "/links",             "/pdf",
+    "/dom/query",            "/dom/html",              "/cookies/delete",        "/headers",           "/script/inject",
+    "/stop",                 "/scrollintoview",        "/drag",                  "/keyboard/type",     "/keyboard/inserttext",
+    "/keydown",              "/keyup",                 "/wait",                  "/tab/current",       "/tab/new",
+    "/tab/close",            "/highlight",             "/errors",                "/set/offline",       "/set/media",
+    "/set/credentials",      "/find",                  "/trace/start",           "/trace/stop",        "/profiler/start",
+    "/profiler/stop",        "/inspect",               "/window/new",            "/session/list",      "/set/viewport",
+    "/set/useragent",        "/dom/attributes",        "/frames",                "/network",           "/perf/lcp",
+    "/ws/start",             "/ws/stop",               "/batch",                 "/element/state",     "/find-element",
+    "/dialog/auto",          "/dialog/accept",         "/dialog/dismiss",        "/mouse/move",        "/mouse/down",
+    "/mouse/up",             "/mouse/wheel",           "/page/state",            "/clipboard/read",    "/clipboard/write",
+    "/clear",                "/boundingbox",           "/wait/function",         "/response/body",     "/setcontent",
+    "/selectall",            "/setvalue",              "/timezone",              "/locale",            "/permissions",
+    "/tap",                  "/dispatch",              "/download",              "/addstyle",          "/bringtofront",
+    "/pushstate",            "/expose",                "/expose/calls",          "/multiselect",       "/swipe",
+    "/vitals",               "/frame",                 "/mainframe",             "/getattribute",      "/inputvalue",
+    "/react/tree",           "/react/inspect",         "/react/renders",         "/react/suspense",    "/recording/start",
+    "/recording/stop",       "/request/detail",        "/wait/download",         "/initscript/remove", "/evalhandle",
+    "/diff/url",             "/cache/set",             "/cache/get",             "/cache/clear",       "/cache/list",
+    "/screenshot/som",       "/snapshot/changes",      "/recording/export",
+};
+
+fn benchRouteDispatchNewFirst() void {
+    std.mem.doNotOptimizeAway(router.route_table.get(bench_route_paths[0]));
+}
+fn benchRouteDispatchNewLast() void {
+    std.mem.doNotOptimizeAway(router.route_table.get(bench_route_paths[bench_route_paths.len - 1]));
+}
+fn benchRouteDispatchNewMiss() void {
+    std.mem.doNotOptimizeAway(router.route_table.get("/nonexistent/route/xyz"));
+}
+fn benchRouteDispatchNewAvgAll148() void {
+    for (bench_route_paths) |p| std.mem.doNotOptimizeAway(router.route_table.get(p));
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
 // ── Main ───────────────────────────────────────────────────────────────
 
 pub fn main() !void {
@@ -333,6 +403,12 @@ pub fn main() !void {
     std.debug.print("\n── Server infra ──────────────────────────────────────────────────────\n", .{});
     Bench.run("RequestTimer ×100", iters, benchRequestTimer).print();
     Bench.run("arena alloc+reset ×100", iters, benchArenaAllocReset).print();
+
+    std.debug.print("\n── Route dispatch (StaticStringMap + enum switch) ─────────────────────\n", .{});
+    Bench.run("dispatch: first route (/health)", iters, benchRouteDispatchNewFirst).print();
+    Bench.run("dispatch: last route (/recording/export)", iters, benchRouteDispatchNewLast).print();
+    Bench.run("dispatch: 404 miss", iters, benchRouteDispatchNewMiss).print();
+    Bench.run("dispatch: all 148 routes/call", iters, benchRouteDispatchNewAvgAll148).print();
 
     std.debug.print("\n", .{});
 }

--- a/src/browse_main.zig
+++ b/src/browse_main.zig
@@ -4,7 +4,7 @@ const markdown = @import("crawler/markdown.zig");
 const validator = @import("crawler/validator.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.12";
+const version = "0.4.13";
 const user_agent = "kuri-browse/" ++ version;
 
 pub fn main(init: std.process.Init.Minimal) !void {

--- a/src/cdp/client.zig
+++ b/src/cdp/client.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const protocol = @import("protocol.zig");
 const WebSocketClient = @import("websocket.zig").WebSocketClient;
 const compat = @import("../compat.zig");
+const jsonscan = @import("jsonscan.zig");
 
 pub const EventBuffer = struct {
     const BufferedEvent = struct {
@@ -80,6 +81,688 @@ pub const EventBuffer = struct {
     }
 };
 
+/// A fixed-capacity ring that remembers the command IDs of CDP messages we
+/// injected ourselves from inside the read loop (Fetch.continueRequest /
+/// Fetch.fulfillRequest / Fetch.failRequest / Page.handleJavaScriptDialog).
+/// Their acks must be dropped when observed, not buffered as junk events —
+/// no caller ever sent them and no caller is waiting for them.
+///
+/// 32 is enough because acks for injected commands only need to be tracked
+/// for the window between "we write the reply" and "we observe its ack in
+/// the same thread's read loop" — nothing else ever reads this socket
+/// concurrently (the owning mutex is held for the whole loop), so acks
+/// return in near-FIFO order within the next 1-2 reads. On overflow the
+/// oldest tracked id is dropped; if Chrome's ack for it arrives later it
+/// falls through as one harmless buffered junk event that ages out of
+/// EventBuffer's 256-cap ring — never a hang or a misapplied reply.
+pub const InjectedIds = struct {
+    const CAP = 32;
+    ids: [CAP]u32 = @splat(0),
+    head: usize = 0,
+    len: usize = 0,
+
+    pub fn remember(self: *InjectedIds, id: u32) void {
+        const idx = (self.head + self.len) % CAP;
+        self.ids[idx] = id;
+        if (self.len < CAP) {
+            self.len += 1;
+        } else {
+            self.head = (self.head + 1) % CAP;
+        }
+    }
+
+    /// If `msg` is a response ack for one of our tracked ids, remove it from
+    /// the ring and return true.
+    pub fn consumeIfMatch(self: *InjectedIds, msg: []const u8) bool {
+        var i: usize = 0;
+        while (i < self.len) : (i += 1) {
+            const idx = (self.head + i) % CAP;
+            if (CdpClient.matchesResponseId(msg, self.ids[idx])) {
+                // Shift everything after idx back by one to close the gap,
+                // preserving relative order of the remaining tracked ids.
+                var j = idx;
+                while (j != (self.head + self.len - 1) % CAP) {
+                    const nxt = (j + 1) % CAP;
+                    self.ids[j] = self.ids[nxt];
+                    j = nxt;
+                }
+                self.len -= 1;
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+/// One CDP Fetch-interception rule. Rules are matched in order; the first
+/// whose `url_substring` is contained in the paused request's URL wins
+/// ("" matches everything, so an empty-substring rule is a catch-all).
+pub const InterceptRule = struct {
+    url_substring: []const u8, // owned dupe; "" == matches everything
+    action: Action,
+    status: u16 = 200, // fulfill only
+    body: []const u8 = "", // fulfill only — raw bytes (base64'd at send time)
+    content_type: []const u8 = "application/json",
+    error_reason: []const u8 = "Failed", // abort only — a Network.ErrorReason string
+
+    pub const Action = enum { @"continue", abort, fulfill };
+};
+
+/// Bookkeeping record for one Fetch.requestPaused event we auto-answered.
+pub const PausedRequestRecord = struct {
+    request_id: []const u8, // owned dupe (CdpClient.allocator)
+    url: []const u8,
+    method: []const u8,
+    resource_type: []const u8,
+    action_taken: InterceptRule.Action,
+    status: u16, // 0 for continue/abort
+    timestamp: i64,
+};
+
+/// Bounded ring (fixed array, not ArrayListUnmanaged — the record shape and
+/// cap are fixed by spec) of the last ~200 paused requests we answered.
+pub const RequestRing = struct {
+    const CAP = 200;
+    allocator: std.mem.Allocator,
+    items: [CAP]?PausedRequestRecord = @splat(null),
+    next: usize = 0,
+    count: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) RequestRing {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeRecord(self: *RequestRing, rec: PausedRequestRecord) void {
+        self.allocator.free(rec.request_id);
+        self.allocator.free(rec.url);
+        self.allocator.free(rec.method);
+        self.allocator.free(rec.resource_type);
+    }
+
+    pub fn push(self: *RequestRing, rec: PausedRequestRecord) void {
+        if (self.items[self.next]) |old| self.freeRecord(old);
+        self.items[self.next] = rec;
+        self.next = (self.next + 1) % CAP;
+        if (self.count < CAP) self.count += 1;
+    }
+
+    /// Number of live records currently held (<= CAP).
+    pub fn len(self: *const RequestRing) usize {
+        return self.count;
+    }
+
+    /// Drop all currently-held records, freeing their owned strings, and
+    /// reset the ring to empty. Unlike `deinit`, the ring remains usable
+    /// for `push` immediately afterward.
+    pub fn clear(self: *RequestRing) void {
+        for (self.items) |maybe| {
+            if (maybe) |rec| self.freeRecord(rec);
+        }
+        self.items = @splat(null);
+        self.next = 0;
+        self.count = 0;
+    }
+
+    /// Copy out currently-held records in chronological order (oldest
+    /// first). Caller owns the returned slice AND every string inside it
+    /// (all duped into `allocator`, exactly like
+    /// `CdpClient.snapshotInterceptRules` — pass a per-request arena and
+    /// nothing further needs freeing).
+    ///
+    /// The strings MUST be duped rather than aliased: the ring's own copies
+    /// are freed by `push` (rotation) and `clear`, which run on whatever
+    /// thread is draining the CDP socket. A caller that held borrowed
+    /// slices past the `CdpClient.mu` critical section — e.g. the router
+    /// serializing records to JSON — would read freed memory.
+    pub fn snapshot(self: *const RequestRing, allocator: std.mem.Allocator) ![]PausedRequestRecord {
+        const out = try allocator.alloc(PausedRequestRecord, self.count);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |r| {
+                allocator.free(r.request_id);
+                allocator.free(r.url);
+                allocator.free(r.method);
+                allocator.free(r.resource_type);
+            }
+            allocator.free(out);
+        }
+        const start = if (self.count < CAP) 0 else self.next;
+        for (0..self.count) |i| {
+            const rec = self.items[(start + i) % CAP].?;
+
+            const request_id = try allocator.dupe(u8, rec.request_id);
+            errdefer allocator.free(request_id);
+            const url = try allocator.dupe(u8, rec.url);
+            errdefer allocator.free(url);
+            const method = try allocator.dupe(u8, rec.method);
+            errdefer allocator.free(method);
+            const resource_type = try allocator.dupe(u8, rec.resource_type);
+
+            out[filled] = .{
+                .request_id = request_id,
+                .url = url,
+                .method = method,
+                .resource_type = resource_type,
+                .action_taken = rec.action_taken,
+                .status = rec.status,
+                .timestamp = rec.timestamp,
+            };
+            filled += 1;
+        }
+        return out;
+    }
+
+    pub fn deinit(self: *RequestRing) void {
+        for (self.items) |maybe| {
+            if (maybe) |rec| self.freeRecord(rec);
+        }
+    }
+};
+
+/// Per-tab Fetch-interception state: the rule set plus the paused-request
+/// ring. Lives on `CdpClient` exactly like `event_buf` does.
+pub const InterceptState = struct {
+    allocator: std.mem.Allocator, // == CdpClient.allocator (persistent GPA, NOT a per-call arena)
+    rules: std.ArrayListUnmanaged(InterceptRule) = .empty,
+    requests: RequestRing,
+    active: bool = false, // whether Fetch interception is currently enabled for this tab (set by the router's /intercept/start and /intercept/stop)
+
+    pub fn init(allocator: std.mem.Allocator) InterceptState {
+        return .{
+            .allocator = allocator,
+            .requests = RequestRing.init(allocator),
+        };
+    }
+
+    /// Append a rule, duping all owned string fields into `self.allocator`.
+    pub fn addRule(self: *InterceptState, rule: InterceptRule) !void {
+        const owned_url = try self.allocator.dupe(u8, rule.url_substring);
+        errdefer self.allocator.free(owned_url);
+        const owned_body = try self.allocator.dupe(u8, rule.body);
+        errdefer self.allocator.free(owned_body);
+        const owned_ct = try self.allocator.dupe(u8, rule.content_type);
+        errdefer self.allocator.free(owned_ct);
+        const owned_err = try self.allocator.dupe(u8, rule.error_reason);
+        errdefer self.allocator.free(owned_err);
+
+        try self.rules.append(self.allocator, .{
+            .url_substring = owned_url,
+            .action = rule.action,
+            .status = rule.status,
+            .body = owned_body,
+            .content_type = owned_ct,
+            .error_reason = owned_err,
+        });
+    }
+
+    fn freeRule(self: *InterceptState, rule: InterceptRule) void {
+        self.allocator.free(rule.url_substring);
+        self.allocator.free(rule.body);
+        self.allocator.free(rule.content_type);
+        self.allocator.free(rule.error_reason);
+    }
+
+    pub fn clearRules(self: *InterceptState) void {
+        for (self.rules.items) |rule| self.freeRule(rule);
+        self.rules.clearRetainingCapacity();
+    }
+
+    /// Find the first rule whose `url_substring` is contained in `url`.
+    /// Returns null when no rule matches — callers MUST treat null as
+    /// "continue unmodified", never as "no response needed": that is
+    /// exactly the deadlock this whole design exists to prevent.
+    pub fn findMatch(self: *const InterceptState, url: []const u8) ?*const InterceptRule {
+        for (self.rules.items) |*r| {
+            if (r.url_substring.len == 0 or std.mem.indexOf(u8, url, r.url_substring) != null) return r;
+        }
+        return null;
+    }
+
+    pub fn deinit(self: *InterceptState) void {
+        self.clearRules();
+        self.rules.deinit(self.allocator);
+        self.requests.deinit();
+    }
+};
+
+/// Per-tab Page.javascriptDialogOpening auto-responder state. Disabled
+/// (`enabled = false`) by default: unlike Fetch.requestPaused, a paused
+/// dialog does not by itself justify always auto-answering — the router
+/// already exposes a manual dialog-respond flow, and this must not race it.
+pub const DialogAutoState = struct {
+    enabled: bool = false,
+    accept: bool = true,
+    prompt_text: []const u8 = "", // owned dupe when non-empty; freed/replaced by `set`
+
+    /// Update the auto-answer config, freeing the previous prompt_text.
+    pub fn set(self: *DialogAutoState, allocator: std.mem.Allocator, enabled: bool, accept: bool, prompt_text: []const u8) !void {
+        const owned = try allocator.dupe(u8, prompt_text);
+        if (self.prompt_text.len > 0) allocator.free(self.prompt_text);
+        self.prompt_text = owned;
+        self.enabled = enabled;
+        self.accept = accept;
+    }
+
+    pub fn deinit(self: *DialogAutoState, allocator: std.mem.Allocator) void {
+        if (self.prompt_text.len > 0) allocator.free(self.prompt_text);
+        self.prompt_text = "";
+    }
+};
+
+/// One captured `Page.screencastFrame` event. Frame bytes vary wildly in
+/// size (a single JPEG frame can be a few KB or several MB depending on
+/// page content/quality), so unlike the fixed-shape rings below this is
+/// held in a growable list with a running byte counter — see
+/// `ScreencastRing` for why.
+pub const ScreencastFrameRecord = struct {
+    data_b64: []const u8, // owned dupe — base64 image bytes, exactly as Chrome sent them
+    timestamp: f64, // metadata.timestamp, Chrome's clock
+    device_width: u32,
+    device_height: u32,
+    session_id: i64, // the sessionId this frame was acked with
+};
+
+/// Bounded by BOTH frame count and total bytes. Deliberately NOT a fixed
+/// `[CAP]?T` array like `RequestRing`: frame payloads vary from a few KB
+/// to multiple MB, so admitting one large frame can require evicting
+/// *several* old small frames to stay under the byte cap — a fixed array
+/// evicts exactly one slot per push and can't express that. This is the
+/// one collector ring in this file that deliberately diverges from
+/// `RequestRing`'s shape; every other ring below keeps that shape.
+pub const ScreencastRing = struct {
+    pub const MAX_COUNT = 30;
+    pub const MAX_BYTES = 32 * 1024 * 1024; // 32 MiB total, across all held frames' data_b64
+
+    allocator: std.mem.Allocator,
+    items: std.ArrayListUnmanaged(ScreencastFrameRecord) = .empty,
+    total_bytes: usize = 0,
+    dropped_oversize: usize = 0, // frames that alone exceeded MAX_BYTES and were rejected outright (never inserted) — exposed via CdpClient.droppedScreencastFrameCount rather than silently discarded
+
+    pub fn init(allocator: std.mem.Allocator) ScreencastRing {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeRecord(self: *ScreencastRing, rec: ScreencastFrameRecord) void {
+        self.allocator.free(rec.data_b64);
+    }
+
+    /// Takes ownership of `rec.data_b64` (an `self.allocator` dupe already
+    /// made by the caller): stores it, evicting the oldest frames first
+    /// until both caps are satisfied, OR frees it and counts it as dropped
+    /// if it alone would exceed `MAX_BYTES` — this never evicts every held
+    /// frame just to make room for one outlier.
+    pub fn push(self: *ScreencastRing, rec: ScreencastFrameRecord) void {
+        if (rec.data_b64.len > MAX_BYTES) {
+            std.log.warn("cdp collector: dropping oversize screencast frame ({d} bytes > {d} cap)", .{ rec.data_b64.len, MAX_BYTES });
+            self.dropped_oversize += 1;
+            self.freeRecord(rec);
+            return;
+        }
+        while (self.items.items.len > 0 and (self.items.items.len >= MAX_COUNT or self.total_bytes + rec.data_b64.len > MAX_BYTES)) {
+            const evicted = self.items.orderedRemove(0);
+            self.total_bytes -= evicted.data_b64.len;
+            self.freeRecord(evicted);
+        }
+        self.items.append(self.allocator, rec) catch {
+            self.freeRecord(rec);
+            return;
+        };
+        self.total_bytes += rec.data_b64.len;
+    }
+
+    pub fn len(self: *const ScreencastRing) usize {
+        return self.items.items.len;
+    }
+
+    pub fn clear(self: *ScreencastRing) void {
+        for (self.items.items) |rec| self.freeRecord(rec);
+        self.items.clearRetainingCapacity();
+        self.total_bytes = 0;
+    }
+
+    /// Copy out held frames, oldest first, every `data_b64` duped into
+    /// `allocator` — same dupe-on-snapshot contract as
+    /// `RequestRing.snapshot` (see its doc comment): the ring's own copies
+    /// are freed by `push` (eviction) and `clear`, which run on whatever
+    /// thread is draining the CDP socket, so a caller must never alias
+    /// past `CdpClient.mu`.
+    pub fn snapshot(self: *const ScreencastRing, allocator: std.mem.Allocator) ![]ScreencastFrameRecord {
+        const out = try allocator.alloc(ScreencastFrameRecord, self.items.items.len);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |r| allocator.free(r.data_b64);
+            allocator.free(out);
+        }
+        for (self.items.items, 0..) |rec, i| {
+            out[i] = .{
+                .data_b64 = try allocator.dupe(u8, rec.data_b64),
+                .timestamp = rec.timestamp,
+                .device_width = rec.device_width,
+                .device_height = rec.device_height,
+                .session_id = rec.session_id,
+            };
+            filled += 1;
+        }
+        return out;
+    }
+
+    /// The single most recent frame, if any. Same dupe contract as `snapshot`.
+    pub fn latest(self: *const ScreencastRing, allocator: std.mem.Allocator) !?ScreencastFrameRecord {
+        if (self.items.items.len == 0) return null;
+        const rec = self.items.items[self.items.items.len - 1];
+        return .{
+            .data_b64 = try allocator.dupe(u8, rec.data_b64),
+            .timestamp = rec.timestamp,
+            .device_width = rec.device_width,
+            .device_height = rec.device_height,
+            .session_id = rec.session_id,
+        };
+    }
+
+    pub fn deinit(self: *ScreencastRing) void {
+        for (self.items.items) |rec| self.freeRecord(rec);
+        self.items.deinit(self.allocator);
+    }
+};
+
+/// One captured `Runtime.bindingCalled` event (a page calling a function
+/// exposed via `window.<name>` / `Runtime.addBinding`, e.g. `/expose`).
+pub const BindingCallRecord = struct {
+    pub const MAX_NAME = 256; // binding names are short JS identifiers we ourselves registered; capped defensively anyway
+    pub const MAX_PAYLOAD = 64 * 1024; // 64 KiB — payloads are page-supplied strings and can be arbitrarily large
+
+    name: []const u8, // owned dupe, truncated to MAX_NAME
+    payload: []const u8, // owned dupe, truncated to MAX_PAYLOAD
+    truncated: bool, // true if payload was cut to MAX_PAYLOAD (name truncation is not separately flagged: names this short are never attacker-controlled in practice)
+    timestamp: i64,
+};
+
+/// Fixed-capacity ring, same shape as `RequestRing`: bounded by both a
+/// fixed slot count AND a fixed per-record byte cap, so total memory is
+/// bounded (CAP * (MAX_NAME + MAX_PAYLOAD)) even without a running byte
+/// counter like `ScreencastRing` needs.
+pub const BindingCallRing = struct {
+    pub const CAP = 200;
+
+    allocator: std.mem.Allocator,
+    items: [CAP]?BindingCallRecord = @splat(null),
+    next: usize = 0,
+    count: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) BindingCallRing {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeRecord(self: *BindingCallRing, rec: BindingCallRecord) void {
+        self.allocator.free(rec.name);
+        self.allocator.free(rec.payload);
+    }
+
+    pub fn push(self: *BindingCallRing, rec: BindingCallRecord) void {
+        if (self.items[self.next]) |old| self.freeRecord(old);
+        self.items[self.next] = rec;
+        self.next = (self.next + 1) % CAP;
+        if (self.count < CAP) self.count += 1;
+    }
+
+    pub fn len(self: *const BindingCallRing) usize {
+        return self.count;
+    }
+
+    pub fn clear(self: *BindingCallRing) void {
+        for (self.items) |maybe| if (maybe) |rec| self.freeRecord(rec);
+        self.items = @splat(null);
+        self.next = 0;
+        self.count = 0;
+    }
+
+    /// Dupe-on-snapshot, same contract as `RequestRing.snapshot`.
+    pub fn snapshot(self: *const BindingCallRing, allocator: std.mem.Allocator) ![]BindingCallRecord {
+        const out = try allocator.alloc(BindingCallRecord, self.count);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |r| {
+                allocator.free(r.name);
+                allocator.free(r.payload);
+            }
+            allocator.free(out);
+        }
+        const start = if (self.count < CAP) 0 else self.next;
+        for (0..self.count) |i| {
+            const rec = self.items[(start + i) % CAP].?;
+            const name = try allocator.dupe(u8, rec.name);
+            errdefer allocator.free(name);
+            const payload = try allocator.dupe(u8, rec.payload);
+            out[filled] = .{ .name = name, .payload = payload, .truncated = rec.truncated, .timestamp = rec.timestamp };
+            filled += 1;
+        }
+        return out;
+    }
+
+    pub fn deinit(self: *BindingCallRing) void {
+        for (self.items) |maybe| if (maybe) |rec| self.freeRecord(rec);
+    }
+};
+
+/// One `Network.requestWillBeSent`/`responseReceived` pair, tracked
+/// *alongside* (never instead of) `HarRecorder`'s own consumption of the
+/// same events — see `collectNetworkRequestWillBeSent`/`ResponseReceived`,
+/// which always return `false` from `collect` so the event still reaches
+/// `event_buf` for `flushEventsToHar`. This ring exists only so
+/// `findNetworkRequestByUrl` can hand `/response/body` a real `requestId`.
+pub const NetworkRecord = struct {
+    pub const MAX_URL = 8 * 1024; // 8 KiB — generous for real URLs; bounds a pathological data:/blob: URL
+
+    request_id: []const u8, // owned dupe
+    url: []const u8, // owned dupe, truncated to MAX_URL
+    url_truncated: bool,
+    method: []const u8, // owned dupe
+    mime_type: []const u8, // owned dupe when non-empty; "" (not allocator-owned) until responseReceived fills it in
+    timestamp: i64,
+};
+
+/// Fixed-capacity ring, same shape and cap as `RequestRing`. Never holds a
+/// response body — bodies are fetched on demand via `Network.getResponseBody`
+/// using the `requestId` this ring hands back.
+pub const NetworkRing = struct {
+    pub const CAP = 200;
+
+    allocator: std.mem.Allocator,
+    items: [CAP]?NetworkRecord = @splat(null),
+    next: usize = 0,
+    count: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) NetworkRing {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeRecord(self: *NetworkRing, rec: NetworkRecord) void {
+        self.allocator.free(rec.request_id);
+        self.allocator.free(rec.url);
+        self.allocator.free(rec.method);
+        if (rec.mime_type.len > 0) self.allocator.free(rec.mime_type);
+    }
+
+    pub fn push(self: *NetworkRing, rec: NetworkRecord) void {
+        if (self.items[self.next]) |old| self.freeRecord(old);
+        self.items[self.next] = rec;
+        self.next = (self.next + 1) % CAP;
+        if (self.count < CAP) self.count += 1;
+    }
+
+    pub fn len(self: *const NetworkRing) usize {
+        return self.count;
+    }
+
+    /// Attach a mime type to the record matching `request_id`, freeing any
+    /// previous one. Takes ownership of `owned_mime` only when a match is
+    /// found (return true); the caller must free it themselves on `false`
+    /// (request already evicted from the 200-record ring).
+    pub fn updateMimeType(self: *NetworkRing, request_id: []const u8, owned_mime: []const u8) bool {
+        var i: usize = 0;
+        while (i < CAP) : (i += 1) {
+            if (self.items[i]) |rec| {
+                if (std.mem.eql(u8, rec.request_id, request_id)) {
+                    if (rec.mime_type.len > 0) self.allocator.free(rec.mime_type);
+                    self.items[i].?.mime_type = owned_mime;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    pub fn clear(self: *NetworkRing) void {
+        for (self.items) |maybe| if (maybe) |rec| self.freeRecord(rec);
+        self.items = @splat(null);
+        self.next = 0;
+        self.count = 0;
+    }
+
+    fn dupeRecord(allocator: std.mem.Allocator, rec: NetworkRecord) !NetworkRecord {
+        const request_id = try allocator.dupe(u8, rec.request_id);
+        errdefer allocator.free(request_id);
+        const url = try allocator.dupe(u8, rec.url);
+        errdefer allocator.free(url);
+        const method = try allocator.dupe(u8, rec.method);
+        errdefer allocator.free(method);
+        const mime_type = if (rec.mime_type.len > 0) try allocator.dupe(u8, rec.mime_type) else "";
+        return .{
+            .request_id = request_id,
+            .url = url,
+            .url_truncated = rec.url_truncated,
+            .method = method,
+            .mime_type = mime_type,
+            .timestamp = rec.timestamp,
+        };
+    }
+
+    /// Dupe-on-snapshot, same contract as `RequestRing.snapshot`.
+    pub fn snapshot(self: *const NetworkRing, allocator: std.mem.Allocator) ![]NetworkRecord {
+        const out = try allocator.alloc(NetworkRecord, self.count);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |r| {
+                allocator.free(r.request_id);
+                allocator.free(r.url);
+                allocator.free(r.method);
+                if (r.mime_type.len > 0) allocator.free(r.mime_type);
+            }
+            allocator.free(out);
+        }
+        const start = if (self.count < CAP) 0 else self.next;
+        for (0..self.count) |i| {
+            const rec = self.items[(start + i) % CAP].?;
+            out[filled] = try dupeRecord(allocator, rec);
+            filled += 1;
+        }
+        return out;
+    }
+
+    /// Last-match-wins scan (oldest to newest) for the most recent request
+    /// whose URL contains `url_substring`. Result duped independent of ring
+    /// storage, same contract as `snapshot`.
+    pub fn findByUrlSubstring(self: *const NetworkRing, allocator: std.mem.Allocator, url_substring: []const u8) !?NetworkRecord {
+        const start = if (self.count < CAP) 0 else self.next;
+        var found: ?NetworkRecord = null;
+        for (0..self.count) |i| {
+            const rec = self.items[(start + i) % CAP].?;
+            if (std.mem.indexOf(u8, rec.url, url_substring) != null) found = rec;
+        }
+        const rec = found orelse return null;
+        return try dupeRecord(allocator, rec);
+    }
+
+    pub fn deinit(self: *NetworkRing) void {
+        for (self.items) |maybe| if (maybe) |rec| self.freeRecord(rec);
+    }
+};
+
+/// The one-shot IO stream handle from a `Tracing.tracingComplete` event
+/// (only populated when `Tracing.start` was called with
+/// `"transferMode":"ReturnAsStream"` — see `CdpClient.takeTraceStream`'s
+/// doc comment). Never holds trace bytes themselves: a full trace can be
+/// tens of MB, and the whole point of ReturnAsStream is to keep it out of
+/// this process's memory until a caller explicitly drains it via `IO.read`.
+pub const TraceStreamRecord = struct {
+    stream_handle: []const u8, // owned dupe
+    data_loss: bool,
+    trace_format: []const u8, // owned dupe when non-empty; "" if the event didn't include one
+};
+
+/// Singleton — only one trace can be active per tab, so there is nothing
+/// to bound beyond "one record, replaced wholesale on the next
+/// `tracingComplete`".
+pub const TraceStreamState = struct {
+    allocator: std.mem.Allocator,
+    current: ?TraceStreamRecord = null,
+
+    pub fn init(allocator: std.mem.Allocator) TraceStreamState {
+        return .{ .allocator = allocator };
+    }
+
+    fn freeRecord(self: *TraceStreamState, rec: TraceStreamRecord) void {
+        self.allocator.free(rec.stream_handle);
+        if (rec.trace_format.len > 0) self.allocator.free(rec.trace_format);
+    }
+
+    /// Replace any previously-recorded (and presumably already-consumed or
+    /// abandoned) stream handle with a new one.
+    pub fn set(self: *TraceStreamState, rec: TraceStreamRecord) void {
+        if (self.current) |old| self.freeRecord(old);
+        self.current = rec;
+    }
+
+    /// Destructive read: dupes the current record into `allocator` then
+    /// clears `self.current`, unlike every other collector accessor in
+    /// this file (all of which are non-destructive peeks). This is
+    /// intentional, not an oversight — see `CdpClient.takeTraceStream`'s
+    /// doc comment for why a stream handle can't be safely re-peeked.
+    pub fn take(self: *TraceStreamState, allocator: std.mem.Allocator) !?TraceStreamRecord {
+        const cur = self.current orelse return null;
+        const stream_handle = try allocator.dupe(u8, cur.stream_handle);
+        errdefer allocator.free(stream_handle);
+        const trace_format = if (cur.trace_format.len > 0) try allocator.dupe(u8, cur.trace_format) else "";
+        self.freeRecord(cur);
+        self.current = null;
+        return .{ .stream_handle = stream_handle, .data_loss = cur.data_loss, .trace_format = trace_format };
+    }
+
+    pub fn deinit(self: *TraceStreamState) void {
+        if (self.current) |cur| self.freeRecord(cur);
+    }
+};
+
+/// Bag of every passive CDP-event collector's state, lives on `CdpClient`
+/// exactly like `intercept`/`dialog_auto` do (same persistent-allocator
+/// rule: `allocator` here is always `CdpClient.allocator`, the process's
+/// GPA, never a per-HTTP-request arena — see `InterceptState`'s doc
+/// comment, which states the same invariant).
+pub const CollectorState = struct {
+    allocator: std.mem.Allocator,
+    screencast: ScreencastRing,
+    bindings: BindingCallRing,
+    network: NetworkRing,
+    tracing: TraceStreamState,
+
+    pub fn init(allocator: std.mem.Allocator) CollectorState {
+        return .{
+            .allocator = allocator,
+            .screencast = ScreencastRing.init(allocator),
+            .bindings = BindingCallRing.init(allocator),
+            .network = NetworkRing.init(allocator),
+            .tracing = TraceStreamState.init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *CollectorState) void {
+        self.screencast.deinit();
+        self.bindings.deinit();
+        self.network.deinit();
+        self.tracing.deinit();
+    }
+};
+
 /// 🧁 she's not just a bro, not just a baddie — she's a browdie.
 /// CDP WebSocket client that talks to Chrome DevTools Protocol.
 pub const CdpClient = struct {
@@ -91,11 +774,21 @@ pub const CdpClient = struct {
     dead: bool,
     mu: compat.PthreadMutex,
 
-    // Owned buffers for WebSocket I/O
-    ws_read_buf: [512 * 1024]u8,
-    ws_write_buf: [8192]u8,
+    // Owned read buffer for WebSocket I/O. Only ever needed for the one-shot
+    // HTTP upgrade response in the handshake and RFC 6455 control-frame
+    // (ping/pong) scratch space, both capped well under this size -- actual
+    // message bodies go through `receiveMessageAlloc`, which allocates its
+    // own buffer and never touches this one. 16KiB replaces a previous
+    // 512KiB allocation that was ~97% headroom nothing in the codebase
+    // could reach (see perf task notes). `ws_write_buf` used to live here
+    // too but had zero readers anywhere -- removed as dead storage.
+    ws_read_buf: [16 * 1024]u8,
 
     event_buf: EventBuffer,
+    injected_ids: InjectedIds,
+    intercept: InterceptState,
+    dialog_auto: DialogAutoState,
+    collectors: CollectorState,
 
     pub fn init(allocator: std.mem.Allocator, cdp_url: []const u8) CdpClient {
         return .{
@@ -107,8 +800,11 @@ pub const CdpClient = struct {
             .dead = false,
             .mu = .{},
             .ws_read_buf = undefined,
-            .ws_write_buf = undefined,
             .event_buf = EventBuffer.init(allocator),
+            .injected_ids = .{},
+            .intercept = InterceptState.init(allocator),
+            .dialog_auto = .{},
+            .collectors = CollectorState.init(allocator),
         };
     }
 
@@ -128,7 +824,6 @@ pub const CdpClient = struct {
             self.allocator,
             self.cdp_url,
             &self.ws_read_buf,
-            &self.ws_write_buf,
         ) catch return error.ConnectionRefused;
         self.connected = true;
     }
@@ -178,8 +873,9 @@ pub const CdpClient = struct {
                 return response;
             }
 
-            // Buffer event instead of discarding
-            self.event_buf.push(allocator, response);
+            // Not our response — handle it inline (drop injected-command ack,
+            // auto-answer Fetch.requestPaused/dialog) or buffer it as an event.
+            self.handleOrBuffer(allocator, response, ws);
         }
 
         return error.ConnectionRefused;
@@ -227,6 +923,17 @@ pub const CdpClient = struct {
 
     /// Wait for a specific CDP event by polling buffered events and reading new ones.
     /// Returns true if the event was seen within max_attempts reads.
+    ///
+    /// The exact message that satisfies the wait is ALSO run through `collect`
+    /// (the same passive-collector dispatch `handleOrBuffer` uses for every
+    /// other message) before being discarded -- otherwise a collector whose
+    /// only source event happens to be the thing someone is waiting for (e.g.
+    /// `collectTracingComplete`, awaited directly by /trace/stop) would never
+    /// fire: its event would be freed raw right here instead. `collect` never
+    /// frees `response` itself (same contract `handleOrBuffer` relies on), so
+    /// `response` is still unconditionally freed afterward, preserving this
+    /// fast path's original behavior for methods `collect` doesn't know about
+    /// (Page.loadEventFired, Page.downloadWillBegin, ...).
     pub fn waitForEvent(self: *CdpClient, allocator: std.mem.Allocator, method: []const u8, max_attempts: u32) bool {
         self.mu.lock();
         defer self.mu.unlock();
@@ -239,10 +946,11 @@ pub const CdpClient = struct {
         while (attempts < max_attempts) : (attempts += 1) {
             const response = ws.receiveMessageAlloc(allocator, 2 * 1024 * 1024) catch return false;
             if (eventMatchesMethod(response, method)) {
+                _ = self.collect(allocator, response, ws);
                 allocator.free(response);
                 return true;
             }
-            self.event_buf.push(allocator, response);
+            self.handleOrBuffer(allocator, response, ws);
         }
         return false;
     }
@@ -261,12 +969,631 @@ pub const CdpClient = struct {
         var drained: u32 = 0;
         while (drained < 2000) : (drained += 1) {
             const msg = ws.receiveMessageAlloc(allocator, 2 * 1024 * 1024) catch break;
-            self.event_buf.push(allocator, msg);
+            self.handleOrBuffer(allocator, msg, ws);
         }
+    }
+
+    // ── In-read-loop auto-responder ─────────────────────────────────────
+    //
+    // Called from send()/waitForEvent()/drainWsEvents() — all three already
+    // hold self.mu — for every message that did not satisfy the caller's
+    // own wait condition. This is the ONLY place matching/replying logic
+    // lives; the three call sites each do one thing: hand the message here
+    // instead of pushing it straight to event_buf.
+
+    /// Takes ownership of `msg` (allocated with `allocator`): either
+    /// consumed here (dropped ack, auto-answered event) or handed to
+    /// event_buf.push, which dupes it into self.allocator and frees the
+    /// caller's copy — same contract EventBuffer.push already had.
+    fn handleOrBuffer(self: *CdpClient, allocator: std.mem.Allocator, msg: []const u8, ws: *WebSocketClient) void {
+        // (a) Ack for one of OUR OWN injected auto-reply commands — drop,
+        // not a real event for any caller to see.
+        if (self.injected_ids.consumeIfMatch(msg)) {
+            allocator.free(msg);
+            return;
+        }
+
+        // (b) Something we auto-answer inline (Fetch.requestPaused / dialog).
+        if (self.autoRespond(allocator, msg, ws)) {
+            allocator.free(msg);
+            return;
+        }
+
+        // (b.5) A passive collector fully consumes this one (screencast /
+        // bindingCalled / tracingComplete) -- Network.* collectors return
+        // false here on purpose so step (c) still runs for them.
+        if (self.collect(allocator, msg, ws)) {
+            allocator.free(msg);
+            return;
+        }
+
+        // (c) Ordinary event — existing behavior, unchanged.
+        self.event_buf.push(allocator, msg);
+    }
+
+    /// Returns true if `msg` was handled (caller should free it, not buffer it).
+    fn autoRespond(self: *CdpClient, allocator: std.mem.Allocator, msg: []const u8, ws: *WebSocketClient) bool {
+        if (eventMatchesMethod(msg, "Fetch.requestPaused")) {
+            return self.autoRespondFetch(allocator, msg, ws);
+        }
+        if (self.dialog_auto.enabled and eventMatchesMethod(msg, "Page.javascriptDialogOpening")) {
+            return self.autoRespondDialog(allocator, ws);
+        }
+        return false;
+    }
+
+    const RequestPausedFields = struct {
+        request_id: []const u8,
+        url: []const u8,
+        method: []const u8,
+        resource_type: []const u8,
+    };
+
+    fn extractRequestPausedFields(event_json: []const u8) ?RequestPausedFields {
+        const request_id = jsonscan.extractField(event_json, "requestId") orelse return null;
+        const request_obj = jsonscan.extractObject(event_json, "request") orelse return null;
+        const url = jsonscan.extractField(request_obj, "url") orelse return null;
+        const method = jsonscan.extractField(request_obj, "method") orelse "GET";
+        const resource_type = jsonscan.extractField(event_json, "resourceType") orelse "Other";
+        return .{ .request_id = request_id, .url = url, .method = method, .resource_type = resource_type };
+    }
+
+    /// Fetch.requestPaused -> match rules -> failRequest | fulfillRequest |
+    /// continueRequest, written inline on the already-open `ws`.
+    ///
+    /// ALWAYS answers — even when no rule matches (continueRequest with no
+    /// modifications) — because once Chrome has paused a request on us,
+    /// failing to reply hangs the page forever. This is the single most
+    /// important correctness property of the whole design, so it is not
+    /// gated by any "interception enabled" flag: if we can see the event at
+    /// all, Fetch domain is already enabled on the Chrome side, and we must
+    /// resolve it.
+    fn autoRespondFetch(self: *CdpClient, allocator: std.mem.Allocator, event_json: []const u8, ws: *WebSocketClient) bool {
+        const fields = extractRequestPausedFields(event_json) orelse return false;
+        const rule = self.intercept.findMatch(fields.url);
+        const action: InterceptRule.Action = if (rule) |r| r.action else .@"continue";
+
+        var params: []const u8 = undefined;
+        var method: []const u8 = undefined;
+
+        switch (action) {
+            .@"continue" => {
+                method = protocol.Methods.fetch_continue_request;
+                params = std.fmt.allocPrint(allocator, "{{\"requestId\":\"{s}\"}}", .{fields.request_id}) catch return false;
+            },
+            .abort => {
+                method = protocol.Methods.fetch_fail_request;
+                const raw_reason = if (rule) |r| r.error_reason else "Failed";
+                const reason = jsonscan.escapeJsonAlloc(allocator, raw_reason) catch return false;
+                defer allocator.free(reason);
+                params = std.fmt.allocPrint(allocator, "{{\"requestId\":\"{s}\",\"errorReason\":\"{s}\"}}", .{ fields.request_id, reason }) catch return false;
+            },
+            .fulfill => {
+                method = protocol.Methods.fetch_fulfill_request;
+                const r = rule.?; // action == .fulfill only ever comes from a matched rule
+                const enc = std.base64.standard.Encoder;
+                const b64_buf = allocator.alloc(u8, enc.calcSize(r.body.len)) catch return false;
+                defer allocator.free(b64_buf);
+                const b64_body = enc.encode(b64_buf, r.body);
+                const content_type = jsonscan.escapeJsonAlloc(allocator, r.content_type) catch return false;
+                defer allocator.free(content_type);
+                params = std.fmt.allocPrint(
+                    allocator,
+                    "{{\"requestId\":\"{s}\",\"responseCode\":{d},\"responseHeaders\":[{{\"name\":\"Content-Type\",\"value\":\"{s}\"}}],\"body\":\"{s}\"}}",
+                    .{ fields.request_id, r.status, content_type, b64_body },
+                ) catch return false;
+            },
+        }
+        defer allocator.free(params);
+
+        const id = self.nextId();
+        const cmd = self.buildMessageWithId(allocator, id, method, params) catch return false;
+        defer allocator.free(cmd);
+
+        ws.sendText(cmd) catch {
+            self.connected = false;
+            self.dead = true;
+            return false;
+        };
+        self.injected_ids.remember(id);
+
+        const status: u16 = if (action == .fulfill) rule.?.status else 0;
+        self.recordPausedRequest(fields, action, status);
+
+        return true;
+    }
+
+    fn recordPausedRequest(self: *CdpClient, fields: RequestPausedFields, action: InterceptRule.Action, status: u16) void {
+        const rid = self.allocator.dupe(u8, fields.request_id) catch return;
+        const url_dup = self.allocator.dupe(u8, fields.url) catch {
+            self.allocator.free(rid);
+            return;
+        };
+        const method_dup = self.allocator.dupe(u8, fields.method) catch {
+            self.allocator.free(rid);
+            self.allocator.free(url_dup);
+            return;
+        };
+        const rtype_dup = self.allocator.dupe(u8, fields.resource_type) catch {
+            self.allocator.free(rid);
+            self.allocator.free(url_dup);
+            self.allocator.free(method_dup);
+            return;
+        };
+
+        self.intercept.requests.push(.{
+            .request_id = rid,
+            .url = url_dup,
+            .method = method_dup,
+            .resource_type = rtype_dup,
+            .action_taken = action,
+            .status = status,
+            .timestamp = compat.milliTimestamp(),
+        });
+    }
+
+    /// Page.javascriptDialogOpening -> Page.handleJavaScriptDialog, gated by
+    /// `dialog_auto.enabled` (checked by the caller, `autoRespond`).
+    ///
+    /// Sharper caveat than Fetch: an unanswered dialog suspends all further
+    /// JS execution and most CDP traffic on the page, not just one request.
+    fn autoRespondDialog(self: *CdpClient, allocator: std.mem.Allocator, ws: *WebSocketClient) bool {
+        const prompt_text = jsonscan.escapeJsonAlloc(allocator, self.dialog_auto.prompt_text) catch return false;
+        defer allocator.free(prompt_text);
+
+        const params = std.fmt.allocPrint(
+            allocator,
+            "{{\"accept\":{s},\"promptText\":\"{s}\"}}",
+            .{ if (self.dialog_auto.accept) "true" else "false", prompt_text },
+        ) catch return false;
+        defer allocator.free(params);
+
+        const id = self.nextId();
+        const cmd = self.buildMessageWithId(allocator, id, protocol.Methods.page_handle_dialog, params) catch return false;
+        defer allocator.free(cmd);
+
+        ws.sendText(cmd) catch {
+            self.connected = false;
+            self.dead = true;
+            return false;
+        };
+        self.injected_ids.remember(id);
+        return true;
+    }
+
+    // ── Passive CDP event collectors ─────────────────────────────────────
+    //
+    // Unlike `autoRespond` above (which answers Chrome inline because an
+    // unanswered Fetch/dialog event hangs the page), everything here is
+    // read-only bookkeeping: extract a few fields with `jsonscan`, dupe
+    // them into `self.collectors`, and either fully consume the event
+    // (screencast/bindings/tracing — nothing else in this codebase reads
+    // them) or merely observe it (Network.* — `HarRecorder` still needs to
+    // see it via `event_buf`, so these always return false here; see
+    // `flushEventsToHar` in router.zig, and `har.zig`'s own
+    // `handleCdpEvent`, which must keep working unmodified).
+    //
+    // `collect` is the ONE generic mechanism plugged into `handleOrBuffer`
+    // (a single new line there, mirroring the `autoRespond` call above):
+    // it extracts the event's "method" field exactly once and scans a
+    // small static table, rather than each event type re-scanning the
+    // whole message with its own `eventMatchesMethod` call the way
+    // `autoRespond` does above (fine for 2 event types, wasteful for the
+    // 5 handled here). Per-event-type *behavior* still differs (ack vs.
+    // record-only vs. observe-and-forward), which is why each table entry
+    // still needs its own handler function — but the registration and
+    // routing are singular and data-driven, not five bespoke branches.
+
+    const CollectHandler = *const fn (*CdpClient, std.mem.Allocator, []const u8, *WebSocketClient) bool;
+    const CollectEntry = struct { method: []const u8, handler: CollectHandler };
+
+    const collect_table = [_]CollectEntry{
+        .{ .method = "Page.screencastFrame", .handler = collectScreencastFrame },
+        .{ .method = "Runtime.bindingCalled", .handler = collectBindingCalled },
+        .{ .method = "Network.requestWillBeSent", .handler = collectNetworkRequestWillBeSent },
+        .{ .method = "Network.responseReceived", .handler = collectNetworkResponseReceived },
+        .{ .method = "Tracing.tracingComplete", .handler = collectTracingComplete },
+    };
+
+    /// Returns true if `msg` was fully consumed here (caller should free
+    /// it, not buffer it) — same "handled means free it" contract as
+    /// `autoRespond`.
+    fn collect(self: *CdpClient, allocator: std.mem.Allocator, msg: []const u8, ws: *WebSocketClient) bool {
+        const method = jsonscan.extractField(msg, "method") orelse return false;
+        for (collect_table) |entry| {
+            if (std.mem.eql(u8, method, entry.method)) {
+                return entry.handler(self, allocator, msg, ws);
+            }
+        }
+        return false;
+    }
+
+    /// `Page.screencastFrame` -> ack + record. The ack MUST happen even if
+    /// everything after it fails to parse/store: an unacked frame stalls
+    /// the whole screencast stream (Chrome won't send the next one until
+    /// it's acked), so this always returns true (event fully handled)
+    /// once the ack attempt has been made, regardless of storage outcome.
+    fn collectScreencastFrame(self: *CdpClient, allocator: std.mem.Allocator, msg: []const u8, ws: *WebSocketClient) bool {
+        if (jsonscan.extractField(msg, "sessionId")) |session_id_str| {
+            const params = std.fmt.allocPrint(allocator, "{{\"sessionId\":{s}}}", .{session_id_str}) catch return true;
+            defer allocator.free(params);
+            const id = self.nextId();
+            const cmd = self.buildMessageWithId(allocator, id, protocol.Methods.page_screencast_frame_ack, params) catch return true;
+            defer allocator.free(cmd);
+            ws.sendText(cmd) catch {
+                self.connected = false;
+                self.dead = true;
+                return true; // socket is dead either way; nothing more to do with this event
+            };
+            self.injected_ids.remember(id);
+        }
+
+        const data = jsonscan.extractField(msg, "data") orelse return true;
+        const metadata = jsonscan.extractObject(msg, "metadata");
+        const timestamp: f64 = blk: {
+            const m = metadata orelse break :blk 0;
+            const ts = jsonscan.extractField(m, "timestamp") orelse break :blk 0;
+            break :blk std.fmt.parseFloat(f64, ts) catch 0;
+        };
+        const device_width: u32 = blk: {
+            const m = metadata orelse break :blk 0;
+            const w = jsonscan.extractField(m, "deviceWidth") orelse break :blk 0;
+            break :blk std.fmt.parseInt(u32, w, 10) catch 0;
+        };
+        const device_height: u32 = blk: {
+            const m = metadata orelse break :blk 0;
+            const h = jsonscan.extractField(m, "deviceHeight") orelse break :blk 0;
+            break :blk std.fmt.parseInt(u32, h, 10) catch 0;
+        };
+        const session_id: i64 = blk: {
+            const sid = jsonscan.extractField(msg, "sessionId") orelse break :blk 0;
+            break :blk std.fmt.parseInt(i64, sid, 10) catch 0;
+        };
+
+        const owned_data = self.allocator.dupe(u8, data) catch return true;
+        self.collectors.screencast.push(.{
+            .data_b64 = owned_data,
+            .timestamp = timestamp,
+            .device_width = device_width,
+            .device_height = device_height,
+            .session_id = session_id,
+        });
+        return true;
+    }
+
+    /// `Runtime.bindingCalled` -> record only. Nothing else in this
+    /// codebase consumes this event, so it's always fully handled.
+    fn collectBindingCalled(self: *CdpClient, _: std.mem.Allocator, msg: []const u8, _: *WebSocketClient) bool {
+        const name = jsonscan.extractField(msg, "name") orelse return true;
+        const payload = jsonscan.extractField(msg, "payload") orelse "";
+
+        const name_truncated = name.len > BindingCallRecord.MAX_NAME;
+        const capped_name = if (name_truncated) name[0..BindingCallRecord.MAX_NAME] else name;
+        const payload_truncated = payload.len > BindingCallRecord.MAX_PAYLOAD;
+        const capped_payload = if (payload_truncated) payload[0..BindingCallRecord.MAX_PAYLOAD] else payload;
+        if (payload_truncated) {
+            std.log.warn("cdp collector: truncating Runtime.bindingCalled payload for \"{s}\" ({d} bytes > {d} cap)", .{ capped_name, payload.len, BindingCallRecord.MAX_PAYLOAD });
+        }
+
+        const owned_name = self.allocator.dupe(u8, capped_name) catch return true;
+        const owned_payload = self.allocator.dupe(u8, capped_payload) catch {
+            self.allocator.free(owned_name);
+            return true;
+        };
+        self.collectors.bindings.push(.{
+            .name = owned_name,
+            .payload = owned_payload,
+            .truncated = payload_truncated,
+            .timestamp = compat.milliTimestamp(),
+        });
+        return true;
+    }
+
+    /// `Network.requestWillBeSent` -> record only, then ALWAYS falls
+    /// through (returns false) so `event_buf`/`HarRecorder.handleCdpEvent`
+    /// still see it — this collector observes, it must never consume
+    /// Network events.
+    fn collectNetworkRequestWillBeSent(self: *CdpClient, _: std.mem.Allocator, msg: []const u8, _: *WebSocketClient) bool {
+        const request_id = jsonscan.extractField(msg, "requestId") orelse return false;
+        const request_obj = jsonscan.extractObject(msg, "request") orelse return false;
+        const url = jsonscan.extractField(request_obj, "url") orelse return false;
+        const method = jsonscan.extractField(request_obj, "method") orelse "GET";
+
+        const url_truncated = url.len > NetworkRecord.MAX_URL;
+        const capped_url = if (url_truncated) url[0..NetworkRecord.MAX_URL] else url;
+        if (url_truncated) {
+            std.log.warn("cdp collector: truncating Network.requestWillBeSent url for requestId \"{s}\" ({d} bytes > {d} cap)", .{ request_id, url.len, NetworkRecord.MAX_URL });
+        }
+
+        const owned_id = self.allocator.dupe(u8, request_id) catch return false;
+        const owned_url = self.allocator.dupe(u8, capped_url) catch {
+            self.allocator.free(owned_id);
+            return false;
+        };
+        const owned_method = self.allocator.dupe(u8, method) catch {
+            self.allocator.free(owned_id);
+            self.allocator.free(owned_url);
+            return false;
+        };
+        self.collectors.network.push(.{
+            .request_id = owned_id,
+            .url = owned_url,
+            .url_truncated = url_truncated,
+            .method = owned_method,
+            .mime_type = "",
+            .timestamp = compat.milliTimestamp(),
+        });
+        return false;
+    }
+
+    /// `Network.responseReceived` -> attach mimeType to the matching
+    /// request record, if it's still held. Always returns false (observe
+    /// only) for the same reason as `collectNetworkRequestWillBeSent`.
+    fn collectNetworkResponseReceived(self: *CdpClient, _: std.mem.Allocator, msg: []const u8, _: *WebSocketClient) bool {
+        const request_id = jsonscan.extractField(msg, "requestId") orelse return false;
+        const response_obj = jsonscan.extractObject(msg, "response") orelse return false;
+        const mime = jsonscan.extractField(response_obj, "mimeType") orelse return false;
+
+        const owned_mime = self.allocator.dupe(u8, mime) catch return false;
+        if (!self.collectors.network.updateMimeType(request_id, owned_mime)) {
+            // Request already evicted from the 200-record ring (or never
+            // recorded, e.g. observed mid-stream) -- nothing to attach to.
+            self.allocator.free(owned_mime);
+        }
+        return false;
+    }
+
+    /// `Tracing.tracingComplete` -> dupe only the (short) stream handle;
+    /// never the trace bytes themselves -- see `TraceStreamRecord`'s doc
+    /// comment. Always fully consumed: nothing else in this codebase
+    /// reads this event, and even a missing `stream` field (Tracing.start
+    /// wasn't called with `transferMode: ReturnAsStream`) leaves nothing
+    /// useful to forward.
+    fn collectTracingComplete(self: *CdpClient, _: std.mem.Allocator, msg: []const u8, _: *WebSocketClient) bool {
+        const stream = jsonscan.extractField(msg, "stream") orelse return true;
+        const data_loss_str = jsonscan.extractField(msg, "dataLoss");
+        const data_loss = if (data_loss_str) |d| std.mem.eql(u8, d, "true") else false;
+        const trace_format = jsonscan.extractField(msg, "traceFormat") orelse "";
+
+        const owned_stream = self.allocator.dupe(u8, stream) catch return true;
+        const owned_format = if (trace_format.len > 0) (self.allocator.dupe(u8, trace_format) catch "") else "";
+        self.collectors.tracing.set(.{
+            .stream_handle = owned_stream,
+            .data_loss = data_loss,
+            .trace_format = owned_format,
+        });
+        return true;
+    }
+
+    // ── Public accessors for router.zig (thread-safe: each takes self.mu) ──
+    //
+    // The same *CdpClient is handed out to concurrent HTTP-handler threads
+    // by Bridge.getCdpClient, so anything touching `intercept`/`dialog_auto`
+    // from outside the read-loop functions above must lock first.
+
+    /// Replace the intercept rule set for this client. Existing rules (and
+    /// their owned strings) are freed first.
+    pub fn setInterceptRules(self: *CdpClient, rules: []const InterceptRule) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.intercept.clearRules();
+        for (rules) |r| try self.intercept.addRule(r);
+    }
+
+    /// Append a single intercept rule without disturbing existing ones.
+    pub fn addInterceptRule(self: *CdpClient, rule: InterceptRule) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        try self.intercept.addRule(rule);
+    }
+
+    /// Remove all intercept rules (subsequent paused requests default to continue).
+    pub fn clearInterceptRules(self: *CdpClient) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.intercept.clearRules();
+    }
+
+    /// Snapshot of currently-configured intercept rules, in match order.
+    /// Caller owns the returned slice and every owned string inside it
+    /// (all duped into `allocator` — pass a per-request arena and nothing
+    /// further needs freeing).
+    pub fn snapshotInterceptRules(self: *CdpClient, allocator: std.mem.Allocator) ![]InterceptRule {
+        self.mu.lock();
+        defer self.mu.unlock();
+        const out = try allocator.alloc(InterceptRule, self.intercept.rules.items.len);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |r| {
+                allocator.free(r.url_substring);
+                allocator.free(r.body);
+                allocator.free(r.content_type);
+                allocator.free(r.error_reason);
+            }
+            allocator.free(out);
+        }
+        for (self.intercept.rules.items) |r| {
+            const url_substring = try allocator.dupe(u8, r.url_substring);
+            errdefer allocator.free(url_substring);
+            const body = try allocator.dupe(u8, r.body);
+            errdefer allocator.free(body);
+            const content_type = try allocator.dupe(u8, r.content_type);
+            errdefer allocator.free(content_type);
+            const error_reason = try allocator.dupe(u8, r.error_reason);
+
+            out[filled] = .{
+                .url_substring = url_substring,
+                .action = r.action,
+                .status = r.status,
+                .body = body,
+                .content_type = content_type,
+                .error_reason = error_reason,
+            };
+            filled += 1;
+        }
+        return out;
+    }
+
+    /// Snapshot of currently-recorded paused-request records, oldest first.
+    /// Caller owns the returned slice AND every string inside it (all duped
+    /// into `allocator` — pass a per-request arena and nothing further needs
+    /// freeing). Duping is required for safety, not convenience: see
+    /// `RequestRing.snapshot`.
+    pub fn snapshotPausedRequests(self: *CdpClient, allocator: std.mem.Allocator) ![]PausedRequestRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.intercept.requests.snapshot(allocator);
+    }
+
+    /// Number of paused-request records currently held (<= 200), without allocating.
+    pub fn pausedRequestCount(self: *CdpClient) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.intercept.requests.len();
+    }
+
+    /// Drop all recorded paused-request history. Rules are untouched — see
+    /// `clearInterceptRules` for that.
+    pub fn clearPausedRequests(self: *CdpClient) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.intercept.requests.clear();
+    }
+
+    /// Enable/disable dialog auto-response and set the answer to give.
+    /// `prompt_text` is duped; pass "" if the dialog isn't a prompt().
+    pub fn setDialogAuto(self: *CdpClient, enabled: bool, accept: bool, prompt_text: []const u8) !void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        try self.dialog_auto.set(self.allocator, enabled, accept, prompt_text);
+    }
+
+    /// Record whether Fetch interception is currently enabled for this tab
+    /// (set by the router around its own Fetch.enable/Fetch.disable calls).
+    /// Purely bookkeeping — does not itself send any CDP command.
+    pub fn setInterceptActive(self: *CdpClient, active: bool) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.intercept.active = active;
+    }
+
+    /// Whether interception was last set active via `setInterceptActive`.
+    pub fn interceptActive(self: *CdpClient) bool {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.intercept.active;
+    }
+
+    // ── Case 1: screencast/video frames ──────────────────────────────────
+
+    /// Snapshot of currently-held screencast frames, oldest first. Same
+    /// dupe-on-snapshot contract as `snapshotPausedRequests`.
+    pub fn snapshotScreencastFrames(self: *CdpClient, allocator: std.mem.Allocator) ![]ScreencastFrameRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.screencast.snapshot(allocator);
+    }
+
+    /// The single most recent screencast frame, if any. Same dupe contract.
+    pub fn latestScreencastFrame(self: *CdpClient, allocator: std.mem.Allocator) !?ScreencastFrameRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.screencast.latest(allocator);
+    }
+
+    pub fn screencastFrameCount(self: *CdpClient) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.screencast.len();
+    }
+
+    /// Number of frames dropped outright for being individually larger
+    /// than `ScreencastRing.MAX_BYTES` -- expose rather than silently
+    /// swallow (see hard requirement: log/expose what was dropped).
+    pub fn droppedScreencastFrameCount(self: *CdpClient) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.screencast.dropped_oversize;
+    }
+
+    /// Call from `/screencast/stop` (`handleScreencastStop`) so a later
+    /// `/screencast/start` doesn't return stale frames from a prior session.
+    pub fn clearScreencastFrames(self: *CdpClient) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.collectors.screencast.clear();
+    }
+
+    // ── Case 2: Runtime.bindingCalled ────────────────────────────────────
+
+    /// Snapshot of currently-held binding-call records, oldest first.
+    pub fn snapshotBindingCalls(self: *CdpClient, allocator: std.mem.Allocator) ![]BindingCallRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.bindings.snapshot(allocator);
+    }
+
+    pub fn bindingCallCount(self: *CdpClient) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.bindings.len();
+    }
+
+    pub fn clearBindingCalls(self: *CdpClient) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.collectors.bindings.clear();
+    }
+
+    // ── Case 3: Network ───────────────────────────────────────────────────
+
+    /// Snapshot of currently-held network request records, oldest first.
+    pub fn snapshotNetworkRequests(self: *CdpClient, allocator: std.mem.Allocator) ![]NetworkRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.network.snapshot(allocator);
+    }
+
+    /// Last-match-wins scan for the most recent request whose URL contains
+    /// `url_substring` -- gives `/response/body` (`handleResponseBody`) a
+    /// real `requestId` instead of the `runtime_evaluate(fetch(...))`
+    /// workaround it uses today.
+    pub fn findNetworkRequestByUrl(self: *CdpClient, allocator: std.mem.Allocator, url_substring: []const u8) !?NetworkRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.network.findByUrlSubstring(allocator, url_substring);
+    }
+
+    pub fn networkRequestCount(self: *CdpClient) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.network.len();
+    }
+
+    /// Call from `handleNetwork` when `mode == "disable"`.
+    pub fn clearNetworkRequests(self: *CdpClient) void {
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.collectors.network.clear();
+    }
+
+    // ── Case 4: Tracing ───────────────────────────────────────────────────
+
+    /// Destructive: dupes the current stream handle (if any) into
+    /// `allocator`, then clears it. See `TraceStreamState.take`'s doc
+    /// comment for why this one accessor is a "take" rather than a "peek"
+    /// like every other accessor above.
+    pub fn takeTraceStream(self: *CdpClient, allocator: std.mem.Allocator) !?TraceStreamRecord {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.collectors.tracing.take(allocator);
     }
 
     pub fn deinit(self: *CdpClient) void {
         self.event_buf.deinit();
+        self.intercept.deinit();
+        self.dialog_auto.deinit(self.allocator);
+        self.collectors.deinit();
         self.disconnect();
     }
 };
@@ -361,4 +1688,710 @@ test "EventBuffer drain frees all" {
     try std.testing.expectEqual(@as(usize, 2), buf.len());
     buf.drain();
     try std.testing.expectEqual(@as(usize, 0), buf.len());
+}
+
+// ── InjectedIds ──────────────────────────────────────────────────────────
+
+test "InjectedIds remembers and consumes a matching ack" {
+    var ids = InjectedIds{};
+    ids.remember(7);
+    ids.remember(8);
+
+    try std.testing.expect(ids.consumeIfMatch("{\"id\":7,\"result\":{}}"));
+    try std.testing.expectEqual(@as(usize, 1), ids.len);
+    // Not consumed twice
+    try std.testing.expect(!ids.consumeIfMatch("{\"id\":7,\"result\":{}}"));
+    // Still finds the other one
+    try std.testing.expect(ids.consumeIfMatch("{\"id\":8,\"result\":{}}"));
+    try std.testing.expectEqual(@as(usize, 0), ids.len);
+}
+
+test "InjectedIds does not match unrelated ids or real events" {
+    var ids = InjectedIds{};
+    ids.remember(1);
+    try std.testing.expect(!ids.consumeIfMatch("{\"id\":2,\"result\":{}}"));
+    try std.testing.expect(!ids.consumeIfMatch("{\"method\":\"Page.loadEventFired\",\"params\":{}}"));
+}
+
+test "InjectedIds drops oldest on overflow without corrupting the ring" {
+    var ids = InjectedIds{};
+    var i: u32 = 0;
+    while (i < InjectedIds.CAP + 5) : (i += 1) {
+        ids.remember(i);
+    }
+    // Ring is full; oldest 5 ids (0..4) were evicted.
+    try std.testing.expectEqual(@as(usize, InjectedIds.CAP), ids.len);
+    try std.testing.expect(!ids.consumeIfMatch("{\"id\":0,\"result\":{}}"));
+    try std.testing.expect(!ids.consumeIfMatch("{\"id\":4,\"result\":{}}"));
+    // But the newest surviving one is still tracked correctly.
+    try std.testing.expect(ids.consumeIfMatch("{\"id\":5,\"result\":{}}"));
+    var last_buf: [32]u8 = undefined;
+    const last_msg = std.fmt.bufPrint(&last_buf, "{{\"id\":{d},\"result\":{{}}}}", .{i - 1}) catch unreachable;
+    try std.testing.expect(ids.consumeIfMatch(last_msg));
+}
+
+// ── InterceptState / rule matching ──────────────────────────────────────
+
+test "InterceptState findMatch returns null (default continue) when no rules configured" {
+    var state = InterceptState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try std.testing.expect(state.findMatch("https://example.com/anything") == null);
+}
+
+test "InterceptState findMatch matches by url substring in order" {
+    var state = InterceptState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.addRule(.{ .url_substring = "/api/", .action = .abort, .error_reason = "Failed" });
+    try state.addRule(.{ .url_substring = "/ads/", .action = .fulfill, .status = 204, .body = "" });
+
+    const m1 = state.findMatch("https://example.com/api/users").?;
+    try std.testing.expectEqual(InterceptRule.Action.abort, m1.action);
+
+    const m2 = state.findMatch("https://example.com/ads/banner.js").?;
+    try std.testing.expectEqual(InterceptRule.Action.fulfill, m2.action);
+    try std.testing.expectEqual(@as(u16, 204), m2.status);
+
+    try std.testing.expect(state.findMatch("https://example.com/home") == null);
+}
+
+test "InterceptState catch-all empty-substring rule matches everything" {
+    var state = InterceptState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.addRule(.{ .url_substring = "", .action = .abort });
+    try std.testing.expect(state.findMatch("https://anything.example/whatever") != null);
+}
+
+test "InterceptState clearRules frees rules and resets matching to default-continue" {
+    var state = InterceptState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.addRule(.{ .url_substring = "x", .action = .abort });
+    try std.testing.expect(state.findMatch("x") != null);
+
+    state.clearRules();
+    try std.testing.expect(state.findMatch("x") == null);
+    try std.testing.expectEqual(@as(usize, 0), state.rules.items.len);
+}
+
+// ── RequestRing ──────────────────────────────────────────────────────────
+
+fn makeTestRecord(allocator: std.mem.Allocator, tag: u32) !PausedRequestRecord {
+    var buf: [32]u8 = undefined;
+    const url = try std.fmt.bufPrint(&buf, "https://example.com/{d}", .{tag});
+    return .{
+        .request_id = try allocator.dupe(u8, "req"),
+        .url = try allocator.dupe(u8, url),
+        .method = try allocator.dupe(u8, "GET"),
+        .resource_type = try allocator.dupe(u8, "Document"),
+        .action_taken = .@"continue",
+        .status = 0,
+        .timestamp = @intCast(tag),
+    };
+}
+
+test "RequestRing push and snapshot preserve chronological order" {
+    var ring = RequestRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    ring.push(try makeTestRecord(std.testing.allocator, 1));
+    ring.push(try makeTestRecord(std.testing.allocator, 2));
+    ring.push(try makeTestRecord(std.testing.allocator, 3));
+
+    try std.testing.expectEqual(@as(usize, 3), ring.len());
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer freeRecordSnapshot(std.testing.allocator, snap);
+    try std.testing.expectEqual(@as(usize, 3), snap.len);
+    try std.testing.expectEqual(@as(i64, 1), snap[0].timestamp);
+    try std.testing.expectEqual(@as(i64, 2), snap[1].timestamp);
+    try std.testing.expectEqual(@as(i64, 3), snap[2].timestamp);
+}
+
+test "RequestRing overflow evicts oldest and keeps cap" {
+    var ring = RequestRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    var i: u32 = 0;
+    while (i < RequestRing.CAP + 10) : (i += 1) {
+        ring.push(try makeTestRecord(std.testing.allocator, i));
+    }
+
+    try std.testing.expectEqual(@as(usize, RequestRing.CAP), ring.len());
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer freeRecordSnapshot(std.testing.allocator, snap);
+    try std.testing.expectEqual(@as(usize, RequestRing.CAP), snap.len);
+    // Oldest surviving record should be tag 10 (0..9 evicted), newest CAP+9.
+    try std.testing.expectEqual(@as(i64, 10), snap[0].timestamp);
+    try std.testing.expectEqual(@as(i64, RequestRing.CAP + 9), snap[snap.len - 1].timestamp);
+}
+
+// ── DialogAutoState ──────────────────────────────────────────────────────
+
+test "DialogAutoState set replaces prompt_text and frees the previous one" {
+    var state = DialogAutoState{};
+    defer state.deinit(std.testing.allocator);
+
+    try state.set(std.testing.allocator, true, true, "first");
+    try std.testing.expectEqualStrings("first", state.prompt_text);
+
+    try state.set(std.testing.allocator, true, false, "second");
+    try std.testing.expectEqualStrings("second", state.prompt_text);
+    try std.testing.expect(!state.accept);
+}
+
+// ── CdpClient public accessors ──────────────────────────────────────────
+
+test "CdpClient setInterceptRules / snapshotPausedRequests / setDialogAuto round-trip" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+
+    try client.setInterceptRules(&[_]InterceptRule{
+        .{ .url_substring = "/blocked", .action = .abort },
+    });
+    try std.testing.expectEqual(@as(usize, 1), client.intercept.rules.items.len);
+
+    try client.addInterceptRule(.{ .url_substring = "/ads", .action = .fulfill, .status = 204 });
+    try std.testing.expectEqual(@as(usize, 2), client.intercept.rules.items.len);
+
+    client.clearInterceptRules();
+    try std.testing.expectEqual(@as(usize, 0), client.intercept.rules.items.len);
+
+    try std.testing.expectEqual(@as(usize, 0), client.pausedRequestCount());
+    const empty_snap = try client.snapshotPausedRequests(std.testing.allocator);
+    defer std.testing.allocator.free(empty_snap);
+    try std.testing.expectEqual(@as(usize, 0), empty_snap.len);
+
+    try client.setDialogAuto(true, false, "no thanks");
+    try std.testing.expect(client.dialog_auto.enabled);
+    try std.testing.expect(!client.dialog_auto.accept);
+    try std.testing.expectEqualStrings("no thanks", client.dialog_auto.prompt_text);
+}
+
+// ── RequestRing.clear / snapshotInterceptRules / clearPausedRequests /
+// setInterceptActive ────────────────────────────────────────────────────
+
+test "RequestRing clear frees all records and resets for reuse" {
+    var ring = RequestRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    ring.push(try makeTestRecord(std.testing.allocator, 1));
+    ring.push(try makeTestRecord(std.testing.allocator, 2));
+    try std.testing.expectEqual(@as(usize, 2), ring.len());
+
+    ring.clear();
+    try std.testing.expectEqual(@as(usize, 0), ring.len());
+
+    // Still usable afterward.
+    ring.push(try makeTestRecord(std.testing.allocator, 3));
+    try std.testing.expectEqual(@as(usize, 1), ring.len());
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer freeRecordSnapshot(std.testing.allocator, snap);
+    try std.testing.expectEqual(@as(i64, 3), snap[0].timestamp);
+}
+
+fn freeRecordSnapshot(allocator: std.mem.Allocator, snap: []PausedRequestRecord) void {
+    for (snap) |r| {
+        allocator.free(r.request_id);
+        allocator.free(r.url);
+        allocator.free(r.method);
+        allocator.free(r.resource_type);
+    }
+    allocator.free(snap);
+}
+
+test "RequestRing snapshot dupes record strings so rotation and clear can't free them underneath a reader" {
+    var ring = RequestRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    ring.push(try makeTestRecord(std.testing.allocator, 1));
+    ring.push(try makeTestRecord(std.testing.allocator, 2));
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer freeRecordSnapshot(std.testing.allocator, snap);
+    try std.testing.expectEqual(@as(usize, 2), snap.len);
+
+    const url_before = try std.testing.allocator.dupe(u8, snap[0].url);
+    defer std.testing.allocator.free(url_before);
+
+    // Both paths that free the ring's own copies: rotation (push) and clear.
+    // Either one running on the socket-draining thread while the router is
+    // still serializing `snap` must not disturb the snapshot's strings.
+    ring.push(try makeTestRecord(std.testing.allocator, 3));
+    ring.clear();
+
+    try std.testing.expectEqualStrings(url_before, snap[0].url);
+    try std.testing.expectEqual(@as(i64, 1), snap[0].timestamp);
+    try std.testing.expectEqual(@as(i64, 2), snap[1].timestamp);
+}
+
+test "CdpClient snapshotInterceptRules dupes rule fields independent of the client's own copies" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+
+    try client.setInterceptRules(&[_]InterceptRule{
+        .{ .url_substring = "/ads", .action = .fulfill, .status = 204, .body = "{}", .content_type = "application/json" },
+        .{ .url_substring = "/blocked", .action = .abort, .error_reason = "BlockedByClient" },
+    });
+
+    const snap = try client.snapshotInterceptRules(std.testing.allocator);
+    defer {
+        for (snap) |r| {
+            std.testing.allocator.free(r.url_substring);
+            std.testing.allocator.free(r.body);
+            std.testing.allocator.free(r.content_type);
+            std.testing.allocator.free(r.error_reason);
+        }
+        std.testing.allocator.free(snap);
+    }
+
+    try std.testing.expectEqual(@as(usize, 2), snap.len);
+    try std.testing.expectEqualStrings("/ads", snap[0].url_substring);
+    try std.testing.expectEqual(InterceptRule.Action.fulfill, snap[0].action);
+    try std.testing.expectEqual(@as(u16, 204), snap[0].status);
+    try std.testing.expectEqualStrings("/blocked", snap[1].url_substring);
+    try std.testing.expectEqualStrings("BlockedByClient", snap[1].error_reason);
+
+    // Clearing the client's live rules must not invalidate the snapshot.
+    client.clearInterceptRules();
+    try std.testing.expectEqualStrings("/ads", snap[0].url_substring);
+}
+
+test "CdpClient clearPausedRequests empties the ring without touching rules" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+
+    try client.addInterceptRule(.{ .url_substring = "/keep", .action = .@"continue" });
+    client.intercept.requests.push(try makeTestRecord(std.testing.allocator, 1));
+    try std.testing.expectEqual(@as(usize, 1), client.pausedRequestCount());
+
+    client.clearPausedRequests();
+    try std.testing.expectEqual(@as(usize, 0), client.pausedRequestCount());
+    try std.testing.expectEqual(@as(usize, 1), client.intercept.rules.items.len);
+}
+
+test "CdpClient setInterceptActive / interceptActive round-trip" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+
+    try std.testing.expect(!client.interceptActive());
+    client.setInterceptActive(true);
+    try std.testing.expect(client.interceptActive());
+    client.setInterceptActive(false);
+    try std.testing.expect(!client.interceptActive());
+}
+
+// ── autoRespondFetch: the critical default-continue property ───────────
+// These exercise field extraction and the ring/injected-id bookkeeping
+// directly. A full send-over-the-wire exercise of autoRespondFetch/Dialog
+// needs a live Chrome CDP endpoint (covered instead by the pre-existing
+// `zig build test` integration surface via the router layer once wired up).
+
+test "extractRequestPausedFields parses the real Fetch.requestPaused shape" {
+    const event =
+        \\{"method":"Fetch.requestPaused","params":{"requestId":"interception-job-1.0","request":{"url":"https://example.com/api/data","method":"POST","headers":{}},"resourceType":"XHR"}}
+    ;
+    const fields = CdpClient.extractRequestPausedFields(event).?;
+    try std.testing.expectEqualStrings("interception-job-1.0", fields.request_id);
+    try std.testing.expectEqualStrings("https://example.com/api/data", fields.url);
+    try std.testing.expectEqualStrings("POST", fields.method);
+    try std.testing.expectEqualStrings("XHR", fields.resource_type);
+}
+
+test "extractRequestPausedFields returns null on malformed event" {
+    try std.testing.expect(CdpClient.extractRequestPausedFields("{\"method\":\"Fetch.requestPaused\",\"params\":{}}") == null);
+}
+
+test "eventMatchesMethod recognizes Fetch.requestPaused and dialog events" {
+    try std.testing.expect(eventMatchesMethod("{\"method\":\"Fetch.requestPaused\",\"params\":{}}", "Fetch.requestPaused"));
+    try std.testing.expect(eventMatchesMethod("{\"method\":\"Page.javascriptDialogOpening\",\"params\":{}}", "Page.javascriptDialogOpening"));
+    try std.testing.expect(!eventMatchesMethod("{\"method\":\"Page.loadEventFired\",\"params\":{}}", "Fetch.requestPaused"));
+}
+
+// ── Generic CDP event collector: ScreencastRing ─────────────────────────
+
+fn makeScreencastFrame(allocator: std.mem.Allocator, size: usize, tag: u8) !ScreencastFrameRecord {
+    const data = try allocator.alloc(u8, size);
+    @memset(data, tag);
+    return .{ .data_b64 = data, .timestamp = 0, .device_width = 0, .device_height = 0, .session_id = 0 };
+}
+
+test "ScreencastRing evicts oldest by count when frames are individually small" {
+    var ring = ScreencastRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    var i: u32 = 0;
+    while (i < ScreencastRing.MAX_COUNT + 5) : (i += 1) {
+        ring.push(try makeScreencastFrame(std.testing.allocator, 16, @intCast(i % 256)));
+    }
+    try std.testing.expectEqual(@as(usize, ScreencastRing.MAX_COUNT), ring.len());
+}
+
+test "ScreencastRing evicts oldest frames to satisfy the byte cap, well before the count cap is hit" {
+    var ring = ScreencastRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    const frame_size = 12 * 1024 * 1024; // 12 MiB
+    ring.push(try makeScreencastFrame(std.testing.allocator, frame_size, 1));
+    ring.push(try makeScreencastFrame(std.testing.allocator, frame_size, 2));
+    try std.testing.expectEqual(@as(usize, 2), ring.len());
+
+    // A third 12 MiB frame would put total_bytes at ~36 MiB, over the 32
+    // MiB cap, while count sits at only 3 (nowhere near MAX_COUNT=30) --
+    // the oldest frame must be evicted to make room.
+    ring.push(try makeScreencastFrame(std.testing.allocator, frame_size, 3));
+    try std.testing.expectEqual(@as(usize, 2), ring.len());
+    try std.testing.expect(ring.total_bytes <= ScreencastRing.MAX_BYTES);
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer {
+        for (snap) |f| std.testing.allocator.free(f.data_b64);
+        std.testing.allocator.free(snap);
+    }
+    try std.testing.expectEqual(@as(u8, 2), snap[0].data_b64[0]);
+    try std.testing.expectEqual(@as(u8, 3), snap[1].data_b64[0]);
+}
+
+test "ScreencastRing drops a single frame that alone exceeds the byte cap, without touching existing frames" {
+    var ring = ScreencastRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    ring.push(try makeScreencastFrame(std.testing.allocator, 1024, 1));
+    try std.testing.expectEqual(@as(usize, 1), ring.len());
+
+    ring.push(try makeScreencastFrame(std.testing.allocator, ScreencastRing.MAX_BYTES + 1, 9));
+    try std.testing.expectEqual(@as(usize, 1), ring.len());
+    try std.testing.expectEqual(@as(usize, 1), ring.dropped_oversize);
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer {
+        for (snap) |f| std.testing.allocator.free(f.data_b64);
+        std.testing.allocator.free(snap);
+    }
+    try std.testing.expectEqual(@as(u8, 1), snap[0].data_b64[0]);
+}
+
+test "ScreencastRing snapshot dupes survive a later clear" {
+    var ring = ScreencastRing.init(std.testing.allocator);
+    defer ring.deinit();
+    ring.push(try makeScreencastFrame(std.testing.allocator, 8, 7));
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer {
+        for (snap) |f| std.testing.allocator.free(f.data_b64);
+        std.testing.allocator.free(snap);
+    }
+    ring.clear();
+
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expectEqual(@as(u8, 7), snap[0].data_b64[0]);
+    try std.testing.expectEqual(@as(usize, 0), ring.len());
+}
+
+// ── Generic CDP event collector: NetworkRing / BindingCallRing ──────────
+
+test "NetworkRing updateMimeType attaches to the matching record and findByUrlSubstring is last-match-wins" {
+    var ring = NetworkRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    ring.push(.{ .request_id = try std.testing.allocator.dupe(u8, "r1"), .url = try std.testing.allocator.dupe(u8, "https://example.com/a"), .url_truncated = false, .method = try std.testing.allocator.dupe(u8, "GET"), .mime_type = "", .timestamp = 1 });
+    ring.push(.{ .request_id = try std.testing.allocator.dupe(u8, "r2"), .url = try std.testing.allocator.dupe(u8, "https://example.com/api/b"), .url_truncated = false, .method = try std.testing.allocator.dupe(u8, "POST"), .mime_type = "", .timestamp = 2 });
+
+    const mime = try std.testing.allocator.dupe(u8, "application/json");
+    try std.testing.expect(ring.updateMimeType("r2", mime));
+    // Unknown request id: caller keeps ownership of the mime it tried to attach.
+    const orphan_mime = try std.testing.allocator.dupe(u8, "text/plain");
+    try std.testing.expect(!ring.updateMimeType("nope", orphan_mime));
+    std.testing.allocator.free(orphan_mime);
+
+    const found = try ring.findByUrlSubstring(std.testing.allocator, "/api/");
+    try std.testing.expect(found != null);
+    defer {
+        std.testing.allocator.free(found.?.request_id);
+        std.testing.allocator.free(found.?.url);
+        std.testing.allocator.free(found.?.method);
+        if (found.?.mime_type.len > 0) std.testing.allocator.free(found.?.mime_type);
+    }
+    try std.testing.expectEqualStrings("r2", found.?.request_id);
+    try std.testing.expectEqualStrings("application/json", found.?.mime_type);
+
+    try std.testing.expect(try ring.findByUrlSubstring(std.testing.allocator, "/nonexistent/") == null);
+}
+
+test "NetworkRing snapshot dupes survive a later clear (dupe-independence)" {
+    var ring = NetworkRing.init(std.testing.allocator);
+    defer ring.deinit();
+    ring.push(.{ .request_id = try std.testing.allocator.dupe(u8, "r1"), .url = try std.testing.allocator.dupe(u8, "https://example.com/x"), .url_truncated = false, .method = try std.testing.allocator.dupe(u8, "GET"), .mime_type = "", .timestamp = 5 });
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer {
+        for (snap) |r| {
+            std.testing.allocator.free(r.request_id);
+            std.testing.allocator.free(r.url);
+            std.testing.allocator.free(r.method);
+            if (r.mime_type.len > 0) std.testing.allocator.free(r.mime_type);
+        }
+        std.testing.allocator.free(snap);
+    }
+    ring.clear();
+
+    try std.testing.expectEqual(@as(usize, 1), snap.len);
+    try std.testing.expectEqualStrings("https://example.com/x", snap[0].url);
+    try std.testing.expectEqual(@as(usize, 0), ring.len());
+}
+
+test "BindingCallRing overflow evicts oldest and keeps cap" {
+    var ring = BindingCallRing.init(std.testing.allocator);
+    defer ring.deinit();
+
+    var i: u32 = 0;
+    while (i < BindingCallRing.CAP + 3) : (i += 1) {
+        ring.push(.{
+            .name = try std.testing.allocator.dupe(u8, "onMsg"),
+            .payload = try std.testing.allocator.dupe(u8, "x"),
+            .truncated = false,
+            .timestamp = @intCast(i),
+        });
+    }
+    try std.testing.expectEqual(@as(usize, BindingCallRing.CAP), ring.len());
+
+    const snap = try ring.snapshot(std.testing.allocator);
+    defer {
+        for (snap) |r| {
+            std.testing.allocator.free(r.name);
+            std.testing.allocator.free(r.payload);
+        }
+        std.testing.allocator.free(snap);
+    }
+    try std.testing.expectEqual(@as(i64, 3), snap[0].timestamp);
+}
+
+// ── Generic CDP event collector: TraceStreamState ───────────────────────
+
+test "TraceStreamState take is destructive: a second take sees nothing" {
+    var state = TraceStreamState.init(std.testing.allocator);
+    defer state.deinit();
+
+    state.set(.{
+        .stream_handle = try std.testing.allocator.dupe(u8, "42"),
+        .data_loss = false,
+        .trace_format = try std.testing.allocator.dupe(u8, "proto"),
+    });
+
+    const first = try state.take(std.testing.allocator);
+    try std.testing.expect(first != null);
+    defer {
+        std.testing.allocator.free(first.?.stream_handle);
+        if (first.?.trace_format.len > 0) std.testing.allocator.free(first.?.trace_format);
+    }
+    try std.testing.expectEqualStrings("42", first.?.stream_handle);
+
+    try std.testing.expect(try state.take(std.testing.allocator) == null);
+}
+
+// ── Generic CDP event collector: `collect` dispatch via CdpClient ──────
+
+fn makeDummyWs(read_buf: []u8) WebSocketClient {
+    return .{ .allocator = std.testing.allocator, .fd = -1, .connected = false, .read_buf = read_buf };
+}
+
+test "collect dispatches Runtime.bindingCalled to the registered handler and truncates oversized payloads" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+    var read_buf: [64]u8 = undefined;
+    var ws = makeDummyWs(&read_buf);
+
+    const big_payload = try std.testing.allocator.alloc(u8, BindingCallRecord.MAX_PAYLOAD + 500);
+    defer std.testing.allocator.free(big_payload);
+    @memset(big_payload, 'z');
+
+    const event = try std.fmt.allocPrint(std.testing.allocator, "{{\"method\":\"Runtime.bindingCalled\",\"params\":{{\"name\":\"onMsg\",\"payload\":\"{s}\"}}}}", .{big_payload});
+    const handled = client.collect(std.testing.allocator, event, &ws);
+    std.testing.allocator.free(event);
+
+    try std.testing.expect(handled);
+    try std.testing.expectEqual(@as(usize, 1), client.bindingCallCount());
+
+    const snap = try client.snapshotBindingCalls(std.testing.allocator);
+    defer {
+        for (snap) |r| {
+            std.testing.allocator.free(r.name);
+            std.testing.allocator.free(r.payload);
+        }
+        std.testing.allocator.free(snap);
+    }
+    try std.testing.expectEqualStrings("onMsg", snap[0].name);
+    try std.testing.expect(snap[0].truncated);
+    try std.testing.expectEqual(@as(usize, BindingCallRecord.MAX_PAYLOAD), snap[0].payload.len);
+}
+
+test "collect observes (never consumes) Network.requestWillBeSent/responseReceived so HAR still sees them" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+    var read_buf: [64]u8 = undefined;
+    var ws = makeDummyWs(&read_buf);
+
+    const req_event = try std.testing.allocator.dupe(u8, "{\"method\":\"Network.requestWillBeSent\",\"params\":{\"requestId\":\"42.1\",\"request\":{\"url\":\"https://example.com/api/data\",\"method\":\"POST\"}}}");
+    const handled1 = client.collect(std.testing.allocator, req_event, &ws);
+    std.testing.allocator.free(req_event);
+    try std.testing.expect(!handled1);
+    try std.testing.expectEqual(@as(usize, 1), client.networkRequestCount());
+
+    const resp_event = try std.testing.allocator.dupe(u8, "{\"method\":\"Network.responseReceived\",\"params\":{\"requestId\":\"42.1\",\"response\":{\"status\":200,\"mimeType\":\"application/json\"}}}");
+    const handled2 = client.collect(std.testing.allocator, resp_event, &ws);
+    std.testing.allocator.free(resp_event);
+    try std.testing.expect(!handled2);
+
+    const found = try client.findNetworkRequestByUrl(std.testing.allocator, "/api/data");
+    try std.testing.expect(found != null);
+    defer {
+        std.testing.allocator.free(found.?.request_id);
+        std.testing.allocator.free(found.?.url);
+        std.testing.allocator.free(found.?.method);
+        if (found.?.mime_type.len > 0) std.testing.allocator.free(found.?.mime_type);
+    }
+    try std.testing.expectEqualStrings("42.1", found.?.request_id);
+    try std.testing.expectEqualStrings("application/json", found.?.mime_type);
+}
+
+test "collect fully consumes Tracing.tracingComplete and feeds takeTraceStream" {
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+    var read_buf: [64]u8 = undefined;
+    var ws = makeDummyWs(&read_buf);
+
+    const event = try std.testing.allocator.dupe(u8, "{\"method\":\"Tracing.tracingComplete\",\"params\":{\"dataLoss\":false,\"stream\":\"42\",\"traceFormat\":\"proto\"}}");
+    const handled = client.collect(std.testing.allocator, event, &ws);
+    std.testing.allocator.free(event);
+    try std.testing.expect(handled);
+
+    const first = try client.takeTraceStream(std.testing.allocator);
+    try std.testing.expect(first != null);
+    defer {
+        std.testing.allocator.free(first.?.stream_handle);
+        if (first.?.trace_format.len > 0) std.testing.allocator.free(first.?.trace_format);
+    }
+    try std.testing.expectEqualStrings("42", first.?.stream_handle);
+    try std.testing.expectEqualStrings("proto", first.?.trace_format);
+    try std.testing.expect(!first.?.data_loss);
+
+    try std.testing.expect(try client.takeTraceStream(std.testing.allocator) == null);
+}
+
+test "waitForEvent runs collect on the exact matching event so collectTracingComplete isn't skipped" {
+    // Regression test: `waitForEvent`'s own fast path used to match the
+    // awaited event by method name and free it immediately, never routing
+    // it through `collect` -- so the ONE call site that both waits for
+    // Tracing.tracingComplete AND needs its payload (/trace/stop) always
+    // saw takeTraceStream() return null, even though Chrome's event
+    // genuinely carried a `stream` handle. This exercises the real
+    // `waitForEvent` -> socket-read -> match path end to end (a real
+    // WebSocket text frame over a socketpair), not just `collect` called
+    // directly, since that's exactly the integration path the bug lived in.
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    const c_socketpair = @extern(*const fn (c_int, c_int, c_int, *[2]c_int) callconv(.c) c_int, .{ .name = "socketpair" });
+    var fds: [2]c_int = undefined;
+    try std.testing.expect(c_socketpair(@intCast(std.posix.AF.UNIX), @intCast(std.posix.SOCK.STREAM), 0, &fds) == 0);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    var read_buf: [4096]u8 = undefined;
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+    client.ws = WebSocketClient{
+        .allocator = std.testing.allocator,
+        .fd = fds[0],
+        .connected = true,
+        .read_buf = &read_buf,
+    };
+
+    // Write a real, unmasked WebSocket text frame (servers never mask, per
+    // RFC 6455) carrying Tracing.tracingComplete with a stream handle --
+    // exactly what Chrome sends after Tracing.end when /trace/start asked
+    // for transferMode: ReturnAsStream.
+    const payload = "{\"method\":\"Tracing.tracingComplete\",\"params\":{\"dataLoss\":false,\"stream\":\"7\",\"traceFormat\":\"json\"}}";
+    var frame: [2 + payload.len]u8 = undefined;
+    frame[0] = 0x81; // FIN=1, opcode=1 (text)
+    frame[1] = @intCast(payload.len); // MASK bit unset, len < 126
+    @memcpy(frame[2..], payload);
+    try std.testing.expect(std.c.write(fds[1], &frame, frame.len) == frame.len);
+
+    try std.testing.expect(client.waitForEvent(std.testing.allocator, "Tracing.tracingComplete", 1));
+
+    const stream_rec = try client.takeTraceStream(std.testing.allocator);
+    try std.testing.expect(stream_rec != null);
+    defer {
+        std.testing.allocator.free(stream_rec.?.stream_handle);
+        if (stream_rec.?.trace_format.len > 0) std.testing.allocator.free(stream_rec.?.trace_format);
+    }
+    try std.testing.expectEqualStrings("7", stream_rec.?.stream_handle);
+    try std.testing.expectEqualStrings("json", stream_rec.?.trace_format);
+    try std.testing.expect(!stream_rec.?.data_loss);
+}
+
+test "collectScreencastFrame always acks inline via Page.screencastFrameAck and records the frame" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    const c_socketpair = @extern(*const fn (c_int, c_int, c_int, *[2]c_int) callconv(.c) c_int, .{ .name = "socketpair" });
+    var fds: [2]c_int = undefined;
+    try std.testing.expect(c_socketpair(@intCast(std.posix.AF.UNIX), @intCast(std.posix.SOCK.STREAM), 0, &fds) == 0);
+    defer _ = std.c.close(fds[0]);
+    defer _ = std.c.close(fds[1]);
+
+    var read_buf: [4096]u8 = undefined;
+    var ws = WebSocketClient{
+        .allocator = std.testing.allocator,
+        .fd = fds[0],
+        .connected = true,
+        .read_buf = &read_buf,
+    };
+
+    var client = CdpClient.init(std.testing.allocator, "ws://localhost:9222");
+    defer client.deinit();
+
+    const event = try std.testing.allocator.dupe(u8, "{\"method\":\"Page.screencastFrame\",\"params\":{\"data\":\"ZmFrZWpwZWc=\",\"metadata\":{\"timestamp\":123.5,\"deviceWidth\":800,\"deviceHeight\":600},\"sessionId\":42}}");
+    const handled = client.collect(std.testing.allocator, event, &ws);
+    std.testing.allocator.free(event);
+    try std.testing.expect(handled);
+
+    try std.testing.expectEqual(@as(usize, 1), client.screencastFrameCount());
+    const snap = try client.snapshotScreencastFrames(std.testing.allocator);
+    defer {
+        for (snap) |f| std.testing.allocator.free(f.data_b64);
+        std.testing.allocator.free(snap);
+    }
+    try std.testing.expectEqualStrings("ZmFrZWpwZWc=", snap[0].data_b64);
+    try std.testing.expectEqual(@as(u32, 800), snap[0].device_width);
+    try std.testing.expectEqual(@as(u32, 600), snap[0].device_height);
+
+    // An ack frame was written to the peer end of the socketpair over the
+    // real (masked) WebSocket wire format -- unmask it by hand to confirm
+    // it names the right method and sessionId.
+    var recv_buf: [512]u8 = undefined;
+    const n: usize = try std.posix.read(fds[1], &recv_buf);
+    try std.testing.expect(n >= 6);
+    try std.testing.expectEqual(@as(u8, 0x81), recv_buf[0]); // FIN=1, opcode=1 (text)
+    try std.testing.expect((recv_buf[1] & 0x80) != 0); // client frames are always masked
+    const payload_len: usize = recv_buf[1] & 0x7F;
+    try std.testing.expect(payload_len <= 125); // small ack payload, no extended length needed
+    try std.testing.expect(n >= 6 + payload_len);
+    const mask = recv_buf[2..6];
+    var decoded: [256]u8 = undefined;
+    for (0..payload_len) |i| decoded[i] = recv_buf[6 + i] ^ mask[i % 4];
+    const decoded_slice = decoded[0..payload_len];
+    try std.testing.expect(std.mem.indexOf(u8, decoded_slice, "Page.screencastFrameAck") != null);
+    try std.testing.expect(std.mem.indexOf(u8, decoded_slice, "\"sessionId\":42") != null);
+}
+
+test "CollectorState init/deinit round trip" {
+    var state = CollectorState.init(std.testing.allocator);
+    defer state.deinit();
+    try std.testing.expectEqual(@as(usize, 0), state.screencast.len());
+    try std.testing.expectEqual(@as(usize, 0), state.bindings.len());
+    try std.testing.expectEqual(@as(usize, 0), state.network.len());
+    try std.testing.expect(state.tracing.current == null);
 }

--- a/src/cdp/har.zig
+++ b/src/cdp/har.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const CdpClient = @import("client.zig").CdpClient;
 const compat = @import("../compat.zig");
+const jsonscan = @import("jsonscan.zig");
 
 /// HAR (HTTP Archive) recorder using CDP Network domain events.
 /// Captures request/response pairs with timing, headers, and status.
@@ -182,12 +183,12 @@ pub const HarRecorder = struct {
 
         if (std.mem.indexOf(u8, event_json, "\"Network.requestWillBeSent\"") != null) {
             // CDP shape: {"method":"Network.requestWillBeSent","params":{"requestId":"X","request":{"url":"...","method":"GET",...},...}}
-            const request_id = extractField(event_json, "requestId") orelse return;
+            const request_id = jsonscan.extractField(event_json, "requestId") orelse return;
             // url and method are inside the nested "request" object — search after "\"request\":{" to skip the top-level "method" field
             const request_obj_pos = std.mem.indexOf(u8, event_json, "\"request\":{") orelse return;
             const request_obj = event_json[request_obj_pos..];
-            const url = extractField(request_obj, "url") orelse return;
-            const method = extractField(request_obj, "method") orelse "GET";
+            const url = jsonscan.extractField(request_obj, "url") orelse return;
+            const method = jsonscan.extractField(request_obj, "method") orelse "GET";
 
             const owned_id = self.allocator.dupe(u8, request_id) catch return;
             const owned_url = self.allocator.dupe(u8, url) catch {
@@ -200,10 +201,10 @@ pub const HarRecorder = struct {
                 return;
             };
             // Capture request headers JSON blob
-            const headers_json = extractHeadersObject(request_obj) orelse "";
+            const headers_json = jsonscan.extractObject(request_obj, "headers") orelse "";
             const owned_headers = if (headers_json.len > 0) self.allocator.dupe(u8, headers_json) catch "" else "";
             // Capture POST body if present
-            const post_data = extractField(request_obj, "postData") orelse "";
+            const post_data = jsonscan.extractField(request_obj, "postData") orelse "";
             const owned_post = if (post_data.len > 0) self.allocator.dupe(u8, post_data) catch "" else "";
             const pending = PendingRequest{
                 .url = owned_url,
@@ -220,7 +221,7 @@ pub const HarRecorder = struct {
                 if (owned_post.len > 0) self.allocator.free(owned_post);
             };
         } else if (std.mem.indexOf(u8, event_json, "\"Network.responseReceived\"") != null) {
-            const request_id = extractField(event_json, "requestId") orelse return;
+            const request_id = jsonscan.extractField(event_json, "requestId") orelse return;
             const pending_kv = self.pending_requests.fetchRemove(request_id) orelse return;
             const pending = pending_kv.value;
             defer {
@@ -234,13 +235,13 @@ pub const HarRecorder = struct {
             // Extract status and mimeType from the nested "response" object
             const response_obj_pos = std.mem.indexOf(u8, event_json, "\"response\":{");
             const search_json = if (response_obj_pos) |pos| event_json[pos..] else event_json;
-            const status_str = extractField(search_json, "status");
+            const status_str = jsonscan.extractField(search_json, "status");
             const status: u16 = if (status_str) |s|
                 std.fmt.parseInt(u16, s, 10) catch 200
             else
                 200;
-            const mime = extractField(search_json, "mimeType") orelse "application/octet-stream";
-            const status_text = extractField(search_json, "statusText") orelse if (status >= 200 and status < 300) "OK" else if (status >= 300 and status < 400) "Redirect" else if (status >= 400) "Error" else "Unknown";
+            const mime = jsonscan.extractField(search_json, "mimeType") orelse "application/octet-stream";
+            const status_text = jsonscan.extractField(search_json, "statusText") orelse if (status >= 200 and status < 300) "OK" else if (status >= 300 and status < 400) "Redirect" else if (status >= 400) "Error" else "Unknown";
 
             self.addEntry(.{
                 .url = pending.url,
@@ -256,53 +257,6 @@ pub const HarRecorder = struct {
                 .post_data = pending.post_data,
             }) catch return;
         }
-    }
-
-    /// Extract the "headers":{...} object as a raw JSON string from a CDP request object.
-    fn extractHeadersObject(json: []const u8) ?[]const u8 {
-        const key = "\"headers\":{";
-        const key_pos = std.mem.indexOf(u8, json, key) orelse return null;
-        const obj_start = key_pos + key.len - 1; // include the {
-        var depth: usize = 0;
-        var i = obj_start;
-        while (i < json.len) : (i += 1) {
-            if (json[i] == '{') depth += 1 else if (json[i] == '}') {
-                depth -= 1;
-                if (depth == 0) return json[obj_start .. i + 1];
-            }
-        }
-        return null;
-    }
-
-    /// Extract a simple string or scalar field value from JSON.
-    fn extractField(json: []const u8, field: []const u8) ?[]const u8 {
-        var search_buf: [256]u8 = undefined;
-        const prefix = std.fmt.bufPrint(&search_buf, "\"{s}\"", .{field}) catch return null;
-
-        const field_pos = std.mem.indexOf(u8, json, prefix) orelse return null;
-        const after_field = field_pos + prefix.len;
-
-        // Skip colon and whitespace
-        var i = after_field;
-        while (i < json.len and (json[i] == ':' or json[i] == ' ' or json[i] == '\t')) : (i += 1) {}
-        if (i >= json.len) return null;
-
-        if (json[i] == '"') {
-            const val_start = i + 1;
-            const val_end = std.mem.indexOfScalarPos(u8, json, val_start, '"') orelse return null;
-            return json[val_start..val_end];
-        }
-
-        const val_start = i;
-        var val_end = i;
-        while (val_end < json.len) : (val_end += 1) {
-            switch (json[val_end]) {
-                ',', '}', ']', ' ', '\t', '\r', '\n' => break,
-                else => {},
-            }
-        }
-        if (val_end == val_start) return null;
-        return json[val_start..val_end];
     }
 
     pub fn deinit(self: *HarRecorder) void {
@@ -462,28 +416,34 @@ test "HarRecorder start clears stale pending requests before enabling network" {
     try std.testing.expectEqual(@as(usize, 0), rec.pending_requests.count());
 }
 
-test "HarRecorder extractField helper" {
+test "HarRecorder event parsing relies on jsonscan.extractField" {
+    // har.zig used to hand-roll its own extractField/extractHeadersObject
+    // (not escape-aware, not string-aware brace counting -- see jsonscan.zig's
+    // doc comment for the failure modes that motivated it). Both were deleted
+    // in favor of the shared, already-tested `jsonscan` module; these two
+    // tests now exercise that module directly through the same call shape
+    // `handleCdpEvent` uses.
     const json = "{\"method\":\"Network.requestWillBeSent\",\"requestId\":\"abc123\",\"url\":\"https://test.com\"}";
-    const rid = HarRecorder.extractField(json, "requestId");
+    const rid = jsonscan.extractField(json, "requestId");
     try std.testing.expect(rid != null);
     try std.testing.expectEqualStrings("abc123", rid.?);
 
-    const url = HarRecorder.extractField(json, "url");
+    const url = jsonscan.extractField(json, "url");
     try std.testing.expect(url != null);
     try std.testing.expectEqualStrings("https://test.com", url.?);
 
-    const missing = HarRecorder.extractField(json, "nonexistent");
+    const missing = jsonscan.extractField(json, "nonexistent");
     try std.testing.expect(missing == null);
 }
 
-test "HarRecorder extractField parses numeric values" {
+test "HarRecorder event parsing parses numeric field values via jsonscan.extractField" {
     const json = "{\"status\":304,\"encodedDataLength\":512}";
 
-    const status = HarRecorder.extractField(json, "status");
+    const status = jsonscan.extractField(json, "status");
     try std.testing.expect(status != null);
     try std.testing.expectEqualStrings("304", status.?);
 
-    const length = HarRecorder.extractField(json, "encodedDataLength");
+    const length = jsonscan.extractField(json, "encodedDataLength");
     try std.testing.expect(length != null);
     try std.testing.expectEqualStrings("512", length.?);
 }

--- a/src/cdp/js/console_collector.js
+++ b/src/cdp/js/console_collector.js
@@ -1,0 +1,65 @@
+// kuri console + error collector.
+// Injected on every new document (via Page.addScriptToEvaluateOnNewDocument)
+// and once into the live page. Populates window.__kuri_console and
+// window.__kuri_errors, which the /console and /errors endpoints read + clear.
+// Runs before page scripts so it captures console output and errors from load.
+(function () {
+  if (window.__kuri_collector_installed) return;
+  window.__kuri_collector_installed = true;
+  window.__kuri_console = window.__kuri_console || [];
+  window.__kuri_errors = window.__kuri_errors || [];
+
+  var MAX = 500;
+  function trim(a) { if (a.length > MAX) a.splice(0, a.length - MAX); }
+
+  function fmt(args) {
+    try {
+      return Array.prototype.map.call(args, function (a) {
+        if (a instanceof Error) return a.stack || (a.name + ": " + a.message);
+        if (a && typeof a === "object") {
+          try { return JSON.stringify(a); } catch (e) { return String(a); }
+        }
+        return String(a);
+      }).join(" ");
+    } catch (e) { return ""; }
+  }
+
+  ["log", "info", "warn", "error", "debug"].forEach(function (level) {
+    var orig = (console && console[level]) ? console[level].bind(console) : function () {};
+    console[level] = function () {
+      try {
+        window.__kuri_console.push({ type: level, text: fmt(arguments), ts: Date.now() });
+        trim(window.__kuri_console);
+      } catch (e) {}
+      return orig.apply(console, arguments);
+    };
+  });
+
+  window.addEventListener("error", function (e) {
+    try {
+      window.__kuri_errors.push({
+        type: "error",
+        text: e.message || String((e && e.error) || "error"),
+        source: e.filename || "",
+        line: e.lineno || 0,
+        col: e.colno || 0,
+        stack: (e.error && e.error.stack) || "",
+        ts: Date.now()
+      });
+      trim(window.__kuri_errors);
+    } catch (_) {}
+  }, true);
+
+  window.addEventListener("unhandledrejection", function (e) {
+    try {
+      var r = e && e.reason;
+      window.__kuri_errors.push({
+        type: "unhandledrejection",
+        text: (r && (r.message || String(r))) || "unhandledrejection",
+        stack: (r && r.stack) || "",
+        ts: Date.now()
+      });
+      trim(window.__kuri_errors);
+    } catch (_) {}
+  });
+})();

--- a/src/cdp/js/react_fiber.js
+++ b/src/cdp/js/react_fiber.js
@@ -1,0 +1,407 @@
+// kuri React fiber introspector.
+//
+// Injected on every new document (via Page.addScriptToEvaluateOnNewDocument)
+// and once into the live page, same dual pattern as stealth.js and
+// console_collector.js. Populates window.__kuri_react, a small namespace of
+// entry points read by the /react/tree, /react/inspect, /react/renders and
+// /react/suspense endpoints.
+//
+// Deliberately does NOT depend on window.__REACT_DEVTOOLS_GLOBAL_HOOK__ being
+// populated by a real extension -- kuri runs in an automated Chrome with no
+// DevTools extension installed, so that hook never exists on its own. Fibers
+// are found directly via the `__reactFiber$*` / `__reactContainer$*` /
+// `__reactInternalInstance$*` own-properties react-dom stamps onto DOM nodes.
+// A lightweight hook *stub* is installed only so react-dom's own `inject()`
+// call (which happens unconditionally on init, hook-or-no-hook) hands us the
+// renderer version and a commit callback for free -- kuri never behaves like
+// a real DevTools backend and never claims to.
+(function () {
+  if (window.__kuri_react) return;
+
+  var K = (window.__kuri_react = {
+    _registry: new Map(), // id -> fiber, cleared + repopulated by every /react/tree or /react/suspense call
+    _nextId: 1,
+    _renderers: {}, // rendererId -> {version, rendererPackageName}, populated by the hook-stub's inject()
+    _commitLog: [], // bounded ring, populated by onCommitFiberRoot
+  });
+  var MAX_COMMITS = 200;
+
+  // ---- version-detection + commit-observation hook stub ----
+  // Never overwrite a real extension's hook if one somehow exists.
+  if (!window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+    var nextRendererId = 0;
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      supportsFiber: true,
+      renderers: new Map(),
+      inject: function (renderer) {
+        nextRendererId++;
+        K._renderers[nextRendererId] = {
+          version: renderer.version || null,
+          rendererPackageName: renderer.rendererPackageName || null,
+        };
+        this.renderers.set(nextRendererId, renderer);
+        return nextRendererId;
+      },
+      onScheduleFiberRoot: function () {},
+      onCommitFiberRoot: function (id) {
+        try {
+          K._commitLog.push({ ts: Date.now(), rendererId: id });
+          if (K._commitLog.length > MAX_COMMITS) K._commitLog.splice(0, K._commitLog.length - MAX_COMMITS);
+        } catch (e) {}
+      },
+      onCommitFiberUnmount: function () {},
+      checkDCE: function () {},
+    };
+  }
+
+  function versionInfo() {
+    var ids = Object.keys(K._renderers);
+    for (var i = 0; i < ids.length; i++) {
+      var r = K._renderers[ids[i]];
+      if (r && r.version) return { version: r.version, versionSource: "devtools-hook" };
+    }
+    if (window.React && window.React.version) return { version: window.React.version, versionSource: "window.React" };
+    return { version: null, versionSource: "unknown" };
+  }
+
+  // ---- fiber-key discovery: no devtools hook needed ----
+  function keyOn(el, prefix) {
+    var names = Object.getOwnPropertyNames(el);
+    for (var i = 0; i < names.length; i++) if (names[i].indexOf(prefix) === 0) return names[i];
+    return null;
+  }
+  function getFiberForElement(el) {
+    var k = keyOn(el, "__reactFiber$") || keyOn(el, "__reactInternalInstance$"); // 17+ / 16
+    return k ? el[k] : null;
+  }
+
+  // React double-buffers fibers: every fiber has an `alternate`, and each
+  // commit swaps which of the pair is "current". The `__reactContainer$`
+  // property is stamped on the container element once at mount and keeps
+  // pointing at whichever HostRoot fiber existed then — so after the very
+  // first commit it is typically the OFF-SCREEN one, whose `.child` is null.
+  // Walking it yields a root with zero children on every real app (verified
+  // against React 19.2.5 / TodoMVC: hasChild=false, alternate.child=truthy).
+  // Always prefer whichever side of the pair actually has a rendered tree.
+  function currentSide(fiber) {
+    if (!fiber) return fiber;
+    if (fiber.child) return fiber;
+    if (fiber.alternate && fiber.alternate.child) return fiber.alternate;
+    return fiber;
+  }
+
+  var MAX_SCAN = 20000; // safety valve on pathological DOMs
+  function findRoots() {
+    var roots = [];
+    var all = document.getElementsByTagName("*");
+    var n = Math.min(all.length, MAX_SCAN);
+    for (var i = 0; i < n; i++) {
+      var ck = keyOn(all[i], "__reactContainer$"); // value is the HostRoot fiber directly
+      if (ck) roots.push(currentSide(all[i][ck]));
+    }
+    if (roots.length === 0) {
+      for (var j = 0; j < n; j++) {
+        var f = getFiberForElement(all[j]);
+        if (f) {
+          while (f.return) f = f.return;
+          roots.push(currentSide(f));
+          break;
+        }
+      }
+    }
+    return roots;
+  }
+
+  // ---- classification: prefer Symbol.for('react.*') over fiber.tag numbers ----
+  function sf(name) {
+    try {
+      return Symbol.for(name);
+    } catch (e) {
+      return null;
+    }
+  }
+  var SYM = {
+    suspense: sf("react.suspense"),
+    suspense_list: sf("react.suspense_list"),
+    fragment: sf("react.fragment"),
+    strict_mode: sf("react.strict_mode"),
+    profiler: sf("react.profiler"),
+    provider: sf("react.provider"),
+    context: sf("react.context"),
+    forward_ref: sf("react.forward_ref"),
+    memo: sf("react.memo"),
+    offscreen: sf("react.offscreen"),
+    activity: sf("react.activity"),
+    element: sf("react.element"),
+  };
+  function displayName(t) {
+    return t ? t.displayName || t.name || null : null;
+  }
+
+  function classifyFiber(fiber) {
+    var type = fiber.type;
+    if (type && type.$$typeof) {
+      if (type.$$typeof === SYM.forward_ref) return { kind: "ForwardRef", name: displayName(type.render) || "(ForwardRef)" };
+      if (type.$$typeof === SYM.memo) return { kind: "Memo", name: displayName(type.type) || "(Memo)" };
+      if (type.$$typeof === SYM.provider) return { kind: "Context.Provider", name: displayName(type._context) || "Provider" };
+      if (type.$$typeof === SYM.context) return { kind: "Context.Consumer", name: "Consumer" };
+    }
+    if (type === SYM.suspense) return { kind: "Suspense", name: "Suspense" };
+    if (type === SYM.suspense_list) return { kind: "SuspenseList", name: "SuspenseList" };
+    if (type === SYM.fragment) return { kind: "Fragment", name: "Fragment" };
+    if (type === SYM.strict_mode) return { kind: "StrictMode", name: "StrictMode" };
+    if (type === SYM.profiler) return { kind: "Profiler", name: (fiber.pendingProps && fiber.pendingProps.id) || "Profiler" };
+    if (type === SYM.offscreen || type === SYM.activity) return { kind: "Offscreen", name: "Offscreen" };
+    if (type === null) {
+      var isText = fiber.tag === 6; // no Symbol exists for host text; tag is the only signal
+      return isText ? { kind: "HostText", name: null } : { kind: "Root", name: "#root" };
+    }
+    if (typeof type === "string") return { kind: "HostComponent", name: type }; // 'div', 'span', ...
+    if (typeof type === "function") {
+      var isClass = !!(type.prototype && type.prototype.isReactComponent);
+      return { kind: isClass ? "ClassComponent" : "FunctionComponent", name: displayName(type) || "(anonymous)" };
+    }
+    return { kind: "tag" + fiber.tag, name: "(unrecognized)" };
+  }
+
+  // ---- safe serializer: depth cap + array/key caps + total-value budget + cycle guard ----
+  function safeSerialize(value, depth, seenStack, maxDepth, budget) {
+    if (budget.n++ > budget.cap) return { __kuri: "truncated", reason: "max-values" };
+    if (depth > maxDepth) return { __kuri: "truncated", reason: "max-depth" };
+    if (value === undefined) return { __kuri: "undefined" };
+    if (value === null) return null;
+    var t = typeof value;
+    if (t === "string") return value.length > 2000 ? value.slice(0, 2000) + "…" : value;
+    if (t === "number" || t === "boolean") return value;
+    if (t === "function") return { __kuri: "function", name: value.name || "(anonymous)" };
+    if (t === "symbol") return { __kuri: "symbol", description: String(value) };
+    if (t === "bigint") return { __kuri: "bigint", value: value.toString() };
+    if (t !== "object") return String(value);
+
+    if (seenStack.indexOf(value) !== -1) return { __kuri: "circular" };
+    if (typeof Node !== "undefined" && value instanceof Node)
+      return { __kuri: "domnode", tag: (value.nodeName || "?").toLowerCase(), id: value.id || undefined };
+    if (value.$$typeof === SYM.element) return { __kuri: "reactelement", type: displayName(value.type) || String(value.type) };
+    if (value instanceof Error) return { __kuri: "error", name: value.name, message: value.message };
+
+    seenStack.push(value);
+    try {
+      if (Array.isArray(value)) {
+        var lim = Math.min(value.length, 50);
+        var arr = [];
+        for (var i = 0; i < lim; i++) arr.push(safeSerialize(value[i], depth + 1, seenStack, maxDepth, budget));
+        if (value.length > lim) arr.push({ __kuri: "truncated", reason: "max-array-len", remaining: value.length - lim });
+        return arr;
+      }
+      if (value instanceof Map || value instanceof Set) {
+        var items = [];
+        var k2 = 0;
+        var isMap = value instanceof Map;
+        value.forEach(function (v, k) {
+          if (k2++ >= 50) return;
+          items.push(isMap ? [safeSerialize(k, depth + 1, seenStack, maxDepth, budget), safeSerialize(v, depth + 1, seenStack, maxDepth, budget)] : safeSerialize(v, depth + 1, seenStack, maxDepth, budget));
+        });
+        return { __kuri: isMap ? "map" : "set", size: value.size, entries: items };
+      }
+      var keys;
+      try {
+        keys = Object.keys(value);
+      } catch (e) {
+        return { __kuri: "unserializable", error: String(e && e.message) };
+      }
+      var res = {};
+      var kn = Math.min(keys.length, 50);
+      for (var ki = 0; ki < kn; ki++) {
+        try {
+          res[keys[ki]] = safeSerialize(value[keys[ki]], depth + 1, seenStack, maxDepth, budget);
+        } catch (e2) {
+          res[keys[ki]] = { __kuri: "unserializable", error: String(e2 && e2.message) };
+        }
+      }
+      if (keys.length > kn) res.__kuriTruncatedKeys = keys.length - kn;
+      return res;
+    } finally {
+      seenStack.pop(); // pop, don't keep -- allows the same object at sibling branches (a diamond, not a cycle)
+    }
+  }
+
+  // ---- /react/tree ----
+  K.tree = function (opts) {
+    opts = opts || {};
+    var maxNodes = Math.min(opts.maxNodes || 500, 3000);
+    var maxDepth = Math.min(opts.maxDepth || 40, 150); // recursion depth == maxDepth, safe for JS's call stack
+    var includeHostText = !!opts.includeHostText;
+    var roots = findRoots();
+    if (roots.length === 0) return { react: false };
+
+    K._registry.clear();
+    K._nextId = 1;
+    var vi = versionInfo();
+    var out = { react: true, version: vi.version, versionSource: vi.versionSource, roots: [], truncated: false, nodeCount: 0 };
+    for (var r = 0; r < roots.length; r++) out.roots.push(build(roots[r], 0));
+    return out;
+
+    function build(fiber, depth) {
+      out.nodeCount++;
+      var info = classifyFiber(fiber);
+      var id = "k" + K._nextId++;
+      K._registry.set(id, fiber);
+      var node = {
+        id: id,
+        name: info.name,
+        kind: info.kind,
+        key: fiber.key != null ? String(fiber.key) : null,
+        depth: depth,
+        children: [],
+      };
+      if (depth >= maxDepth) {
+        node.truncated = true;
+        out.truncated = true;
+        delete node.children;
+        return node;
+      }
+      var child = fiber.child;
+      while (child) {
+        if (!includeHostText && child.tag === 6) {
+          child = child.sibling;
+          continue;
+        }
+        if (out.nodeCount >= maxNodes) {
+          node.moreChildren = true;
+          out.truncated = true;
+          break;
+        }
+        node.children.push(build(child, depth + 1));
+        child = child.sibling;
+      }
+      return node;
+    }
+  };
+
+  // ---- /react/inspect ----
+  function inspectFiber(fiber) {
+    if (!fiber) return { ok: false, react: true, error: "no fiber" };
+    var info = classifyFiber(fiber);
+    var maxDepth = 6;
+    var budget = { n: 0, cap: 2000 };
+    var isClass = !!(fiber.type && fiber.type.prototype && fiber.type.prototype.isReactComponent);
+    var props = safeSerialize(fiber.memoizedProps, 0, [], maxDepth, budget);
+    var state = isClass ? safeSerialize(fiber.memoizedState, 0, [], maxDepth, budget) : null;
+    var hooks = !isClass && typeof fiber.type === "function" ? walkHooks(fiber.memoizedState, maxDepth, budget) : null;
+    return {
+      ok: true,
+      react: true,
+      name: info.name,
+      kind: info.kind,
+      key: fiber.key != null ? String(fiber.key) : null,
+      props: props,
+      state: state,
+      hooks: hooks,
+      source: fiber._debugSource ? { fileName: fiber._debugSource.fileName, lineNumber: fiber._debugSource.lineNumber } : null,
+    };
+  }
+  function walkHooks(memoizedState, maxDepth, budget) {
+    var out = [];
+    var h = memoizedState;
+    var i = 0;
+    while (h && i < 200) {
+      out.push({ index: i, value: safeSerialize(h.memoizedState, 0, [], maxDepth, budget) });
+      h = h.next;
+      i++;
+    }
+    if (h) out.push({ __kuri: "truncated", reason: "max-hooks" });
+    return out;
+  }
+  K.inspect = function (opts) {
+    opts = opts || {};
+    if (findRoots().length === 0) return { react: false };
+    var fiber = null;
+    if (opts.id) fiber = K._registry.get(opts.id) || null;
+    else if (opts.selector) {
+      var el = document.querySelector(opts.selector);
+      fiber = el ? getFiberForElement(el) : null;
+    }
+    if (!fiber)
+      return {
+        ok: false,
+        react: true,
+        error: opts.id ? "unknown id (ids reset on every /react/tree or /react/suspense call)" : "selector matched no element with a React fiber",
+      };
+    return inspectFiber(fiber);
+  };
+  K.inspectElement = function (el) {
+    // entry point for the ref path (`this` bound via Runtime.callFunctionOn)
+    if (findRoots().length === 0) return { react: false };
+    var fiber = getFiberForElement(el);
+    return fiber ? inspectFiber(fiber) : { ok: false, react: true, error: "element has no React fiber" };
+  };
+
+  // ---- /react/renders ----
+  // Not the Profiler API (that needs the profiling bundle + explicit
+  // start/stopProfiling and is a much heavier commitment than this endpoint
+  // warrants). Instead: a real, small, bounded commit log fed by the hook
+  // stub's onCommitFiberRoot, which fires on every commit -- but only for
+  // commits that happen *after* kuri's persistent script installed the stub,
+  // and only if it was installed before react-dom's own init ran (i.e. this
+  // is the persistent Page.addScriptToEvaluateOnNewDocument copy, not the
+  // one-shot patch of an already-running page). hookAttachedBeforeInit tells
+  // the caller whether that happened for this page load.
+  K.renders = function () {
+    if (findRoots().length === 0) return { react: false };
+    var vi = versionInfo();
+    var attached = Object.keys(K._renderers).length > 0;
+    return {
+      ok: true,
+      react: true,
+      version: vi.version,
+      versionSource: vi.versionSource,
+      hookAttachedBeforeInit: attached,
+      commits: K._commitLog.slice(),
+      note: attached
+        ? "commit timestamps observed since kuri attached"
+        : "no commits observed -- this page loaded before kuri's persistent hook was installed, or nothing has re-rendered yet; reload the page to get commit tracking",
+    };
+  };
+
+  // ---- /react/suspense ----
+  K.suspense = function (opts) {
+    opts = opts || {};
+    var maxNodes = Math.min(opts.maxNodes || 500, 3000);
+    var maxDepth = Math.min(opts.maxDepth || 150, 300);
+    var roots = findRoots();
+    if (roots.length === 0) return { react: false };
+    K._registry.clear();
+    K._nextId = 1;
+    var out = { react: true, ok: true, boundaries: [], truncated: false };
+    var count = 0;
+
+    function walk(fiber, path, depth) {
+      if (count >= maxNodes) {
+        out.truncated = true;
+        return;
+      }
+      if (depth > maxDepth) {
+        out.truncated = true;
+        return;
+      }
+      count++;
+      var info = classifyFiber(fiber);
+      var nextPath = path;
+      if (info.kind === "Suspense") {
+        var id = "k" + K._nextId++;
+        K._registry.set(id, fiber);
+        out.boundaries.push({ id: id, path: path.slice(), showingFallback: fiber.memoizedState !== null });
+        nextPath = path.concat([info.name || "Suspense"]);
+      } else if (info.name) {
+        nextPath = path.concat([info.name]);
+      }
+      var child = fiber.child;
+      while (child && count < maxNodes) {
+        walk(child, nextPath, depth + 1);
+        child = child.sibling;
+      }
+    }
+    for (var r = 0; r < roots.length && count < maxNodes; r++) walk(roots[r], [], 0);
+    return out;
+  };
+})();

--- a/src/cdp/js/stealth.js
+++ b/src/cdp/js/stealth.js
@@ -1,65 +1,79 @@
-// Stealth script — injected via Page.addScriptToEvaluateOnNewDocument
-// Hides automation indicators from bot detection
+// Stealth script — injected via Page.addScriptToEvaluateOnNewDocument AND
+// evaluated once into the already-loaded page (same dual pattern as
+// console_collector.js / react_fiber.js).
+//
+// That dual injection is why this whole file is an IIFE with an idempotence
+// guard. Previously the body was top-level, so re-running it in the SAME
+// global (which happens whenever discoverTabs re-runs against a live tab)
+// re-declared `const originalQuery` — a SyntaxError that (a) aborted the
+// entire re-injection at parse time, so nothing after it applied, and (b)
+// surfaced in the page's error stream, polluting /errors with a kuri-internal
+// failure on every page. The guard also prevents the permissions-query
+// wrapper from being wrapped around itself on repeat application.
+(function () {
+    if (window.__kuri_stealth_applied) return;
+    window.__kuri_stealth_applied = true;
 
-// 1. Override navigator.webdriver
-Object.defineProperty(navigator, 'webdriver', {
-    get: () => false,
-    configurable: true,
-});
+    // 1. Override navigator.webdriver
+    Object.defineProperty(navigator, 'webdriver', {
+        get: () => false,
+        configurable: true,
+    });
 
-// 2. Fake plugins array (Chrome normally has plugins)
-Object.defineProperty(navigator, 'plugins', {
-    get: () => {
-        const plugins = [
-            { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
-            { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
-            { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' },
-        ];
-        plugins.length = 3;
-        return plugins;
-    },
-    configurable: true,
-});
+    // 2. Fake plugins array (Chrome normally has plugins)
+    Object.defineProperty(navigator, 'plugins', {
+        get: () => {
+            const plugins = [
+                { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer', description: 'Portable Document Format' },
+                { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai', description: '' },
+                { name: 'Native Client', filename: 'internal-nacl-plugin', description: '' },
+            ];
+            plugins.length = 3;
+            return plugins;
+        },
+        configurable: true,
+    });
 
-// 3. Fake languages
-Object.defineProperty(navigator, 'languages', {
-    get: () => ['en-US', 'en'],
-    configurable: true,
-});
+    // 3. Fake languages
+    Object.defineProperty(navigator, 'languages', {
+        get: () => ['en-US', 'en'],
+        configurable: true,
+    });
 
-// 4. Override chrome.runtime to appear as real Chrome
-if (!window.chrome) {
-    window.chrome = {};
-}
-if (!window.chrome.runtime) {
-    window.chrome.runtime = {
-        connect: () => {},
-        sendMessage: () => {},
-        id: undefined,
-    };
-}
-
-// 5. Override permissions query
-const originalQuery = window.navigator.permissions?.query;
-if (originalQuery) {
-    window.navigator.permissions.query = (parameters) => {
-        if (parameters.name === 'notifications') {
-            return Promise.resolve({ state: Notification.permission });
-        }
-        return originalQuery(parameters);
-    };
-}
-
-// 6. Spoof iframe contentWindow
-try {
-    const elementDescriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
-    if (elementDescriptor) {
-        Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
-            get: function () {
-                return elementDescriptor.get.call(this);
-            },
-        });
+    // 4. Override chrome.runtime to appear as real Chrome
+    if (!window.chrome) {
+        window.chrome = {};
     }
-} catch (e) {
-    // Silently fail
-}
+    if (!window.chrome.runtime) {
+        window.chrome.runtime = {
+            connect: () => {},
+            sendMessage: () => {},
+            id: undefined,
+        };
+    }
+
+    // 5. Override permissions query
+    const originalQuery = window.navigator.permissions?.query;
+    if (originalQuery) {
+        window.navigator.permissions.query = (parameters) => {
+            if (parameters.name === 'notifications') {
+                return Promise.resolve({ state: Notification.permission });
+            }
+            return originalQuery(parameters);
+        };
+    }
+
+    // 6. Spoof iframe contentWindow
+    try {
+        const elementDescriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+        if (elementDescriptor) {
+            Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+                get: function () {
+                    return elementDescriptor.get.call(this);
+                },
+            });
+        }
+    } catch (e) {
+        // Silently fail
+    }
+})();

--- a/src/cdp/jsonscan.zig
+++ b/src/cdp/jsonscan.zig
@@ -1,0 +1,209 @@
+const std = @import("std");
+
+/// Hand-rolled, zero-copy JSON substring scanning shared by the CDP event
+/// consumers (`har.zig`'s Network event parsing and `client.zig`'s in-read-
+/// loop Fetch.requestPaused handling). Deliberately NOT `std.json` — these
+/// call sites need cheap substring slicing per CDP event, not a parse tree,
+/// and this matches the pre-existing idiom in `har.zig` (see
+/// `extractField`/`extractHeadersObject`, which this module generalizes).
+///
+/// All returned slices borrow from the input `json` slice — callers must
+/// `allocator.dupe(...)` anything they need to outlive it.
+/// Extract the object value for `key` (e.g. "request", "response", "headers")
+/// as a raw JSON substring, by counting brace depth from the object's `{`.
+/// Returns null if `key` isn't found as an object (i.e. `"key":{`) or the
+/// object never closes (malformed/truncated JSON).
+pub fn extractObject(json: []const u8, key: []const u8) ?[]const u8 {
+    var key_buf: [256]u8 = undefined;
+    const needle = std.fmt.bufPrint(&key_buf, "\"{s}\":{{", .{key}) catch return null;
+    const key_pos = std.mem.indexOf(u8, json, needle) orelse return null;
+    const obj_start = key_pos + needle.len - 1; // include the opening {
+
+    // Brace-depth counting must be JSON-string-aware: a literal '{' or '}'
+    // inside a string value (e.g. an unescaped '{' in a request URL's query
+    // string — '{'/'}' are NOT in the WHATWG URL query percent-encode set,
+    // so they pass through a real browser request unescaped) would otherwise
+    // desync `depth` and either return null (hanging a paused Fetch request
+    // forever, since the caller never replies to Chrome) or return a
+    // truncated object. So: track whether we're inside a string literal and
+    // ignore braces there, honoring backslash escapes so an escaped quote
+    // (\") doesn't prematurely end the string.
+    var depth: usize = 0;
+    var in_string = false;
+    var escaped = false;
+    var i = obj_start;
+    while (i < json.len) : (i += 1) {
+        const c = json[i];
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (c) {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if (depth == 0) return json[obj_start .. i + 1];
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// Extract a simple string or scalar (number/bool/null) field value from
+/// JSON. Zero-copy: the returned slice borrows from `json` and is NOT
+/// unescaped (a `"` field containing `\"` is returned with the backslash
+/// still in it) — fine for our use, which is re-embedding CDP-supplied
+/// values verbatim into a new outgoing CDP command, never displaying them.
+pub fn extractField(json: []const u8, field: []const u8) ?[]const u8 {
+    var search_buf: [256]u8 = undefined;
+    const prefix = std.fmt.bufPrint(&search_buf, "\"{s}\"", .{field}) catch return null;
+
+    const field_pos = std.mem.indexOf(u8, json, prefix) orelse return null;
+    const after_field = field_pos + prefix.len;
+
+    // Skip colon and whitespace
+    var i = after_field;
+    while (i < json.len and (json[i] == ':' or json[i] == ' ' or json[i] == '\t')) : (i += 1) {}
+    if (i >= json.len) return null;
+
+    if (json[i] == '"') {
+        const val_start = i + 1;
+        // Find the closing quote, honoring backslash escapes. A naive
+        // indexOfScalarPos would stop at the first `"` byte and truncate the
+        // value at an embedded `\"` — reachable from real Chrome payloads
+        // (opaque-path URLs like javascript:/data:/mailto: keep raw quotes,
+        // as do header values echoed into a Fetch.requestPaused event). A
+        // truncated value is not merely wrong: these slices get re-embedded
+        // verbatim into the outgoing CDP reply, so cutting mid-escape emits a
+        // trailing backslash, Chrome rejects the malformed command, and the
+        // paused request is never answered — i.e. the page hangs.
+        var j = val_start;
+        while (j < json.len) : (j += 1) {
+            switch (json[j]) {
+                '\\' => j += 1, // skip the escaped byte
+                '"' => return json[val_start..j],
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    const val_start = i;
+    var val_end = i;
+    while (val_end < json.len) : (val_end += 1) {
+        switch (json[val_end]) {
+            ',', '}', ']', ' ', '\t', '\r', '\n' => break,
+            else => {},
+        }
+    }
+    if (val_end == val_start) return null;
+    return json[val_start..val_end];
+}
+
+/// Escape `"`, `\`, and common control characters for safe embedding inside
+/// a JSON string literal. Allocates; caller frees. Used only for strings we
+/// did NOT receive from Chrome (dialog prompt text, rule content-type/error
+/// fields set by a caller) — values echoed straight back from a CDP event
+/// (requestId, url, method) are already validly-escaped JSON and are never
+/// passed through this function.
+pub fn escapeJsonAlloc(allocator: std.mem.Allocator, s: []const u8) ![]const u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    for (s) |c| {
+        switch (c) {
+            '"' => try out.appendSlice(allocator, "\\\""),
+            '\\' => try out.appendSlice(allocator, "\\\\"),
+            '\n' => try out.appendSlice(allocator, "\\n"),
+            '\r' => try out.appendSlice(allocator, "\\r"),
+            '\t' => try out.appendSlice(allocator, "\\t"),
+            else => try out.append(allocator, c),
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test "extractField finds string and numeric values" {
+    const json = "{\"method\":\"Network.requestWillBeSent\",\"requestId\":\"abc123\",\"status\":304}";
+    try std.testing.expectEqualStrings("abc123", extractField(json, "requestId").?);
+    try std.testing.expectEqualStrings("304", extractField(json, "status").?);
+    try std.testing.expect(extractField(json, "nonexistent") == null);
+}
+
+test "extractObject extracts a balanced nested object" {
+    const json = "{\"method\":\"Fetch.requestPaused\",\"params\":{\"requestId\":\"1\",\"request\":{\"url\":\"https://example.com/\",\"method\":\"GET\",\"headers\":{\"a\":\"b\"}},\"resourceType\":\"Document\"}}";
+    const request_obj = extractObject(json, "request").?;
+    try std.testing.expectEqualStrings("https://example.com/", extractField(request_obj, "url").?);
+    try std.testing.expectEqualStrings("GET", extractField(request_obj, "method").?);
+}
+
+test "extractObject returns null when key is absent" {
+    try std.testing.expect(extractObject("{\"a\":1}", "request") == null);
+}
+
+test "extractObject is unfazed by unbalanced literal braces inside a string value (GraphQL-over-GET query string)" {
+    // '{' and '}' are not in the WHATWG URL query percent-encode set, so a
+    // request like fetch('https://api.example.com/graphql?q={a{b') reaches
+    // Fetch.requestPaused with literal, unescaped braces in the url string.
+    // A naive (non-string-aware) brace counter desyncs on these and never
+    // sees depth return to 0, returning null — which upstream (autoRespondFetch)
+    // turns into a silently buffered, never-answered Fetch.requestPaused event,
+    // hanging the paused request forever.
+    const json = "{\"method\":\"Fetch.requestPaused\",\"params\":{\"requestId\":\"1\",\"request\":{\"url\":\"https://api.example.com/graphql?q={a{b\",\"method\":\"GET\",\"headers\":{\"a\":\"b\"}},\"resourceType\":\"Document\"}}";
+    const request_obj = extractObject(json, "request").?;
+    try std.testing.expectEqualStrings("https://api.example.com/graphql?q={a{b", extractField(request_obj, "url").?);
+    try std.testing.expectEqualStrings("GET", extractField(request_obj, "method").?);
+}
+
+test "extractObject is unfazed by a string value with more literal '}' than '{'" {
+    const json = "{\"params\":{\"requestId\":\"1\",\"request\":{\"url\":\"https://example.com/?q=}}\",\"method\":\"GET\"}}}";
+    const request_obj = extractObject(json, "request").?;
+    try std.testing.expectEqualStrings("https://example.com/?q=}}", extractField(request_obj, "url").?);
+    try std.testing.expectEqualStrings("GET", extractField(request_obj, "method").?);
+}
+
+test "extractObject does not end a string early on an escaped quote containing a brace-adjacent char" {
+    const json = "{\"params\":{\"request\":{\"note\":\"say \\\"hi}\\\" ok\",\"method\":\"GET\"}}}";
+    const request_obj = extractObject(json, "request").?;
+    try std.testing.expectEqualStrings("GET", extractField(request_obj, "method").?);
+}
+
+test "extractField does not truncate a string value at an escaped quote" {
+    // Reachable from real Chrome payloads: opaque-path schemes (javascript:,
+    // data:, mailto:) use the C0-control-only percent-encode set, so a raw `"`
+    // survives into request.url and arrives JSON-escaped as \". A naive
+    // first-quote scan cuts the value there — and because these slices are
+    // re-embedded verbatim into the outgoing Fetch reply, the cut leaves a
+    // trailing backslash, Chrome rejects the command, and the paused request
+    // is never answered.
+    const json = "{\"url\":\"javascript:alert(\\\"hi\\\")\",\"method\":\"GET\"}";
+    try std.testing.expectEqualStrings("javascript:alert(\\\"hi\\\")", extractField(json, "url").?);
+    try std.testing.expectEqualStrings("GET", extractField(json, "method").?);
+}
+
+test "extractField returns null on an unterminated string value" {
+    try std.testing.expect(extractField("{\"url\":\"https://example.com/", "url") == null);
+    // A trailing backslash must not run the escape skip past the buffer end.
+    try std.testing.expect(extractField("{\"url\":\"abc\\", "url") == null);
+}
+
+test "escapeJsonAlloc escapes quotes and backslashes" {
+    const out = try escapeJsonAlloc(std.testing.allocator, "he said \"hi\"\\ok");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("he said \\\"hi\\\"\\\\ok", out);
+}
+
+test "escapeJsonAlloc passes through plain strings unchanged" {
+    const out = try escapeJsonAlloc(std.testing.allocator, "plain text");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("plain text", out);
+}

--- a/src/cdp/protocol.zig
+++ b/src/cdp/protocol.zig
@@ -72,6 +72,7 @@ pub const Methods = struct {
     pub const emulation_set_geolocation = "Emulation.setGeolocationOverride";
     pub const dom_highlight_node = "Overlay.highlightNode";
     pub const dom_hide_highlight = "Overlay.hideHighlight";
+    pub const overlay_enable = "Overlay.enable";
     pub const overlay_highlight_node = "Overlay.highlightNode";
     pub const overlay_hide_highlight = "Overlay.hideHighlight";
     pub const page_start_screencast = "Page.startScreencast";
@@ -81,12 +82,14 @@ pub const Methods = struct {
     // Runtime domain
     pub const runtime_console_api_called = "Runtime.consoleAPICalled";
     pub const runtime_enable = "Runtime.enable";
+    pub const runtime_add_binding = "Runtime.addBinding";
 
     // Fetch domain (network interception)
     pub const fetch_enable = "Fetch.enable";
     pub const fetch_disable = "Fetch.disable";
     pub const fetch_continue_request = "Fetch.continueRequest";
     pub const fetch_fulfill_request = "Fetch.fulfillRequest";
+    pub const fetch_fail_request = "Fetch.failRequest";
 
     // Network domain (cookies, headers)
     pub const network_get_cookies = "Network.getCookies";
@@ -95,6 +98,7 @@ pub const Methods = struct {
     pub const network_set_extra_http_headers = "Network.setExtraHTTPHeaders";
     pub const network_enable = "Network.enable";
     pub const network_disable = "Network.disable";
+    pub const network_get_response_body = "Network.getResponseBody";
 
     // Page domain (PDF, stop, script injection)
     pub const page_print_to_pdf = "Page.printToPDF";
@@ -144,6 +148,12 @@ pub const Methods = struct {
     // Page domain (frame/dialog)
     pub const page_get_frame_tree = "Page.getFrameTree";
     pub const page_enable = "Page.enable";
+
+    // IO domain (stream draining -- Tracing.start with transferMode:
+    // ReturnAsStream hands back a stream handle read via IO.read/closed
+    // via IO.close)
+    pub const io_read = "IO.read";
+    pub const io_close = "IO.close";
 };
 
 test "methods are valid strings" {
@@ -166,6 +176,14 @@ test "lightpanda parity CDP methods" {
     try std.testing.expectEqualStrings("DOM.getOuterHTML", Methods.dom_get_outer_html);
 }
 
+test "Fetch domain methods" {
+    try std.testing.expectEqualStrings("Fetch.enable", Methods.fetch_enable);
+    try std.testing.expectEqualStrings("Fetch.disable", Methods.fetch_disable);
+    try std.testing.expectEqualStrings("Fetch.continueRequest", Methods.fetch_continue_request);
+    try std.testing.expectEqualStrings("Fetch.fulfillRequest", Methods.fetch_fulfill_request);
+    try std.testing.expectEqualStrings("Fetch.failRequest", Methods.fetch_fail_request);
+}
+
 test "tier 1 parity CDP methods" {
     try std.testing.expectEqualStrings("Input.dispatchKeyEvent", Methods.input_dispatch_key_event);
     try std.testing.expectEqualStrings("Input.insertText", Methods.input_insert_text);
@@ -173,4 +191,15 @@ test "tier 1 parity CDP methods" {
     try std.testing.expectEqualStrings("DOM.scrollIntoViewIfNeeded", Methods.dom_scroll_into_view);
     try std.testing.expectEqualStrings("Emulation.setEmulatedMedia", Methods.emulation_set_emulated_media);
     try std.testing.expectEqualStrings("Network.emulateNetworkConditions", Methods.network_emulate_conditions);
+}
+
+test "collector endpoint CDP methods (screencast/binding/network/tracing/IO)" {
+    try std.testing.expectEqualStrings("Page.startScreencast", Methods.page_start_screencast);
+    try std.testing.expectEqualStrings("Page.stopScreencast", Methods.page_stop_screencast);
+    try std.testing.expectEqualStrings("Page.screencastFrameAck", Methods.page_screencast_frame_ack);
+    try std.testing.expectEqualStrings("Runtime.addBinding", Methods.runtime_add_binding);
+    try std.testing.expectEqualStrings("Network.getResponseBody", Methods.network_get_response_body);
+    try std.testing.expectEqualStrings("Inspector.enable", Methods.inspector_enable);
+    try std.testing.expectEqualStrings("IO.read", Methods.io_read);
+    try std.testing.expectEqualStrings("IO.close", Methods.io_close);
 }

--- a/src/cdp/stealth.zig
+++ b/src/cdp/stealth.zig
@@ -4,6 +4,17 @@ const compat = @import("../compat.zig");
 /// Stealth JS script embedded at comptime.
 pub const stealth_script = @embedFile("js/stealth.js");
 
+/// Console + error collector script embedded at comptime. Injected on every
+/// new document so window.__kuri_console / window.__kuri_errors are populated
+/// from page load; read + cleared by the /console and /errors endpoints.
+pub const console_collector_script = @embedFile("js/console_collector.js");
+
+/// React fiber introspector, embedded at comptime. Injected on every new
+/// document so window.__kuri_react is populated before react-dom's own init
+/// runs (needed for version detection + commit observation); read by the
+/// /react/tree, /react/inspect, /react/renders and /react/suspense endpoints.
+pub const react_fiber_script = @embedFile("js/react_fiber.js");
+
 /// User agents for rotation.
 pub const user_agents = [_][]const u8{
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
@@ -21,6 +32,31 @@ pub fn randomUserAgent() []const u8 {
 
 test "stealth script loads" {
     try std.testing.expect(stealth_script.len > 0);
+    // The script is injected on new document AND evaluated into the live page,
+    // so it must be safe to run twice in the same global. A top-level `const`
+    // made the second run a SyntaxError that aborted the whole injection and
+    // leaked a kuri-internal error into the page's /errors stream.
+    try std.testing.expect(std.mem.indexOf(u8, stealth_script, "__kuri_stealth_applied") != null);
+    try std.testing.expect(std.mem.indexOf(u8, stealth_script, "(function () {") != null);
+    // No top-level `const`/`let`: every declaration must be inside the IIFE.
+    try std.testing.expect(!std.mem.startsWith(u8, stealth_script, "const "));
+    try std.testing.expect(std.mem.indexOf(u8, stealth_script, "\nconst ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stealth_script, "\nlet ") == null);
+}
+
+test "console collector script loads" {
+    try std.testing.expect(console_collector_script.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, console_collector_script, "__kuri_console") != null);
+    try std.testing.expect(std.mem.indexOf(u8, console_collector_script, "__kuri_errors") != null);
+}
+
+test "react fiber script loads" {
+    try std.testing.expect(react_fiber_script.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, react_fiber_script, "__kuri_react") != null);
+    try std.testing.expect(std.mem.indexOf(u8, react_fiber_script, "__reactFiber$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, react_fiber_script, "__REACT_DEVTOOLS_GLOBAL_HOOK__") != null);
+    // Never gate discovery on the devtools hook — must find fibers standalone.
+    try std.testing.expect(std.mem.indexOf(u8, react_fiber_script, "__reactContainer$") != null);
 }
 
 test "randomUserAgent returns valid UA" {

--- a/src/cdp/websocket.zig
+++ b/src/cdp/websocket.zig
@@ -11,9 +11,11 @@ pub const WebSocketClient = struct {
     fd: std.posix.fd_t,
     connected: bool,
 
-    // Buffers owned by caller (stack or heap)
+    // Buffer owned by caller (stack or heap). `write_buf` used to live here
+    // too, but nothing ever read it -- `writeFrame` builds frames with its
+    // own local stack buffers (`frame_buf`, `chunk`); removed as dead
+    // storage rather than carried along for a "symmetric" API.
     read_buf: []u8,
-    write_buf: []u8,
 
     pub const Error = error{
         ConnectionFailed,
@@ -26,7 +28,7 @@ pub const WebSocketClient = struct {
     };
 
     /// Connect to a loopback WebSocket endpoint. url must be like "ws://host:port/path".
-    pub fn connect(allocator: std.mem.Allocator, url: []const u8, read_buf: []u8, write_buf: []u8) !WebSocketClient {
+    pub fn connect(allocator: std.mem.Allocator, url: []const u8, read_buf: []u8) !WebSocketClient {
         if (@import("builtin").os.tag == .windows) return Error.ConnectionFailed;
         const parsed = try parseWsUrl(url);
 
@@ -58,7 +60,6 @@ pub const WebSocketClient = struct {
             .fd = fd,
             .connected = false,
             .read_buf = read_buf,
-            .write_buf = write_buf,
         };
 
         try ws.doHandshake(parsed.host, parsed.port, parsed.path);

--- a/src/fetch_main.zig
+++ b/src/fetch_main.zig
@@ -5,7 +5,7 @@ const markdown = @import("crawler/markdown.zig");
 const js_engine = @import("js_engine.zig");
 const http_fetch = @import("util/http_fetch.zig");
 
-const version = "0.4.12";
+const version = "0.4.13";
 
 pub fn main(init: std.process.Init.Minimal) !void {
     var gpa_impl: std.heap.DebugAllocator(.{}) = .init;

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,7 @@ const api_token = @import("server/api_token.zig");
 const lifecycle = @import("lifecycle.zig");
 const updater = @import("update.zig");
 
-const version = "0.4.12";
+const version = "0.4.13";
 
 const CliAction = enum {
     run,

--- a/src/server/router.zig
+++ b/src/server/router.zig
@@ -12,6 +12,11 @@ const json_util = @import("../util/json.zig");
 const protocol = @import("../cdp/protocol.zig");
 const HarRecorder = @import("../cdp/har.zig").HarRecorder;
 const CdpClient = @import("../cdp/client.zig").CdpClient;
+const InterceptRule = @import("../cdp/client.zig").InterceptRule;
+const ScreencastFrameRecord = @import("../cdp/client.zig").ScreencastFrameRecord;
+const BindingCallRecord = @import("../cdp/client.zig").BindingCallRecord;
+const NetworkRecord = @import("../cdp/client.zig").NetworkRecord;
+const jsonscan = @import("../cdp/jsonscan.zig");
 const auth_profiles = @import("../storage/auth_profiles.zig");
 const url_validator = @import("../crawler/validator.zig");
 
@@ -76,302 +81,473 @@ fn handleConnection(gpa: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_po
     }
 }
 
+/// Every routable path, one variant per distinct URL (not per handler --
+/// several paths share a handler via a literal discriminator argument,
+/// e.g. `/storage/local` and `/storage/session` both call `handleStorage`).
+/// `route_table` below maps the path string to this enum in O(1)-ish time
+/// (StaticStringMap buckets by length, then does a handful of `eql` calls);
+/// `route()` then does an exhaustive `switch` so the compiler guarantees
+/// every variant has a handler and every handler is reachable.
+pub const Route = enum {
+    health,
+    tabs,
+    page_info,
+    discover,
+    navigate,
+    snapshot,
+    action,
+    text,
+    screenshot,
+    evaluate,
+    browdie,
+    har_start,
+    har_stop,
+    har_status,
+    har_replay,
+    close,
+    cookies,
+    cookies_clear,
+    cookies_set,
+    storage_local,
+    storage_session,
+    storage_local_clear,
+    storage_session_clear,
+    get,
+    back,
+    forward,
+    reload,
+    diff_snapshot,
+    emulate,
+    geolocation,
+    upload,
+    session_save,
+    session_load,
+    auth_profile_save,
+    auth_profile_load,
+    auth_profile_list,
+    auth_profile_delete,
+    auth_extract,
+    debug_enable,
+    debug_disable,
+    screenshot_annotated,
+    screenshot_diff,
+    screencast_start,
+    screencast_stop,
+    video_start,
+    video_stop,
+    console,
+    intercept_start,
+    intercept_stop,
+    intercept_requests,
+    intercept_rules,
+    intercept_rules_clear,
+    markdown,
+    links,
+    pdf,
+    dom_query,
+    dom_html,
+    cookies_delete,
+    headers,
+    script_inject,
+    stop,
+    scrollintoview,
+    drag,
+    keyboard_type,
+    keyboard_inserttext,
+    keydown,
+    keyup,
+    wait,
+    tab_current,
+    tab_new,
+    tab_close,
+    highlight,
+    errors,
+    set_offline,
+    set_media,
+    set_credentials,
+    find,
+    trace_start,
+    trace_stop,
+    profiler_start,
+    profiler_stop,
+    inspect,
+    window_new,
+    session_list,
+    set_viewport,
+    set_useragent,
+    dom_attributes,
+    frames,
+    network,
+    perf_lcp,
+    ws_start,
+    ws_stop,
+    batch,
+    element_state,
+    find_element,
+    dialog_auto,
+    dialog_accept,
+    dialog_dismiss,
+    mouse_move,
+    mouse_down,
+    mouse_up,
+    mouse_wheel,
+    page_state,
+    clipboard_read,
+    clipboard_write,
+    clear,
+    boundingbox,
+    wait_function,
+    response_body,
+    setcontent,
+    selectall,
+    setvalue,
+    timezone,
+    locale,
+    permissions,
+    tap,
+    dispatch,
+    download,
+    addstyle,
+    bringtofront,
+    pushstate,
+    expose,
+    expose_calls,
+    multiselect,
+    swipe,
+    vitals,
+    frame,
+    mainframe,
+    getattribute,
+    inputvalue,
+    react_tree,
+    react_inspect,
+    react_renders,
+    react_suspense,
+    recording_start,
+    recording_stop,
+    request_detail,
+    wait_download,
+    initscript_remove,
+    evalhandle,
+    diff_url,
+    cache_set,
+    cache_get,
+    cache_clear,
+    cache_list,
+    screenshot_som,
+    snapshot_changes,
+    recording_export,
+};
+
+pub const route_table = std.StaticStringMap(Route).initComptime(.{
+    .{ "/health", .health },
+    .{ "/tabs", .tabs },
+    .{ "/page/info", .page_info },
+    .{ "/discover", .discover },
+    .{ "/navigate", .navigate },
+    .{ "/snapshot", .snapshot },
+    .{ "/action", .action },
+    .{ "/text", .text },
+    .{ "/screenshot", .screenshot },
+    .{ "/evaluate", .evaluate },
+    .{ "/browdie", .browdie },
+    .{ "/har/start", .har_start },
+    .{ "/har/stop", .har_stop },
+    .{ "/har/status", .har_status },
+    .{ "/har/replay", .har_replay },
+    .{ "/close", .close },
+    .{ "/cookies", .cookies },
+    .{ "/cookies/clear", .cookies_clear },
+    .{ "/cookies/set", .cookies_set },
+    .{ "/storage/local", .storage_local },
+    .{ "/storage/session", .storage_session },
+    .{ "/storage/local/clear", .storage_local_clear },
+    .{ "/storage/session/clear", .storage_session_clear },
+    .{ "/get", .get },
+    .{ "/back", .back },
+    .{ "/forward", .forward },
+    .{ "/reload", .reload },
+    .{ "/diff/snapshot", .diff_snapshot },
+    .{ "/emulate", .emulate },
+    .{ "/geolocation", .geolocation },
+    .{ "/upload", .upload },
+    .{ "/session/save", .session_save },
+    .{ "/session/load", .session_load },
+    .{ "/auth/profile/save", .auth_profile_save },
+    .{ "/auth/profile/load", .auth_profile_load },
+    .{ "/auth/profile/list", .auth_profile_list },
+    .{ "/auth/profile/delete", .auth_profile_delete },
+    .{ "/auth/extract", .auth_extract },
+    .{ "/debug/enable", .debug_enable },
+    .{ "/debug/disable", .debug_disable },
+    .{ "/screenshot/annotated", .screenshot_annotated },
+    .{ "/screenshot/diff", .screenshot_diff },
+    .{ "/screencast/start", .screencast_start },
+    .{ "/screencast/stop", .screencast_stop },
+    .{ "/video/start", .video_start },
+    .{ "/video/stop", .video_stop },
+    .{ "/console", .console },
+    .{ "/intercept/start", .intercept_start },
+    .{ "/intercept/stop", .intercept_stop },
+    .{ "/intercept/requests", .intercept_requests },
+    .{ "/intercept/rules", .intercept_rules },
+    .{ "/intercept/rules/clear", .intercept_rules_clear },
+    .{ "/markdown", .markdown },
+    .{ "/links", .links },
+    .{ "/pdf", .pdf },
+    .{ "/dom/query", .dom_query },
+    .{ "/dom/html", .dom_html },
+    .{ "/cookies/delete", .cookies_delete },
+    .{ "/headers", .headers },
+    .{ "/script/inject", .script_inject },
+    .{ "/stop", .stop },
+    .{ "/scrollintoview", .scrollintoview },
+    .{ "/drag", .drag },
+    .{ "/keyboard/type", .keyboard_type },
+    .{ "/keyboard/inserttext", .keyboard_inserttext },
+    .{ "/keydown", .keydown },
+    .{ "/keyup", .keyup },
+    .{ "/wait", .wait },
+    .{ "/tab/current", .tab_current },
+    .{ "/tab/new", .tab_new },
+    .{ "/tab/close", .tab_close },
+    .{ "/highlight", .highlight },
+    .{ "/errors", .errors },
+    .{ "/set/offline", .set_offline },
+    .{ "/set/media", .set_media },
+    .{ "/set/credentials", .set_credentials },
+    .{ "/find", .find },
+    .{ "/trace/start", .trace_start },
+    .{ "/trace/stop", .trace_stop },
+    .{ "/profiler/start", .profiler_start },
+    .{ "/profiler/stop", .profiler_stop },
+    .{ "/inspect", .inspect },
+    .{ "/window/new", .window_new },
+    .{ "/session/list", .session_list },
+    .{ "/set/viewport", .set_viewport },
+    .{ "/set/useragent", .set_useragent },
+    .{ "/dom/attributes", .dom_attributes },
+    .{ "/frames", .frames },
+    .{ "/network", .network },
+    .{ "/perf/lcp", .perf_lcp },
+    .{ "/ws/start", .ws_start },
+    .{ "/ws/stop", .ws_stop },
+    .{ "/batch", .batch },
+    .{ "/element/state", .element_state },
+    .{ "/find-element", .find_element },
+    .{ "/dialog/auto", .dialog_auto },
+    .{ "/dialog/accept", .dialog_accept },
+    .{ "/dialog/dismiss", .dialog_dismiss },
+    .{ "/mouse/move", .mouse_move },
+    .{ "/mouse/down", .mouse_down },
+    .{ "/mouse/up", .mouse_up },
+    .{ "/mouse/wheel", .mouse_wheel },
+    .{ "/page/state", .page_state },
+    .{ "/clipboard/read", .clipboard_read },
+    .{ "/clipboard/write", .clipboard_write },
+    .{ "/clear", .clear },
+    .{ "/boundingbox", .boundingbox },
+    .{ "/wait/function", .wait_function },
+    .{ "/response/body", .response_body },
+    .{ "/setcontent", .setcontent },
+    .{ "/selectall", .selectall },
+    .{ "/setvalue", .setvalue },
+    .{ "/timezone", .timezone },
+    .{ "/locale", .locale },
+    .{ "/permissions", .permissions },
+    .{ "/tap", .tap },
+    .{ "/dispatch", .dispatch },
+    .{ "/download", .download },
+    .{ "/addstyle", .addstyle },
+    .{ "/bringtofront", .bringtofront },
+    .{ "/pushstate", .pushstate },
+    .{ "/expose", .expose },
+    .{ "/expose/calls", .expose_calls },
+    .{ "/multiselect", .multiselect },
+    .{ "/swipe", .swipe },
+    .{ "/vitals", .vitals },
+    .{ "/frame", .frame },
+    .{ "/mainframe", .mainframe },
+    .{ "/getattribute", .getattribute },
+    .{ "/inputvalue", .inputvalue },
+    .{ "/react/tree", .react_tree },
+    .{ "/react/inspect", .react_inspect },
+    .{ "/react/renders", .react_renders },
+    .{ "/react/suspense", .react_suspense },
+    .{ "/recording/start", .recording_start },
+    .{ "/recording/stop", .recording_stop },
+    .{ "/request/detail", .request_detail },
+    .{ "/wait/download", .wait_download },
+    .{ "/initscript/remove", .initscript_remove },
+    .{ "/evalhandle", .evalhandle },
+    .{ "/diff/url", .diff_url },
+    .{ "/cache/set", .cache_set },
+    .{ "/cache/get", .cache_get },
+    .{ "/cache/clear", .cache_clear },
+    .{ "/cache/list", .cache_list },
+    .{ "/screenshot/som", .screenshot_som },
+    .{ "/snapshot/changes", .snapshot_changes },
+    .{ "/recording/export", .recording_export },
+});
+
 fn route(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_port: u16) void {
     const path = request.head.target;
     const clean_path = if (std.mem.indexOfScalar(u8, path, '?')) |idx| path[0..idx] else path;
 
-    if (std.mem.eql(u8, clean_path, "/health")) {
-        handleHealth(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/tabs")) {
-        handleTabs(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/page/info")) {
-        handlePageInfo(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/discover")) {
-        handleDiscover(request, arena, bridge, cfg, cdp_port);
-    } else if (std.mem.eql(u8, clean_path, "/navigate")) {
-        handleNavigate(request, arena, bridge, cfg);
-    } else if (std.mem.eql(u8, clean_path, "/snapshot")) {
-        handleSnapshot(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/action")) {
-        handleAction(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/text")) {
-        handleText(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screenshot")) {
-        handleScreenshot(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/evaluate")) {
-        handleEvaluate(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/browdie")) {
-        handleBrowdie(request);
-    } else if (std.mem.eql(u8, clean_path, "/har/start")) {
-        handleHarStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/har/stop")) {
-        handleHarStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/har/status")) {
-        handleHarStatus(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/har/replay")) {
-        handleHarReplay(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/close")) {
-        handleClose(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cookies")) {
-        handleCookies(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cookies/clear")) {
-        handleCookiesClear(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cookies/set")) {
-        handleCookiesSet(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/storage/local")) {
-        handleStorage(request, arena, bridge, "localStorage");
-    } else if (std.mem.eql(u8, clean_path, "/storage/session")) {
-        handleStorage(request, arena, bridge, "sessionStorage");
-    } else if (std.mem.eql(u8, clean_path, "/storage/local/clear")) {
-        handleStorageClear(request, arena, bridge, "localStorage");
-    } else if (std.mem.eql(u8, clean_path, "/storage/session/clear")) {
-        handleStorageClear(request, arena, bridge, "sessionStorage");
-    } else if (std.mem.eql(u8, clean_path, "/get")) {
-        handleGet(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/back")) {
-        handleBack(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/forward")) {
-        handleForward(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/reload")) {
-        handleReload(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/diff/snapshot")) {
-        handleDiffSnapshot(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/emulate")) {
-        handleEmulate(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/geolocation")) {
-        handleGeolocation(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/upload")) {
-        handleUpload(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/session/save")) {
-        handleSessionSave(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/session/load")) {
-        handleSessionLoad(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/auth/profile/save")) {
-        handleAuthProfileSave(request, arena, bridge, cfg);
-    } else if (std.mem.eql(u8, clean_path, "/auth/profile/load")) {
-        handleAuthProfileLoad(request, arena, bridge, cfg);
-    } else if (std.mem.eql(u8, clean_path, "/auth/profile/list")) {
-        handleAuthProfileList(request, arena, cfg);
-    } else if (std.mem.eql(u8, clean_path, "/auth/profile/delete")) {
-        handleAuthProfileDelete(request, arena, cfg);
-    } else if (std.mem.eql(u8, clean_path, "/auth/extract")) {
-        handleAuthExtract(request, arena);
-    } else if (std.mem.eql(u8, clean_path, "/debug/enable")) {
-        handleDebugEnable(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/debug/disable")) {
-        handleDebugDisable(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screenshot/annotated")) {
-        handleAnnotatedScreenshot(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screenshot/diff")) {
-        handleDiffScreenshot(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screencast/start")) {
-        handleScreencastStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screencast/stop")) {
-        handleScreencastStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/video/start")) {
-        handleVideoStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/video/stop")) {
-        handleVideoStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/console")) {
-        handleConsole(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/intercept/start")) {
-        handleInterceptStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/intercept/stop")) {
-        handleInterceptStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/intercept/requests")) {
-        handleInterceptRequests(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/markdown")) {
-        handleMarkdown(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/links")) {
-        handleLinks(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/pdf")) {
-        handlePdf(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dom/query")) {
-        handleDomQuery(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dom/html")) {
-        handleDomHtml(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cookies/delete")) {
-        handleCookiesDelete(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/headers")) {
-        handleHeaders(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/script/inject")) {
-        handleScriptInject(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/stop")) {
-        handleStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/scrollintoview")) {
-        handleScrollIntoView(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/drag")) {
-        handleDrag(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/keyboard/type")) {
-        handleKeyboardType(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/keyboard/inserttext")) {
-        handleKeyboardInsertText(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/keydown")) {
-        handleKeyDown(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/keyup")) {
-        handleKeyUp(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/wait")) {
-        handleWait(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/tab/current")) {
-        handleTabCurrent(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/tab/new")) {
-        handleTabNew(request, arena, bridge, cfg, cdp_port);
-    } else if (std.mem.eql(u8, clean_path, "/tab/close")) {
-        handleTabClose(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/highlight")) {
-        handleHighlight(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/errors")) {
-        handleErrors(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/set/offline")) {
-        handleSetOffline(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/set/media")) {
-        handleSetMedia(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/set/credentials")) {
-        handleSetCredentials(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/find")) {
-        handleFind(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/trace/start")) {
-        handleTraceStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/trace/stop")) {
-        handleTraceStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/profiler/start")) {
-        handleProfilerStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/profiler/stop")) {
-        handleProfilerStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/inspect")) {
-        handleInspect(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/window/new")) {
-        handleWindowNew(request, arena, bridge, cfg, cdp_port);
-    } else if (std.mem.eql(u8, clean_path, "/session/list")) {
-        handleSessionList(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/set/viewport")) {
-        handleSetViewport(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/set/useragent")) {
-        handleSetUserAgent(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dom/attributes")) {
-        handleDomAttributes(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/frames")) {
-        handleFrames(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/network")) {
-        handleNetwork(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/perf/lcp")) {
-        handlePerfLcp(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/ws/start")) {
-        handleWsStart(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/ws/stop")) {
-        handleWsStop(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/batch")) {
-        handleBatch(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/element/state")) {
-        handleElementState(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/find-element")) {
-        handleFindElement(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dialog/auto")) {
-        handleDialogAuto(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dialog/accept")) {
-        handleDialogRespond(request, arena, bridge, true);
-    } else if (std.mem.eql(u8, clean_path, "/dialog/dismiss")) {
-        handleDialogRespond(request, arena, bridge, false);
-    } else if (std.mem.eql(u8, clean_path, "/mouse/move")) {
-        handleMouseEvent(request, arena, bridge, "mouseMoved");
-    } else if (std.mem.eql(u8, clean_path, "/mouse/down")) {
-        handleMouseEvent(request, arena, bridge, "mousePressed");
-    } else if (std.mem.eql(u8, clean_path, "/mouse/up")) {
-        handleMouseEvent(request, arena, bridge, "mouseReleased");
-    } else if (std.mem.eql(u8, clean_path, "/mouse/wheel")) {
-        handleMouseWheel(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/page/state")) {
-        handlePageState(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/clipboard/read")) {
-        handleClipboard(request, arena, bridge, "read");
-    } else if (std.mem.eql(u8, clean_path, "/clipboard/write")) {
-        handleClipboard(request, arena, bridge, "write");
-    } else if (std.mem.eql(u8, clean_path, "/clear")) {
-        handleClear(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/boundingbox")) {
-        handleBoundingBox(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/wait/function")) {
-        handleWaitForFunction(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/response/body")) {
-        handleResponseBody(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/setcontent")) {
-        handleSetContent(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/selectall")) {
-        handleSelectAll(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/setvalue")) {
-        handleSetValue(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/timezone")) {
-        handleTimezone(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/locale")) {
-        handleLocale(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/permissions")) {
-        handlePermissions(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/tap")) {
-        handleTap(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/dispatch")) {
-        handleDispatch(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/download")) {
-        handleDownload(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/addstyle")) {
-        handleAddStyle(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/bringtofront")) {
-        handleBringToFront(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/pushstate")) {
-        handlePushState(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/expose")) {
-        handleExpose(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/multiselect")) {
-        handleMultiSelect(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/swipe")) {
-        handleSwipe(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/vitals")) {
-        handleVitals(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/frame")) {
-        handleFrame(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/mainframe")) {
-        handleMainFrame(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/getattribute")) {
-        handleGetAttribute(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/inputvalue")) {
-        handleInputValue(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/react/tree")) {
-        handleReact(request, arena, bridge, "tree");
-    } else if (std.mem.eql(u8, clean_path, "/react/inspect")) {
-        handleReact(request, arena, bridge, "inspect");
-    } else if (std.mem.eql(u8, clean_path, "/react/renders")) {
-        handleReact(request, arena, bridge, "renders");
-    } else if (std.mem.eql(u8, clean_path, "/react/suspense")) {
-        handleReact(request, arena, bridge, "suspense");
-    } else if (std.mem.eql(u8, clean_path, "/recording/start")) {
-        handleRecording(request, arena, bridge, "start");
-    } else if (std.mem.eql(u8, clean_path, "/recording/stop")) {
-        handleRecording(request, arena, bridge, "stop");
-    } else if (std.mem.eql(u8, clean_path, "/request/detail")) {
-        handleRequestDetail(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/wait/download")) {
-        handleWaitForDownload(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/initscript/remove")) {
-        handleRemoveInitScript(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/evalhandle")) {
-        handleEvalHandle(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/diff/url")) {
-        handleDiffUrl(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cache/set")) {
-        handleCacheSet(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cache/get")) {
-        handleCacheGet(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cache/clear")) {
-        handleCacheClear(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/cache/list")) {
-        handleCacheList(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/screenshot/som")) {
-        handleScreenshotSom(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/snapshot/changes")) {
-        handleSnapshotChanges(request, arena, bridge);
-    } else if (std.mem.eql(u8, clean_path, "/recording/export")) {
-        handleRecordingExport(request, arena, bridge);
-    } else {
+    const r = route_table.get(clean_path) orelse {
         resp.sendError(request, 404, "Not Found");
+        return;
+    };
+
+    switch (r) {
+        .health => handleHealth(request, arena, bridge),
+        .tabs => handleTabs(request, arena, bridge),
+        .page_info => handlePageInfo(request, arena, bridge),
+        .discover => handleDiscover(request, arena, bridge, cfg, cdp_port),
+        .navigate => handleNavigate(request, arena, bridge, cfg),
+        .snapshot => handleSnapshot(request, arena, bridge),
+        .action => handleAction(request, arena, bridge),
+        .text => handleText(request, arena, bridge),
+        .screenshot => handleScreenshot(request, arena, bridge),
+        .evaluate => handleEvaluate(request, arena, bridge),
+        .browdie => handleBrowdie(request),
+        .har_start => handleHarStart(request, arena, bridge),
+        .har_stop => handleHarStop(request, arena, bridge),
+        .har_status => handleHarStatus(request, arena, bridge),
+        .har_replay => handleHarReplay(request, arena, bridge),
+        .close => handleClose(request, arena, bridge),
+        .cookies => handleCookies(request, arena, bridge),
+        .cookies_clear => handleCookiesClear(request, arena, bridge),
+        .cookies_set => handleCookiesSet(request, arena, bridge),
+        .storage_local => handleStorage(request, arena, bridge, "localStorage"),
+        .storage_session => handleStorage(request, arena, bridge, "sessionStorage"),
+        .storage_local_clear => handleStorageClear(request, arena, bridge, "localStorage"),
+        .storage_session_clear => handleStorageClear(request, arena, bridge, "sessionStorage"),
+        .get => handleGet(request, arena, bridge),
+        .back => handleBack(request, arena, bridge),
+        .forward => handleForward(request, arena, bridge),
+        .reload => handleReload(request, arena, bridge),
+        .diff_snapshot => handleDiffSnapshot(request, arena, bridge),
+        .emulate => handleEmulate(request, arena, bridge),
+        .geolocation => handleGeolocation(request, arena, bridge),
+        .upload => handleUpload(request, arena, bridge),
+        .session_save => handleSessionSave(request, arena, bridge),
+        .session_load => handleSessionLoad(request, arena, bridge),
+        .auth_profile_save => handleAuthProfileSave(request, arena, bridge, cfg),
+        .auth_profile_load => handleAuthProfileLoad(request, arena, bridge, cfg),
+        .auth_profile_list => handleAuthProfileList(request, arena, cfg),
+        .auth_profile_delete => handleAuthProfileDelete(request, arena, cfg),
+        .auth_extract => handleAuthExtract(request, arena),
+        .debug_enable => handleDebugEnable(request, arena, bridge),
+        .debug_disable => handleDebugDisable(request, arena, bridge),
+        .screenshot_annotated => handleAnnotatedScreenshot(request, arena, bridge),
+        .screenshot_diff => handleDiffScreenshot(request, arena, bridge),
+        .screencast_start => handleScreencastStart(request, arena, bridge),
+        .screencast_stop => handleScreencastStop(request, arena, bridge),
+        .video_start => handleVideoStart(request, arena, bridge),
+        .video_stop => handleVideoStop(request, arena, bridge),
+        .console => handleConsole(request, arena, bridge),
+        .intercept_start => handleInterceptStart(request, arena, bridge),
+        .intercept_stop => handleInterceptStop(request, arena, bridge),
+        .intercept_requests => handleInterceptRequests(request, arena, bridge),
+        .intercept_rules => handleInterceptRules(request, arena, bridge),
+        .intercept_rules_clear => handleInterceptRulesClear(request, arena, bridge),
+        .markdown => handleMarkdown(request, arena, bridge),
+        .links => handleLinks(request, arena, bridge),
+        .pdf => handlePdf(request, arena, bridge),
+        .dom_query => handleDomQuery(request, arena, bridge),
+        .dom_html => handleDomHtml(request, arena, bridge),
+        .cookies_delete => handleCookiesDelete(request, arena, bridge),
+        .headers => handleHeaders(request, arena, bridge),
+        .script_inject => handleScriptInject(request, arena, bridge),
+        .stop => handleStop(request, arena, bridge),
+        .scrollintoview => handleScrollIntoView(request, arena, bridge),
+        .drag => handleDrag(request, arena, bridge),
+        .keyboard_type => handleKeyboardType(request, arena, bridge),
+        .keyboard_inserttext => handleKeyboardInsertText(request, arena, bridge),
+        .keydown => handleKeyDown(request, arena, bridge),
+        .keyup => handleKeyUp(request, arena, bridge),
+        .wait => handleWait(request, arena, bridge),
+        .tab_current => handleTabCurrent(request, arena, bridge),
+        .tab_new => handleTabNew(request, arena, bridge, cfg, cdp_port),
+        .tab_close => handleTabClose(request, arena, bridge),
+        .highlight => handleHighlight(request, arena, bridge),
+        .errors => handleErrors(request, arena, bridge),
+        .set_offline => handleSetOffline(request, arena, bridge),
+        .set_media => handleSetMedia(request, arena, bridge),
+        .set_credentials => handleSetCredentials(request, arena, bridge),
+        .find => handleFind(request, arena, bridge),
+        .trace_start => handleTraceStart(request, arena, bridge),
+        .trace_stop => handleTraceStop(request, arena, bridge),
+        .profiler_start => handleProfilerStart(request, arena, bridge),
+        .profiler_stop => handleProfilerStop(request, arena, bridge),
+        .inspect => handleInspect(request, arena, bridge),
+        .window_new => handleWindowNew(request, arena, bridge, cfg, cdp_port),
+        .session_list => handleSessionList(request, arena, bridge),
+        .set_viewport => handleSetViewport(request, arena, bridge),
+        .set_useragent => handleSetUserAgent(request, arena, bridge),
+        .dom_attributes => handleDomAttributes(request, arena, bridge),
+        .frames => handleFrames(request, arena, bridge),
+        .network => handleNetwork(request, arena, bridge),
+        .perf_lcp => handlePerfLcp(request, arena, bridge),
+        .ws_start => handleWsStart(request, arena, bridge),
+        .ws_stop => handleWsStop(request, arena, bridge),
+        .batch => handleBatch(request, arena, bridge),
+        .element_state => handleElementState(request, arena, bridge),
+        .find_element => handleFindElement(request, arena, bridge),
+        .dialog_auto => handleDialogAuto(request, arena, bridge),
+        .dialog_accept => handleDialogRespond(request, arena, bridge, true),
+        .dialog_dismiss => handleDialogRespond(request, arena, bridge, false),
+        .mouse_move => handleMouseEvent(request, arena, bridge, "mouseMoved"),
+        .mouse_down => handleMouseEvent(request, arena, bridge, "mousePressed"),
+        .mouse_up => handleMouseEvent(request, arena, bridge, "mouseReleased"),
+        .mouse_wheel => handleMouseWheel(request, arena, bridge),
+        .page_state => handlePageState(request, arena, bridge),
+        .clipboard_read => handleClipboard(request, arena, bridge, "read"),
+        .clipboard_write => handleClipboard(request, arena, bridge, "write"),
+        .clear => handleClear(request, arena, bridge),
+        .boundingbox => handleBoundingBox(request, arena, bridge),
+        .wait_function => handleWaitForFunction(request, arena, bridge),
+        .response_body => handleResponseBody(request, arena, bridge),
+        .setcontent => handleSetContent(request, arena, bridge),
+        .selectall => handleSelectAll(request, arena, bridge),
+        .setvalue => handleSetValue(request, arena, bridge),
+        .timezone => handleTimezone(request, arena, bridge),
+        .locale => handleLocale(request, arena, bridge),
+        .permissions => handlePermissions(request, arena, bridge),
+        .tap => handleTap(request, arena, bridge),
+        .dispatch => handleDispatch(request, arena, bridge),
+        .download => handleDownload(request, arena, bridge),
+        .addstyle => handleAddStyle(request, arena, bridge),
+        .bringtofront => handleBringToFront(request, arena, bridge),
+        .pushstate => handlePushState(request, arena, bridge),
+        .expose => handleExpose(request, arena, bridge),
+        .expose_calls => handleExposeCalls(request, arena, bridge),
+        .multiselect => handleMultiSelect(request, arena, bridge),
+        .swipe => handleSwipe(request, arena, bridge),
+        .vitals => handleVitals(request, arena, bridge),
+        .frame => handleFrame(request, arena, bridge),
+        .mainframe => handleMainFrame(request, arena, bridge),
+        .getattribute => handleGetAttribute(request, arena, bridge),
+        .inputvalue => handleInputValue(request, arena, bridge),
+        .react_tree => handleReact(request, arena, bridge, "tree"),
+        .react_inspect => handleReact(request, arena, bridge, "inspect"),
+        .react_renders => handleReact(request, arena, bridge, "renders"),
+        .react_suspense => handleReact(request, arena, bridge, "suspense"),
+        .recording_start => handleRecording(request, arena, bridge, "start"),
+        .recording_stop => handleRecording(request, arena, bridge, "stop"),
+        .request_detail => handleRequestDetail(request, arena, bridge),
+        .wait_download => handleWaitForDownload(request, arena, bridge),
+        .initscript_remove => handleRemoveInitScript(request, arena, bridge),
+        .evalhandle => handleEvalHandle(request, arena, bridge),
+        .diff_url => handleDiffUrl(request, arena, bridge),
+        .cache_set => handleCacheSet(request, arena, bridge),
+        .cache_get => handleCacheGet(request, arena, bridge),
+        .cache_clear => handleCacheClear(request, arena, bridge),
+        .cache_list => handleCacheList(request, arena, bridge),
+        .screenshot_som => handleScreenshotSom(request, arena, bridge),
+        .snapshot_changes => handleSnapshotChanges(request, arena, bridge),
+        .recording_export => handleRecordingExport(request, arena, bridge),
     }
 }
 
@@ -1507,11 +1683,12 @@ fn handleEvaluate(request: *std.http.Server.Request, arena: std.mem.Allocator, b
     rememberCurrentTab(request, bridge, tab_id);
     _ = bridge.touchTab(tab_id);
 
-    const escaped_expr = jsonEscapeAlloc(arena, expr) orelse {
-        resp.sendError(request, 500, "Internal Server Error");
-        return;
-    };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped_expr}) catch {
+    // `expr` is ALREADY JSON-escaped just above. Escaping it a second time was
+    // a real bug: a newline became `\n`, then `\\n`, which JSON-decodes back to
+    // a literal backslash+n in the JS source — so Chrome answered any multi-line
+    // (or quote-containing) expression with "SyntaxError: Invalid or unexpected
+    // token" instead of running it. Escape exactly once.
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -1624,10 +1801,48 @@ pub fn discoverTabs(arena: std.mem.Allocator, bridge: *Bridge, cfg: Config, cdp_
 
             // Auto-apply stealth patches to each discovered tab
             if (bridge.getCdpClient(id_val)) |client| {
+                // Page.enable MUST happen before any Page.addScriptToEvaluateOnNewDocument
+                // call below, on this same CDP session -- verified directly against
+                // Chrome: an init script registered without Page domain enabled first
+                // only survives for the current document and is silently dropped on
+                // the very next navigation (not re-fired at all), which is why
+                // /console, /errors, and /react/tree all went empty on any page
+                // reached via /navigate despite being registered here. Page.enable has
+                // no matching Page.disable anywhere in this codebase, so this is a
+                // one-time, idempotent enable for the life of the session.
+                _ = client.send(arena, protocol.Methods.page_enable, null) catch {};
+
                 const stealth = @import("../cdp/stealth.zig");
                 const escaped = jsonEscapeAlloc(arena, stealth.stealth_script) orelse continue;
                 const add_params = std.fmt.allocPrint(arena, "{{\"source\":\"{s}\"}}", .{escaped}) catch continue;
                 _ = client.send(arena, protocol.Methods.page_add_script, add_params) catch {};
+
+                // Inject the console/error collector: persist across future
+                // navigations, and run once against the already-loaded page so
+                // /console and /errors work without requiring a reload.
+                if (jsonEscapeAlloc(arena, stealth.console_collector_script)) |collector_escaped| {
+                    if (std.fmt.allocPrint(arena, "{{\"source\":\"{s}\"}}", .{collector_escaped})) |collector_add| {
+                        _ = client.send(arena, protocol.Methods.page_add_script, collector_add) catch {};
+                    } else |_| {}
+                    if (std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{collector_escaped})) |collector_eval| {
+                        _ = client.send(arena, protocol.Methods.runtime_evaluate, collector_eval) catch {};
+                    } else |_| {}
+                }
+
+                // Inject the React fiber introspector: persist across future
+                // navigations (this is the copy that actually matters for
+                // version detection + commit tracking, since it must be
+                // present before react-dom's own init runs), and run once
+                // against the already-loaded page so /react/tree etc. work
+                // without requiring a reload first.
+                if (jsonEscapeAlloc(arena, stealth.react_fiber_script)) |react_escaped| {
+                    if (std.fmt.allocPrint(arena, "{{\"source\":\"{s}\"}}", .{react_escaped})) |react_add| {
+                        _ = client.send(arena, protocol.Methods.page_add_script, react_add) catch {};
+                    } else |_| {}
+                    if (std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{react_escaped})) |react_eval| {
+                        _ = client.send(arena, protocol.Methods.runtime_evaluate, react_eval) catch {};
+                    } else |_| {}
+                }
 
                 // Set a random user agent at network level
                 const ua = stealth.randomUserAgent();
@@ -1986,11 +2201,7 @@ fn buildA11yState(arena: std.mem.Allocator, object: []const u8) []const u8 {
 // ── HAR Endpoints ───────────────────────────────────────────────────────
 
 fn handleHarStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const rec = bridge.getHarRecorder(tab_id) orelse {
         resp.sendError(request, 500, "Cannot create HAR recorder");
@@ -2017,11 +2228,7 @@ fn handleHarStart(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 }
 
 fn handleHarStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const rec = bridge.getHarRecorder(tab_id) orelse {
         resp.sendError(request, 404, "No HAR recorder for this tab");
@@ -2092,11 +2299,7 @@ fn flushEventsToHar(arena: std.mem.Allocator, client: *CdpClient, rec: *HarRecor
 }
 
 fn handleHarStatus(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const rec = bridge.getHarRecorder(tab_id) orelse {
         const body = std.fmt.allocPrint(arena, "{{\"recording\":false,\"entries\":0,\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
@@ -2122,10 +2325,7 @@ fn handleHarStatus(request: *std.http.Server.Request, arena: std.mem.Allocator, 
 
 fn handleHarReplay(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const format = getQueryParam(target, "format") orelse "all";
     const filter = getQueryParam(target, "filter") orelse "api";
 
@@ -2241,9 +2441,8 @@ fn handleHarReplay(request: *std.http.Server.Request, arena: std.mem.Allocator, 
 // ── Console Log Capture Endpoint ────────────────────────────────────────
 
 fn handleConsole(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
         return;
     };
 
@@ -2252,24 +2451,25 @@ fn handleConsole(request: *std.http.Server.Request, arena: std.mem.Allocator, br
         return;
     };
 
-    _ = client.send(arena, protocol.Methods.runtime_enable, null) catch {
+    // Read and clear the collector's console buffer. Returns "[]" when the
+    // collector has not been injected yet (e.g. the page never navigated).
+    const params = "{\"expression\":\"(function(){var c=window.__kuri_console||[];window.__kuri_console=[];return JSON.stringify(c);})()\",\"returnByValue\":true}";
+    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
-
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"Runtime.enable sent\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
-        resp.sendError(request, 500, "Internal Server Error");
-        return;
-    };
-    resp.sendJson(request, body);
+    resp.sendJson(request, response);
 }
 
 // ── Network Interception Endpoints ──────────────────────────────────────
+// All endpoints below resolve tab_id the same way /console and /errors do:
+// an explicit ?tab_id= wins, else X-Kuri-Session (or ?session=) is resolved
+// to that session's current tab. See resolveEffectiveTabIdAlloc/getSessionId.
 
 fn handleInterceptStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
         return;
     };
 
@@ -2278,12 +2478,64 @@ fn handleInterceptStart(request: *std.http.Server.Request, arena: std.mem.Alloca
         return;
     };
 
-    _ = client.send(arena, protocol.Methods.fetch_enable, null) catch {
-        resp.sendError(request, 502, "CDP command failed");
+    // ?patterns=a,b,c — comma-separated URL patterns to pause on. Default
+    // (and what an all-blank list falls back to) is "*", matching what
+    // Fetch.enable does when given no patterns at all: pause everything.
+    const patterns_param: []const u8 = getDecodedQueryParamAlloc(arena, target, "patterns") orelse "*";
+
+    var patterns_json: std.ArrayList(u8) = .empty;
+    var enabled_list: std.ArrayList(u8) = .empty;
+    patterns_json.appendSlice(arena, "[") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    enabled_list.appendSlice(arena, "[") catch {
+        resp.sendError(request, 500, "Internal Server Error");
         return;
     };
 
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"Fetch.enable sent\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+    var iter = std.mem.splitScalar(u8, patterns_param, ',');
+    var count: usize = 0;
+    while (iter.next()) |raw| {
+        const pattern = std.mem.trim(u8, raw, " \t");
+        if (pattern.len == 0) continue;
+        if (count > 0) {
+            patterns_json.appendSlice(arena, ",") catch return;
+            enabled_list.appendSlice(arena, ",") catch return;
+        }
+        patterns_json.appendSlice(arena, "{\"urlPattern\":") catch return;
+        writeJsonStringValue(&patterns_json, arena, pattern) catch return;
+        patterns_json.appendSlice(arena, "}") catch return;
+        writeJsonStringValue(&enabled_list, arena, pattern) catch return;
+        count += 1;
+    }
+    if (count == 0) {
+        // Every entry was blank (e.g. ?patterns= or ?patterns=,,) — fall
+        // back to "*" rather than sending Fetch.enable an empty patterns
+        // array, which Chrome treats as "match nothing", the opposite of
+        // what an empty param should mean here.
+        patterns_json.appendSlice(arena, "{\"urlPattern\":\"*\"}") catch return;
+        enabled_list.appendSlice(arena, "\"*\"") catch return;
+    }
+    patterns_json.appendSlice(arena, "]") catch return;
+    enabled_list.appendSlice(arena, "]") catch return;
+
+    const params = std.fmt.allocPrint(arena, "{{\"patterns\":{s}}}", .{patterns_json.items}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    _ = client.send(arena, protocol.Methods.fetch_enable, params) catch {
+        resp.sendError(request, 502, "CDP command failed");
+        return;
+    };
+    client.setInterceptActive(true);
+
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"status\":\"ok\",\"message\":\"Fetch.enable sent\",\"tab_id\":\"{s}\",\"patterns\":{s}}}",
+        .{ tab_id, enabled_list.items },
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2291,9 +2543,8 @@ fn handleInterceptStart(request: *std.http.Server.Request, arena: std.mem.Alloca
 }
 
 fn handleInterceptStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
         return;
     };
 
@@ -2307,7 +2558,156 @@ fn handleInterceptStop(request: *std.http.Server.Request, arena: std.mem.Allocat
         return;
     };
 
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"Fetch.disable sent\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+    client.setInterceptActive(false);
+    client.clearInterceptRules();
+    client.clearPausedRequests();
+
+    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"Fetch.disable sent, rules and records cleared\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, body);
+}
+
+/// Parse a JSON rule body for POST /intercept/rules into an `InterceptRule`.
+/// Accepts `url_pattern` (or `pattern`) as the URL substring to match — "*"
+/// or an absent/empty value is a catch-all (matches every request, same as
+/// an empty string passed straight to `InterceptState.findMatch`).
+/// Returns null only when `action` is present but not one of
+/// continue/abort/fulfill; every other field falls back to a sane default.
+fn parseInterceptRuleBody(arena: std.mem.Allocator, body: []const u8) ?InterceptRule {
+    const raw_pattern = extractSimpleJsonString(body, 0, "\"url_pattern\"") orelse
+        extractSimpleJsonString(body, 0, "\"pattern\"") orelse "";
+    const unescaped_pattern: []const u8 = json_util.jsonUnescape(arena, raw_pattern) catch raw_pattern;
+    const url_substring = if (std.mem.eql(u8, unescaped_pattern, "*")) "" else unescaped_pattern;
+
+    const action_str = extractSimpleJsonString(body, 0, "\"action\"") orelse "continue";
+    const action: InterceptRule.Action = if (std.mem.eql(u8, action_str, "continue"))
+        .@"continue"
+    else if (std.mem.eql(u8, action_str, "abort"))
+        .abort
+    else if (std.mem.eql(u8, action_str, "fulfill"))
+        .fulfill
+    else
+        return null;
+
+    const status: u16 = @intCast(@min(extractSimpleJsonInt(body, 0, "\"status\"") orelse 200, 599));
+
+    const raw_body_field = extractSimpleJsonString(body, 0, "\"body\"") orelse "";
+    const response_body: []const u8 = json_util.jsonUnescape(arena, raw_body_field) catch raw_body_field;
+
+    const raw_content_type = extractSimpleJsonString(body, 0, "\"content_type\"") orelse "application/json";
+    const content_type: []const u8 = json_util.jsonUnescape(arena, raw_content_type) catch raw_content_type;
+
+    const raw_error_reason = extractSimpleJsonString(body, 0, "\"error_reason\"") orelse "Failed";
+    const error_reason: []const u8 = json_util.jsonUnescape(arena, raw_error_reason) catch raw_error_reason;
+
+    return .{
+        .url_substring = url_substring,
+        .action = action,
+        .status = status,
+        .body = response_body,
+        .content_type = content_type,
+        .error_reason = error_reason,
+    };
+}
+
+fn writeInterceptRuleJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, rule: InterceptRule) !void {
+    try buf.appendSlice(allocator, "{");
+    try writeJsonField(buf, allocator, "url_pattern", rule.url_substring);
+    try buf.appendSlice(allocator, ",\"action\":\"");
+    try buf.appendSlice(allocator, @tagName(rule.action));
+    try buf.print(allocator, "\",\"status\":{d},", .{rule.status});
+    try writeJsonField(buf, allocator, "content_type", rule.content_type);
+    try buf.appendSlice(allocator, ",");
+    try writeJsonField(buf, allocator, "body", rule.body);
+    try buf.appendSlice(allocator, ",");
+    try writeJsonField(buf, allocator, "error_reason", rule.error_reason);
+    try buf.appendSlice(allocator, "}");
+}
+
+fn handleInterceptRuleAdd(request: *std.http.Server.Request, arena: std.mem.Allocator, client: *CdpClient) void {
+    const raw_body = readRequestBody(request, arena) orelse {
+        resp.sendError(request, 400, "Missing request body - expected JSON {\"url_pattern\":...,\"action\":\"continue|abort|fulfill\",...}");
+        return;
+    };
+
+    const rule = parseInterceptRuleBody(arena, raw_body) orelse {
+        resp.sendError(request, 400, "Invalid rule: action must be continue, abort, or fulfill");
+        return;
+    };
+
+    client.addInterceptRule(rule) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    buf.appendSlice(arena, "{\"status\":\"ok\",\"rule\":") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    writeInterceptRuleJson(&buf, arena, rule) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    buf.appendSlice(arena, "}") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    resp.sendJson(request, buf.items);
+}
+
+fn handleInterceptRules(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
+        return;
+    };
+
+    const client = bridge.getCdpClient(tab_id) orelse {
+        resp.sendError(request, 404, "Tab not found");
+        return;
+    };
+
+    if (request.head.method == .POST) {
+        handleInterceptRuleAdd(request, arena, client);
+        return;
+    }
+
+    const rules = client.snapshotInterceptRules(arena) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    buf.appendSlice(arena, "{\"rules\":[") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    for (rules, 0..) |r, i| {
+        if (i > 0) buf.appendSlice(arena, ",") catch return;
+        writeInterceptRuleJson(&buf, arena, r) catch return;
+    }
+    buf.print(arena, "],\"count\":{d}}}", .{rules.len}) catch return;
+
+    resp.sendJson(request, buf.items);
+}
+
+fn handleInterceptRulesClear(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
+        return;
+    };
+
+    const client = bridge.getCdpClient(tab_id) orelse {
+        resp.sendError(request, 404, "Tab not found");
+        return;
+    };
+
+    client.clearInterceptRules();
+
+    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"rules cleared\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -2353,10 +2753,7 @@ fn handleClose(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
 
 fn handleCookies(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2389,11 +2786,7 @@ fn handleCookies(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 }
 
 fn handleCookiesClear(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2409,10 +2802,7 @@ fn handleCookiesClear(request: *std.http.Server.Request, arena: std.mem.Allocato
 
 fn handleStorage(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, storage_type: []const u8) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2454,11 +2844,7 @@ fn handleStorage(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 }
 
 fn handleStorageClear(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, storage_type: []const u8) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2597,11 +2983,7 @@ fn handleReload(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
 // ── Diff Snapshot Endpoint ──────────────────────────────────────────────
 
 fn handleDiffSnapshot(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -2694,12 +3076,17 @@ fn writeJsonField(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, key: []
     try buf.print(allocator, "\"{s}\":\"{s}\"", .{ key, escaped });
 }
 
+/// Write a single JSON-escaped string value (with surrounding quotes, no
+/// key) — the bare-value counterpart to `writeJsonField`'s "key":"value".
+fn writeJsonStringValue(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, value: []const u8) !void {
+    const escaped = try json_util.jsonEscape(value, allocator);
+    defer allocator.free(escaped);
+    try buf.print(allocator, "\"{s}\"", .{escaped});
+}
+
 fn handleEmulate(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2735,10 +3122,7 @@ fn handleEmulate(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 fn handleGeolocation(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -2770,10 +3154,7 @@ fn handleGeolocation(request: *std.http.Server.Request, arena: std.mem.Allocator
 
 fn handleUpload(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ref = getQueryParam(target, "ref") orelse {
         resp.sendError(request, 400, "Missing ref parameter");
         return;
@@ -2894,10 +3275,7 @@ fn handleAuthProfileSave(
     cfg: Config,
 ) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const name = getQueryParam(target, "name") orelse {
         resp.sendError(request, 400, "Missing name parameter");
         return;
@@ -2968,10 +3346,7 @@ fn handleAuthProfileLoad(
     cfg: Config,
 ) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const name = getQueryParam(target, "name") orelse {
         resp.sendError(request, 400, "Missing name parameter");
         return;
@@ -3121,10 +3496,7 @@ fn handleDebugEnable(
     bridge: *Bridge,
 ) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const freeze = getQueryParam(target, "freeze");
     const freeze_enabled = freeze != null and std.mem.eql(u8, freeze.?, "true");
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -3201,11 +3573,7 @@ fn handleDebugDisable(
     arena: std.mem.Allocator,
     bridge: *Bridge,
 ) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -3263,27 +3631,55 @@ fn handleDebugDisable(
 
 fn handleAnnotatedScreenshot(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ref = getQueryParam(target, "ref") orelse {
         resp.sendError(request, 400, "Missing ref parameter");
         return;
     };
-    _ = ref;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
 
+    // Resolve the ref to a real backendNodeId the same way /upload does.
+    bridge.mu.lockShared();
+    const cache = bridge.snapshots.get(tab_id);
+    bridge.mu.unlockShared();
+    const bid = if (cache) |c| c.refs.get(ref) else null;
+    const backend_node_id = bid orelse {
+        resp.sendError(request, 400, "Ref not found. Call /snapshot first to populate refs");
+        return;
+    };
+
+    // Overlay.highlightNode requires Overlay.enable to have been called on
+    // this session first -- without it Chrome rejects the call outright
+    // ({"error":{"code":-32600,"message":"Overlay must be enabled before a
+    // tool can be shown"}}), which the old code never checked for (it just
+    // discarded the response), so the highlight silently never appeared.
+    _ = client.send(arena, protocol.Methods.overlay_enable, null) catch {
+        resp.sendError(request, 502, "Overlay.enable failed");
+        return;
+    };
+
     // Highlight the node with an overlay
-    const highlight_params = "{\"nodeId\":0,\"highlightConfig\":{\"showInfo\":true,\"contentColor\":{\"r\":111,\"g\":168,\"b\":220,\"a\":0.66}}}";
-    _ = client.send(arena, protocol.Methods.overlay_highlight_node, highlight_params) catch {
+    const highlight_params = std.fmt.allocPrint(arena, "{{\"backendNodeId\":{d},\"highlightConfig\":{{\"showInfo\":true,\"contentColor\":{{\"r\":111,\"g\":168,\"b\":220,\"a\":0.66}}}}}}", .{backend_node_id}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const highlight_response = client.send(arena, protocol.Methods.overlay_highlight_node, highlight_params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
+    // client.send only errors on transport failure -- a CDP-level rejection
+    // (bad backendNodeId, domain not enabled, etc.) still comes back as a
+    // normal response with an embedded "error" field and must be checked
+    // explicitly, same as the Network.getResponseBody handling above.
+    if (jsonscan.extractObject(highlight_response, "error")) |err_obj| {
+        const err_msg = jsonscan.extractField(err_obj, "message") orelse "Overlay.highlightNode returned an error";
+        resp.sendError(request, 502, err_msg);
+        return;
+    }
 
     // Take screenshot
     const screenshot_params = "{\"format\":\"png\"}";
@@ -3300,10 +3696,7 @@ fn handleAnnotatedScreenshot(request: *std.http.Server.Request, arena: std.mem.A
 
 fn handleDiffScreenshot(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const delay_str = getQueryParam(target, "delay") orelse "1000";
 
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -3336,66 +3729,219 @@ fn handleDiffScreenshot(request: *std.http.Server.Request, arena: std.mem.Alloca
     resp.sendJson(request, body);
 }
 
-fn handleScreencastStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+fn writeScreencastFrameJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, frame: ScreencastFrameRecord) !void {
+    try buf.appendSlice(allocator, "{");
+    try writeJsonField(buf, allocator, "data_b64", frame.data_b64);
+    try buf.appendSlice(allocator, ",");
+    try buf.print(allocator, "\"timestamp\":{d},\"device_width\":{d},\"device_height\":{d},\"session_id\":{d}", .{
+        frame.timestamp, frame.device_width, frame.device_height, frame.session_id,
+    });
+    try buf.appendSlice(allocator, "}");
+}
 
+/// Shared core for /screencast/start and /video/start -- CDP has exactly one
+/// frame-streaming mechanism (Page.startScreencast); "video" is not a
+/// separate capability, so both endpoints drive the same client.zig
+/// ScreencastRing collector. `status_word` and `extra_note` are the only
+/// things that differ between the two, so they're honest about which is
+/// which rather than /video silently aliasing /screencast's response.
+fn startScreencastCapture(
+    request: *std.http.Server.Request,
+    arena: std.mem.Allocator,
+    bridge: *Bridge,
+    status_word: []const u8,
+    extra_note: ?[]const u8,
+) void {
+    const target = request.head.target;
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
 
-    const params = "{\"format\":\"jpeg\",\"quality\":80}";
+    // Validate rather than interpolate raw query text into the outgoing CDP
+    // command: format is one of two literals, quality is clamped to CDP's
+    // valid 0-100 range.
+    const format_param = getQueryParam(target, "format") orelse "jpeg";
+    const format: []const u8 = if (std.mem.eql(u8, format_param, "png")) "png" else "jpeg";
+    const quality: u8 = blk: {
+        const q_str = getQueryParam(target, "quality") orelse "80";
+        const q = std.fmt.parseInt(u16, q_str, 10) catch 80;
+        break :blk @intCast(@min(q, 100));
+    };
+    const params = std.fmt.allocPrint(arena, "{{\"format\":\"{s}\",\"quality\":{d}}}", .{ format, quality }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    // Fresh session: don't hand back frames left over from a prior
+    // start/stop pair that was never drained.
+    client.clearScreencastFrames();
+
     _ = client.send(arena, protocol.Methods.page_start_screencast, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
 
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"screencast_started\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+    var buf: std.ArrayList(u8) = .empty;
+    buf.print(
+        arena,
+        "{{\"status\":\"{s}_started\",\"tab_id\":\"{s}\",\"format\":\"{s}\",\"quality\":{d}",
+        .{ status_word, tab_id, format, quality },
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    resp.sendJson(request, body);
-}
-
-fn handleScreencastStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    if (extra_note) |note| {
+        buf.appendSlice(arena, ",") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        writeJsonField(&buf, arena, "note", note) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+    }
+    buf.appendSlice(arena, "}") catch {
+        resp.sendError(request, 500, "Internal Server Error");
         return;
     };
+    resp.sendJson(request, buf.items);
+}
 
+/// Shared core for /screencast/stop and /video/stop. See
+/// `CdpClient.snapshotScreencastFrames`'s doc comment for the design-limit
+/// context: frames only get pulled off the socket while some command is in
+/// flight, so this drains explicitly (best-effort, no-op on Windows) both
+/// before and after the stop command to catch frames Chrome sent right up
+/// to (and just after) the stop ack.
+///
+/// `?frames=` controls response size, since a full session can legitimately
+/// hold up to the ring's own 32 MiB / 30-frame cap:
+///   - "latest" (default): just the single most recent frame -- the common
+///     "give me a snapshot" case, kept small on purpose.
+///   - "all": every held frame, inline. Safe to inline because the ring
+///     upstream already bounds this to <=32 MiB; this is the "retrieval
+///     path" opt-in for callers who actually want the whole capture.
+///   - "none": counts only, no frame bytes at all.
+fn stopScreencastCapture(
+    request: *std.http.Server.Request,
+    arena: std.mem.Allocator,
+    bridge: *Bridge,
+    status_word: []const u8,
+    extra_note: ?[]const u8,
+) void {
+    const target = request.head.target;
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
+
+    client.drainWsEvents(arena, 1);
 
     _ = client.send(arena, protocol.Methods.page_stop_screencast, null) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
 
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"screencast_stopped\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+    // Chrome can still deliver a frame or two that raced the stop ack.
+    client.drainWsEvents(arena, 1);
+
+    const frames_mode = getQueryParam(target, "frames") orelse "latest";
+    const frames = client.snapshotScreencastFrames(arena) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    resp.sendJson(request, body);
+    const dropped = client.droppedScreencastFrameCount();
+    const frame_count = frames.len;
+    client.clearScreencastFrames();
+
+    var buf: std.ArrayList(u8) = .empty;
+    buf.print(
+        arena,
+        "{{\"status\":\"{s}_stopped\",\"tab_id\":\"{s}\",\"frame_count\":{d},\"dropped_oversize\":{d}",
+        .{ status_word, tab_id, frame_count, dropped },
+    ) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    if (std.mem.eql(u8, frames_mode, "all")) {
+        buf.appendSlice(arena, ",\"frames\":[") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        for (frames, 0..) |f, i| {
+            if (i > 0) buf.appendSlice(arena, ",") catch return;
+            writeScreencastFrameJson(&buf, arena, f) catch return;
+        }
+        buf.appendSlice(arena, "]") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+    } else if (!std.mem.eql(u8, frames_mode, "none")) {
+        buf.appendSlice(arena, ",\"latest_frame\":") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        if (frame_count > 0) {
+            writeScreencastFrameJson(&buf, arena, frames[frame_count - 1]) catch {
+                resp.sendError(request, 500, "Internal Server Error");
+                return;
+            };
+        } else {
+            buf.appendSlice(arena, "null") catch {
+                resp.sendError(request, 500, "Internal Server Error");
+                return;
+            };
+        }
+    }
+
+    if (extra_note) |note| {
+        buf.appendSlice(arena, ",") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        writeJsonField(&buf, arena, "note", note) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+    }
+    buf.appendSlice(arena, "}") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, buf.items);
 }
 
-const handleVideoStart = handleScreencastStart;
-const handleVideoStop = handleScreencastStop;
+fn handleScreencastStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    startScreencastCapture(request, arena, bridge, "screencast", null);
+}
+
+fn handleScreencastStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    stopScreencastCapture(request, arena, bridge, "screencast", null);
+}
+
+// kuri has no video encoder (no ffmpeg/libav dependency) -- there is no
+// second capability behind /video/*, so rather than a canned response that
+// silently reused /screencast's wording, these are honest about reusing
+// Page.startScreencast/stopScreencast and returning raw frames, not a
+// .mp4/.webm file.
+const video_note = "kuri does not encode video (no ffmpeg/libav dependency). This drives the same CDP Page.startScreencast/stopScreencast capture as /screencast/*, returning base64 frames with timestamps -- no video file is produced. Encode client-side if you need one.";
+
+fn handleVideoStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    startScreencastCapture(request, arena, bridge, "video", video_note);
+}
+
+fn handleVideoStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    stopScreencastCapture(request, arena, bridge, "video", video_note);
+}
 
 // ── Lightpanda Parity Endpoints ─────────────────────────────────────────
 
 fn handleMarkdown(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -3452,11 +3998,7 @@ fn handleMarkdown(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 }
 
 fn handleLinks(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -3479,10 +4021,7 @@ fn handleLinks(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
 
 fn handlePdf(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -3504,10 +4043,7 @@ fn handlePdf(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge
 
 fn handleDomQuery(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const selector = getQueryParam(target, "selector") orelse {
         resp.sendError(request, 400, "Missing selector parameter");
         return;
@@ -3546,10 +4082,7 @@ fn handleDomQuery(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 
 fn handleDomHtml(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const node_id_str = getQueryParam(target, "node_id") orelse {
         resp.sendError(request, 400, "Missing node_id parameter");
         return;
@@ -3573,10 +4106,7 @@ fn handleDomHtml(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 fn handleCookiesDelete(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const name = getQueryParam(target, "name") orelse {
         resp.sendError(request, 400, "Missing name parameter");
         return;
@@ -3612,11 +4142,7 @@ fn handleCookiesDelete(request: *std.http.Server.Request, arena: std.mem.Allocat
 }
 
 fn handleHeaders(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -3647,10 +4173,7 @@ fn handleHeaders(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 fn handleScriptInject(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     // Support both query param and POST body for script source.
     // POST body is preferred for large scripts that exceed URL length limits.
@@ -4026,11 +4549,7 @@ fn extractJsonDelimitedField(json: []const u8, field: []const u8, open: u8, clos
 }
 
 fn handleStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -4046,10 +4565,7 @@ fn handleStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
 
 fn handleScrollIntoView(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ref = getQueryParam(target, "ref") orelse {
         resp.sendError(request, 400, "Missing ref parameter");
         return;
@@ -4095,10 +4611,7 @@ fn handleScrollIntoView(request: *std.http.Server.Request, arena: std.mem.Alloca
 
 fn handleDrag(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const src_ref = getQueryParam(target, "src") orelse {
         resp.sendError(request, 400, "Missing src ref parameter");
         return;
@@ -4153,26 +4666,50 @@ fn handleDrag(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
         return;
     };
 
-    // Use JS to perform drag-and-drop via DataTransfer events
-    const js = std.fmt.allocPrint(arena,
-        \\{{"objectId":"{s}","functionDeclaration":"function() {{ var src=this; var tgtOid='{s}'; var dt=new DataTransfer(); src.dispatchEvent(new DragEvent('dragstart',{{bubbles:true,dataTransfer:dt}})); src.dispatchEvent(new DragEvent('drag',{{bubbles:true,dataTransfer:dt}})); return 'drag_started'; }}","returnByValue":true}}
-    , .{ src_oid, tgt_oid }) catch {
+    // Perform a full drag-and-drop sequence via DataTransfer events. CDP's
+    // Runtime.callFunctionOn only binds `this` to the object matching the
+    // given objectId, so a single call cannot dispatch on both src and tgt —
+    // this needs three separate calls sharing state through a page-global
+    // (window.__kuri_dragDT), same idea as Playwright's dragTo internals.
+    const start_js =
+        \\{"objectId":"SRC_OID","functionDeclaration":"function() { var dt = new DataTransfer(); window.__kuri_dragDT = dt; this.dispatchEvent(new DragEvent('dragstart',{bubbles:true,cancelable:true,dataTransfer:dt})); this.dispatchEvent(new DragEvent('drag',{bubbles:true,cancelable:true,dataTransfer:dt})); return 'dragstart_ok'; }","returnByValue":true}
+    ;
+    const start_params = std.mem.replaceOwned(u8, arena, start_js, "SRC_OID", src_oid) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const response = client.send(arena, protocol.Methods.runtime_call_function_on, js) catch {
-        resp.sendError(request, 502, "Drag failed");
+    _ = client.send(arena, protocol.Methods.runtime_call_function_on, start_params) catch {
+        resp.sendError(request, 502, "dragstart failed");
         return;
     };
-    resp.sendJson(request, response);
+
+    const drop_js =
+        \\{"objectId":"TGT_OID","functionDeclaration":"function() { var dt = window.__kuri_dragDT; this.dispatchEvent(new DragEvent('dragenter',{bubbles:true,cancelable:true,dataTransfer:dt})); this.dispatchEvent(new DragEvent('dragover',{bubbles:true,cancelable:true,dataTransfer:dt})); this.dispatchEvent(new DragEvent('drop',{bubbles:true,cancelable:true,dataTransfer:dt})); return 'drop_ok'; }","returnByValue":true}
+    ;
+    const drop_params = std.mem.replaceOwned(u8, arena, drop_js, "TGT_OID", tgt_oid) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const drop_response = client.send(arena, protocol.Methods.runtime_call_function_on, drop_params) catch {
+        resp.sendError(request, 502, "drop failed");
+        return;
+    };
+
+    const end_js =
+        \\{"objectId":"SRC_OID","functionDeclaration":"function() { var dt = window.__kuri_dragDT; this.dispatchEvent(new DragEvent('dragend',{bubbles:true,cancelable:true,dataTransfer:dt})); delete window.__kuri_dragDT; return 'dragend_ok'; }","returnByValue":true}
+    ;
+    const end_params = std.mem.replaceOwned(u8, arena, end_js, "SRC_OID", src_oid) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    _ = client.send(arena, protocol.Methods.runtime_call_function_on, end_params) catch {};
+
+    resp.sendJson(request, drop_response);
 }
 
 fn handleKeyboardType(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const text = getDecodedQueryParamAlloc(arena, target, "text") orelse {
         resp.sendError(request, 400, "Missing text parameter");
         return;
@@ -4182,9 +4719,12 @@ fn handleKeyboardType(request: *std.http.Server.Request, arena: std.mem.Allocato
         return;
     };
 
-    // Type each character via Input.dispatchKeyEvent
-    for (text) |ch| {
-        const char_str = std.fmt.allocPrint(arena, "{c}", .{ch}) catch continue;
+    // Type each Unicode codepoint via Input.dispatchKeyEvent. Iterating over
+    // raw bytes (text: []const u8) would split any multi-byte UTF-8 character
+    // (accents, emoji, CJK, ...) into individual invalid bytes.
+    var utf8_iter: std.unicode.Utf8Iterator = .{ .bytes = text, .i = 0 };
+    while (utf8_iter.nextCodepointSlice()) |cp_bytes| {
+        const char_str = jsonEscapeAlloc(arena, cp_bytes) orelse continue;
         const key_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyDown\",\"text\":\"{s}\",\"key\":\"{s}\",\"unmodifiedText\":\"{s}\"}}", .{ char_str, char_str, char_str }) catch continue;
         _ = client.send(arena, protocol.Methods.input_dispatch_key_event, key_params) catch continue;
         const up_params = std.fmt.allocPrint(arena, "{{\"type\":\"keyUp\",\"key\":\"{s}\"}}", .{char_str}) catch continue;
@@ -4199,10 +4739,7 @@ fn handleKeyboardType(request: *std.http.Server.Request, arena: std.mem.Allocato
 
 fn handleKeyboardInsertText(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const text = getDecodedQueryParamAlloc(arena, target, "text") orelse {
         resp.sendError(request, 400, "Missing text parameter");
         return;
@@ -4225,10 +4762,7 @@ fn handleKeyboardInsertText(request: *std.http.Server.Request, arena: std.mem.Al
 
 fn handleKeyDown(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const key = getQueryParam(target, "key") orelse {
         resp.sendError(request, 400, "Missing key parameter");
         return;
@@ -4251,10 +4785,7 @@ fn handleKeyDown(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 fn handleKeyUp(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const key = getQueryParam(target, "key") orelse {
         resp.sendError(request, 400, "Missing key parameter");
         return;
@@ -4277,10 +4808,7 @@ fn handleKeyUp(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
 
 fn handleWait(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const selector = getDecodedQueryParamAlloc(arena, target, "selector");
     const wait_text = getDecodedQueryParamAlloc(arena, target, "text");
     const wait_url = getDecodedQueryParamAlloc(arena, target, "url");
@@ -4602,10 +5130,7 @@ fn handleTabClose(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 
 fn handleHighlight(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ref = getQueryParam(target, "ref");
     const selector = getQueryParam(target, "selector");
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -4653,9 +5178,8 @@ fn handleHighlight(request: *std.http.Server.Request, arena: std.mem.Allocator, 
 }
 
 fn handleErrors(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
         return;
     };
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -4665,7 +5189,7 @@ fn handleErrors(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
 
     // Enable Runtime to collect exceptions, then evaluate to get any stored errors
     _ = client.send(arena, protocol.Methods.runtime_enable, null) catch {};
-    const params = "{\"expression\":\"(function(){ var e=window.__kuri_errors||[]; return JSON.stringify(e); })()\",\"returnByValue\":true}";
+    const params = "{\"expression\":\"(function(){ var e=window.__kuri_errors||[]; window.__kuri_errors=[]; return JSON.stringify(e); })()\",\"returnByValue\":true}";
     const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
@@ -4675,10 +5199,7 @@ fn handleErrors(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
 
 fn handleSetOffline(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const mode = getQueryParam(target, "mode") orelse "on";
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -4704,10 +5225,7 @@ fn handleSetOffline(request: *std.http.Server.Request, arena: std.mem.Allocator,
 
 fn handleSetMedia(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const scheme = getQueryParam(target, "scheme") orelse "dark";
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -4732,10 +5250,7 @@ fn handleSetMedia(request: *std.http.Server.Request, arena: std.mem.Allocator, b
 
 fn handleSetCredentials(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const username = getQueryParam(target, "username") orelse {
         resp.sendError(request, 400, "Missing username parameter");
         return;
@@ -4749,10 +5264,16 @@ fn handleSetCredentials(request: *std.http.Server.Request, arena: std.mem.Alloca
         return;
     };
 
-    // Enable Fetch to intercept auth challenges
-    _ = client.send(arena, protocol.Methods.fetch_enable, "{\"handleAuthRequests\":true}") catch {};
+    // NOTE: this deliberately does NOT call Fetch.enable({handleAuthRequests:true}).
+    // Doing so makes Chrome pause on Fetch.authRequired for real 401/407 challenges,
+    // and nothing in this codebase answers that event (no Fetch.continueWithAuth
+    // anywhere) — the paused request would hang forever. Real interactive
+    // auth-challenge handling needs the async background CDP event reader
+    // described for /intercept; until that exists, rely solely on the
+    // preemptive Authorization header below, which works for servers that
+    // accept preemptive Basic auth (the common case).
 
-    // Also set as Authorization header for immediate use
+    // Set as a preemptive Authorization header for immediate use
     const b64_input = std.fmt.allocPrint(arena, "{s}:{s}", .{ username, password }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
@@ -4851,16 +5372,21 @@ fn handleFind(request: *std.http.Server.Request, arena: std.mem.Allocator, bridg
 
 fn handleTraceStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
     const categories = getQueryParam(target, "categories") orelse "-*,devtools.timeline,v8.execute,disabled-by-default-devtools.timeline";
-    const params = std.fmt.allocPrint(arena, "{{\"categories\":\"{s}\",\"options\":\"sampling-frequency=10000\"}}", .{categories}) catch {
+    // transferMode: ReturnAsStream is required for /trace/stop to be able to
+    // read the trace back at all -- without it, Tracing.tracingComplete
+    // carries no `stream` handle and the trace only exists as a series of
+    // Tracing.dataCollected events this codebase does not accumulate.
+    const params = std.fmt.allocPrint(
+        arena,
+        "{{\"categories\":\"{s}\",\"options\":\"sampling-frequency=10000\",\"transferMode\":\"ReturnAsStream\"}}",
+        .{categories},
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -4877,28 +5403,180 @@ fn handleTraceStart(request: *std.http.Server.Request, arena: std.mem.Allocator,
 }
 
 fn handleTraceStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const response = client.send(arena, protocol.Methods.tracing_end, null) catch {
+
+    _ = client.send(arena, protocol.Methods.tracing_end, null) catch {
         resp.sendError(request, 502, "Tracing.end failed");
         return;
     };
-    resp.sendJson(request, response);
+
+    // Tracing.end only *requests* a stop; the trace itself isn't ready
+    // until Chrome emits Tracing.tracingComplete (carrying the IO stream
+    // handle, since /trace/start requests transferMode: ReturnAsStream).
+    // waitForEvent is what actually pumps the read loop so
+    // collectTracingComplete (client.zig) gets a chance to observe and
+    // store it -- see the "paused CDP events only make forward progress
+    // while a command is in flight" design limit.
+    if (!client.waitForEvent(arena, "Tracing.tracingComplete", 400)) {
+        resp.sendError(request, 504, "Tracing.tracingComplete was not observed before timing out");
+        return;
+    }
+
+    const stream_rec = (client.takeTraceStream(arena) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    }) orelse {
+        // tracingComplete fired without a `stream` field (e.g. an empty
+        // trace). Nothing to drain -- say so honestly rather than
+        // fabricating trace content that was never produced.
+        const body = std.fmt.allocPrint(
+            arena,
+            "{{\"ok\":true,\"status\":\"trace_complete_no_stream\",\"tab_id\":\"{s}\"}}",
+            .{tab_id},
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        resp.sendJson(request, body);
+        return;
+    };
+
+    const home = compat.getenv("HOME") orelse {
+        resp.sendError(request, 500, "Cannot determine HOME directory to write trace file");
+        return;
+    };
+    const dir_path = std.fmt.allocPrint(arena, "{s}/.kuri/traces", .{home}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    compat.cwdMakePath(dir_path) catch {
+        resp.sendError(request, 500, "Failed to create ~/.kuri/traces directory");
+        return;
+    };
+    const file_path = std.fmt.allocPrint(
+        arena,
+        "{s}/trace-{s}-{d}.json",
+        .{ dir_path, tab_id, compat.milliTimestamp() },
+    ) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    const fd = compat.cwdCreateFile(file_path) catch {
+        resp.sendError(request, 500, "Failed to create trace file (unsupported on this platform, or a disk error)");
+        return;
+    };
+    var closed = false;
+    defer if (!closed) compat.fdClose(fd);
+
+    const escaped_handle = jsonEscapeAlloc(arena, stream_rec.stream_handle) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    // Trace files can legitimately be huge (real profiling sessions run
+    // tens to hundreds of MB); stream to disk chunk-by-chunk via IO.read
+    // rather than buffering the whole thing in memory, bounded by a hard
+    // safety ceiling so a runaway stream can't grow the file unbounded.
+    const max_trace_bytes: usize = 512 * 1024 * 1024;
+    const chunk_size: usize = 1024 * 1024;
+    var total_bytes: usize = 0;
+    var eof = false;
+    var read_error: ?[]const u8 = null;
+    var iterations: usize = 0;
+
+    while (!eof) {
+        iterations += 1;
+        if (iterations > 5000) {
+            read_error = "IO.read did not reach eof within the iteration safety cap";
+            break;
+        }
+        const io_params = std.fmt.allocPrint(arena, "{{\"handle\":\"{s}\",\"size\":{d}}}", .{ escaped_handle, chunk_size }) catch {
+            read_error = "Internal Server Error";
+            break;
+        };
+        const io_response = client.send(arena, protocol.Methods.io_read, io_params) catch {
+            read_error = "IO.read failed";
+            break;
+        };
+        const data = jsonscan.extractField(io_response, "data") orelse {
+            read_error = "IO.read returned no data field";
+            break;
+        };
+        const eof_str = jsonscan.extractField(io_response, "eof") orelse "false";
+        eof = std.mem.eql(u8, eof_str, "true");
+        const b64_str = jsonscan.extractField(io_response, "base64Encoded");
+        const is_base64 = if (b64_str) |v| std.mem.eql(u8, v, "true") else false;
+
+        var decoded: []const u8 = &.{};
+        if (is_base64) {
+            const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(data) catch {
+                read_error = "Invalid base64 in IO.read response";
+                break;
+            };
+            const out = arena.alloc(u8, decoded_len) catch {
+                read_error = "Internal Server Error";
+                break;
+            };
+            std.base64.standard.Decoder.decode(out, data) catch {
+                read_error = "Invalid base64 in IO.read response";
+                break;
+            };
+            decoded = out;
+        } else {
+            decoded = json_util.jsonUnescape(arena, data) catch {
+                read_error = "Internal Server Error";
+                break;
+            };
+        }
+
+        if (total_bytes + decoded.len > max_trace_bytes) {
+            read_error = "Trace exceeded the 512 MiB safety cap; aborted";
+            break;
+        }
+        compat.fdWriteAll(fd, decoded) catch {
+            read_error = "Failed to write trace file";
+            break;
+        };
+        total_bytes += decoded.len;
+    }
+
+    compat.fdClose(fd);
+    closed = true;
+
+    // Always tell Chrome we're done with the stream, success or not.
+    if (std.fmt.allocPrint(arena, "{{\"handle\":\"{s}\"}}", .{escaped_handle}) catch null) |close_params| {
+        _ = client.send(arena, protocol.Methods.io_close, close_params) catch {};
+    }
+
+    if (read_error) |msg| {
+        compat.cwdDeleteFile(file_path) catch {};
+        resp.sendError(request, 502, msg);
+        return;
+    }
+
+    const escaped_path = jsonEscapeAlloc(arena, file_path) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const escaped_format = jsonEscapeAlloc(arena, stream_rec.trace_format) orelse "";
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"ok\":true,\"status\":\"trace_complete\",\"tab_id\":\"{s}\",\"path\":\"{s}\",\"bytes\":{d},\"data_loss\":{s},\"trace_format\":\"{s}\"}}",
+        .{ tab_id, escaped_path, total_bytes, if (stream_rec.data_loss) "true" else "false", escaped_format },
+    ) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, body);
 }
 
 fn handleProfilerStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -4920,11 +5598,7 @@ fn handleProfilerStart(request: *std.http.Server.Request, arena: std.mem.Allocat
 }
 
 fn handleProfilerStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -4938,17 +5612,25 @@ fn handleProfilerStop(request: *std.http.Server.Request, arena: std.mem.Allocato
 }
 
 fn handleInspect(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    _ = client.send(arena, protocol.Methods.inspector_enable, null) catch {};
-    const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"message\":\"DevTools enabled\",\"tab_id\":\"{s}\"}}", .{tab_id}) catch {
+    // Inspector.enable has no synchronous introspection counterpart in
+    // CDP -- it only arms two future notifications (Inspector.targetCrashed,
+    // Inspector.detached) that this codebase doesn't yet surface anywhere.
+    // Report exactly that instead of a canned "DevTools enabled" message
+    // implying a devtools session or queryable state now exists.
+    _ = client.send(arena, protocol.Methods.inspector_enable, null) catch {
+        resp.sendError(request, 502, "Inspector.enable failed");
+        return;
+    };
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"ok\":true,\"action\":\"inspector_enable\",\"tab_id\":\"{s}\",\"note\":\"Inspector.enable succeeded. CDP's Inspector domain has no synchronous introspection command -- it only arms Inspector.targetCrashed/Inspector.detached notifications, which kuri does not yet surface. There is no further state to retrieve from this endpoint.\"}}",
+        .{tab_id},
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -5041,10 +5723,7 @@ fn handleSessionList(request: *std.http.Server.Request, arena: std.mem.Allocator
 
 fn handleSetViewport(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const width = getQueryParam(target, "width") orelse "1280";
     const height = getQueryParam(target, "height") orelse "720";
     const scale = getQueryParam(target, "scale") orelse "1";
@@ -5070,10 +5749,7 @@ fn handleSetViewport(request: *std.http.Server.Request, arena: std.mem.Allocator
 
 fn handleSetUserAgent(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ua = getDecodedQueryParamAlloc(arena, target, "ua") orelse {
         resp.sendError(request, 400, "Missing ua parameter");
         return;
@@ -5104,10 +5780,7 @@ fn handleSetUserAgent(request: *std.http.Server.Request, arena: std.mem.Allocato
 
 fn handleDomAttributes(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const ref = getQueryParam(target, "ref");
     const selector = getQueryParam(target, "selector");
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -5174,24 +5847,74 @@ fn handleFrames(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
     resp.sendJson(request, response);
 }
 
+fn writeNetworkRecordJson(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, rec: NetworkRecord) !void {
+    try buf.appendSlice(allocator, "{");
+    try writeJsonField(buf, allocator, "request_id", rec.request_id);
+    try buf.appendSlice(allocator, ",");
+    try writeJsonField(buf, allocator, "url", rec.url);
+    try buf.appendSlice(allocator, ",");
+    try writeJsonField(buf, allocator, "method", rec.method);
+    try buf.appendSlice(allocator, ",");
+    try writeJsonField(buf, allocator, "mime_type", rec.mime_type);
+    try buf.print(allocator, ",\"url_truncated\":{s},\"timestamp\":{d}}}", .{ if (rec.url_truncated) "true" else "false", rec.timestamp });
+}
+
+/// `mode=enable|disable` (default `enable`) flip Network.enable/disable,
+/// same as before. `mode=list` is new: a lightweight, read-only view over
+/// the bounded 200-record ring client.zig's Network collector keeps
+/// passively (url/method/mime_type/timestamp only) -- it never touches
+/// enable/disable state. This deliberately does NOT duplicate /har/*:
+/// /har/start + /har/stop gives full headers/timing/bodies via a dedicated
+/// recorder; /network?mode=list is the cheap "what's happened recently"
+/// check that doesn't require starting a HAR capture first.
 fn handleNetwork(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const mode = getQueryParam(target, "mode") orelse "enable";
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
 
+    if (std.mem.eql(u8, mode, "list")) {
+        client.drainWsEvents(arena, 1);
+        const url_filter = getDecodedQueryParamAlloc(arena, target, "url");
+        const records = client.snapshotNetworkRequests(arena) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        var buf: std.ArrayList(u8) = .empty;
+        buf.appendSlice(arena, "{\"ok\":true,\"requests\":[") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        var written: usize = 0;
+        for (records) |rec| {
+            if (url_filter) |wanted| {
+                if (std.mem.indexOf(u8, rec.url, wanted) == null) continue;
+            }
+            if (written > 0) buf.appendSlice(arena, ",") catch return;
+            writeNetworkRecordJson(&buf, arena, rec) catch return;
+            written += 1;
+        }
+        buf.print(
+            arena,
+            "],\"count\":{d},\"tab_id\":\"{s}\",\"note\":\"lightweight view over a bounded 200-record ring (url/method/mime_type/timestamp only); for full headers/timing/response bodies use /har/start + /har/stop\"}}",
+            .{ written, tab_id },
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        resp.sendJson(request, buf.items);
+        return;
+    }
+
     const method = if (std.mem.eql(u8, mode, "disable")) protocol.Methods.network_disable else protocol.Methods.network_enable;
-    const response = client.send(arena, method, null) catch {
+    _ = client.send(arena, method, null) catch {
         resp.sendError(request, 502, "Network command failed");
         return;
     };
-    _ = response;
+    if (std.mem.eql(u8, mode, "disable")) client.clearNetworkRequests();
     const body = std.fmt.allocPrint(arena, "{{\"status\":\"ok\",\"network\":\"{s}\"}}", .{mode}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
@@ -5201,10 +5924,7 @@ fn handleNetwork(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 fn handlePerfLcp(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const url = getDecodedQueryParamAlloc(arena, target, "url");
 
     const client = bridge.getCdpClient(tab_id) orelse {
@@ -5255,11 +5975,7 @@ fn handlePerfLcp(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 
 // --- Issue #111: Batch cookie injection via POST body ---
 fn handleCookiesSet(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -5283,16 +5999,54 @@ fn handleCookiesSet(request: *std.http.Server.Request, arena: std.mem.Allocator,
 }
 
 // --- Issue #112: Return captured request/response pairs ---
+// Backwards compatible: while interception is inactive for this tab
+// (nobody has called /intercept/start, or /intercept/stop already ran),
+// this falls back to the pre-existing Resource Timing API snapshot so
+// existing callers keep getting a non-empty answer. Once interception is
+// active, this returns the REAL Fetch.requestPaused records the
+// auto-responder recorded — including tabs where zero requests have paused
+// yet (an empty "requests":[] is still a real, correct answer once
+// active). The `source` field lets callers tell the two shapes apart.
 fn handleInterceptRequests(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
+    const tab_id = resolveEffectiveTabIdAlloc(arena, request, bridge) orelse {
+        resp.sendError(request, 400, "Missing tab_id parameter (or set X-Kuri-Session)");
         return;
     };
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
+
+    if (client.interceptActive()) {
+        const records = client.snapshotPausedRequests(arena) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+
+        var buf: std.ArrayList(u8) = .empty;
+        buf.appendSlice(arena, "{\"source\":\"intercepted\",\"requests\":[") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        for (records, 0..) |rec, i| {
+            if (i > 0) buf.appendSlice(arena, ",") catch return;
+            buf.appendSlice(arena, "{") catch return;
+            writeJsonField(&buf, arena, "request_id", rec.request_id) catch return;
+            buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&buf, arena, "url", rec.url) catch return;
+            buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&buf, arena, "method", rec.method) catch return;
+            buf.appendSlice(arena, ",") catch return;
+            writeJsonField(&buf, arena, "resource_type", rec.resource_type) catch return;
+            buf.appendSlice(arena, ",\"action\":\"") catch return;
+            buf.appendSlice(arena, @tagName(rec.action_taken)) catch return;
+            buf.print(arena, "\",\"status\":{d},\"timestamp\":{d}}}", .{ rec.status, rec.timestamp }) catch return;
+        }
+        buf.print(arena, "],\"count\":{d}}}", .{records.len}) catch return;
+
+        resp.sendJson(request, buf.items);
+        return;
+    }
 
     // Use Runtime.evaluate to capture performance entries (Resource Timing API)
     // This gives us all network requests without needing to maintain server-side state
@@ -5315,7 +6069,15 @@ fn handleInterceptRequests(request: *std.http.Server.Request, arena: std.mem.All
         return;
     };
 
-    resp.sendJson(request, response);
+    // Splice a "source" field into the CDP response's top-level object so
+    // existing callers parsing .result.result.value keep working exactly
+    // as before, while new callers can check .source.
+    const wrapped = if (response.len > 0 and response[0] == '{')
+        std.fmt.allocPrint(arena, "{{\"source\":\"resource_timing\",{s}", .{response[1..]}) catch response
+    else
+        response;
+
+    resp.sendJson(request, wrapped);
 }
 
 // --- Issue #113: Cross-platform browser cookie DB extraction ---
@@ -5421,11 +6183,7 @@ fn handleAuthExtract(request: *std.http.Server.Request, arena: std.mem.Allocator
 
 // --- Issue #114: WebSocket message capture ---
 fn handleWsStart(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -5474,11 +6232,7 @@ fn handleWsStart(request: *std.http.Server.Request, arena: std.mem.Allocator, br
 }
 
 fn handleWsStop(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    const target = request.head.target;
-    const tab_id = getQueryParam(target, "tab_id") orelse {
-        resp.sendError(request, 400, "Missing tab_id parameter");
-        return;
-    };
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
@@ -5935,6 +6689,7 @@ fn handleDialogAuto(request: *std.http.Server.Request, arena: std.mem.Allocator,
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const mode = getQueryParam(target, "mode") orelse "accept";
+    const prompt_text: []const u8 = getDecodedQueryParamAlloc(arena, target, "text") orelse "";
 
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
@@ -5943,7 +6698,31 @@ fn handleDialogAuto(request: *std.http.Server.Request, arena: std.mem.Allocator,
 
     _ = client.send(arena, protocol.Methods.page_enable, null) catch {};
 
-    const accept_str = if (std.mem.eql(u8, mode, "dismiss")) "false" else "true";
+    // mode=off / mode=disable turns the CDP-level auto-responder back off
+    // without touching any dialog that might currently be open.
+    const disabling = std.mem.eql(u8, mode, "off") or std.mem.eql(u8, mode, "disable");
+    const accept = !std.mem.eql(u8, mode, "dismiss");
+    const accept_str = if (accept) "true" else "false";
+
+    // Wire the CDP read-loop auto-responder (client.zig) so
+    // Page.javascriptDialogOpening is answered even between HTTP calls —
+    // not just via the window-level JS listeners below, which only cover
+    // dialogs the page itself can see and only while this handler's own
+    // Runtime.evaluate calls are in flight.
+    client.setDialogAuto(!disabling, accept, prompt_text) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    if (disabling) {
+        const off_body = std.fmt.allocPrint(arena, "{{\"ok\":true,\"mode\":\"{s}\"}}", .{mode}) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        resp.sendJson(request, off_body);
+        return;
+    }
+
     const js = std.fmt.allocPrint(arena, "(() => {{ window.__kuri_dialog_auto = {s}; window.__kuri_dialog_log = []; window.addEventListener('beforeunload', (e) => {{ e.preventDefault(); }}); return 'auto-dialog-{s}'; }})()", .{ accept_str, mode }) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
@@ -6330,42 +7109,97 @@ fn handleWaitForFunction(request: *std.http.Server.Request, arena: std.mem.Alloc
     resp.sendJson(request, "{\"status\":\"timeout\",\"reason\":\"function_not_truthy\"}");
 }
 
+/// `?request_id=` (direct) or `?url=` (looked up against client.zig's
+/// bounded Network collector -- see `findNetworkRequestByUrl`) resolve a
+/// real CDP requestId, then this calls Network.getResponseBody against it.
+/// This replaced a `runtime_evaluate(fetch(url))` workaround: that re-issued
+/// a brand new same-origin-restricted request instead of returning what the
+/// page actually received (wrong body on redirects/POSTs/opaque responses,
+/// and simply failed cross-origin without CORS).
 fn handleResponseBody(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
-    const url_pattern = getDecodedQueryParamAlloc(arena, target, "url") orelse {
-        resp.sendError(request, 400, "Missing url parameter");
-        return;
-    };
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const escaped_url = jsonEscapeAlloc(arena, url_pattern) orelse {
+
+    const direct_request_id = getDecodedQueryParamAlloc(arena, target, "request_id");
+    var request_id: []const u8 = undefined;
+    var matched_url: ?[]const u8 = null;
+    if (direct_request_id) |rid| {
+        request_id = rid;
+    } else {
+        const url_pattern = getDecodedQueryParamAlloc(arena, target, "url") orelse {
+            resp.sendError(request, 400, "Missing request_id or url parameter");
+            return;
+        };
+        client.drainWsEvents(arena, 1);
+        const rec = (client.findNetworkRequestByUrl(arena, url_pattern) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        }) orelse {
+            resp.sendError(
+                request,
+                404,
+                "No recorded network request matches that url substring (is Network.enable active for this tab, e.g. via /network?mode=enable, and did the request already happen?)",
+            );
+            return;
+        };
+        request_id = rec.request_id;
+        matched_url = rec.url;
+    }
+
+    const escaped_request_id = jsonEscapeAlloc(arena, request_id) orelse {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const js = std.fmt.allocPrint(arena, "(async () => {{ try {{ const r = await fetch('{s}'); const t = await r.text(); return JSON.stringify({{status:r.status,url:r.url,body:t.substring(0,10000)}}); }} catch(e) {{ return JSON.stringify({{error:e.message}}); }} }})()", .{escaped_url}) catch {
+    const params = std.fmt.allocPrint(arena, "{{\"requestId\":\"{s}\"}}", .{escaped_request_id}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const escaped = jsonEscapeAlloc(arena, js) orelse {
-        resp.sendError(request, 500, "Internal Server Error");
+    const response = client.send(arena, protocol.Methods.network_get_response_body, params) catch {
+        resp.sendError(request, 502, "Network.getResponseBody failed");
         return;
     };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true,\"awaitPromise\":true}}", .{escaped}) catch {
-        resp.sendError(request, 500, "Internal Server Error");
+
+    if (jsonscan.extractObject(response, "error")) |err_obj| {
+        const err_msg = jsonscan.extractField(err_obj, "message") orelse "Network.getResponseBody returned an error";
+        resp.sendError(request, 502, err_msg);
         return;
-    };
-    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
-        resp.sendError(request, 502, "CDP command failed");
-        return;
-    };
-    const val = extractSimpleJsonString(response, 0, "\"value\"") orelse {
+    }
+
+    const body_field = jsonscan.extractField(response, "body") orelse {
         resp.sendJson(request, response);
         return;
     };
-    resp.sendJson(request, val);
+    const base64_str = jsonscan.extractField(response, "base64Encoded");
+    const is_base64 = if (base64_str) |v| std.mem.eql(u8, v, "true") else false;
+
+    var buf: std.ArrayList(u8) = .empty;
+    buf.appendSlice(arena, "{\"ok\":true,\"request_id\":") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    writeJsonStringValue(&buf, arena, request_id) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    if (matched_url) |u| {
+        buf.appendSlice(arena, ",\"url\":") catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        writeJsonStringValue(&buf, arena, u) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+    }
+    buf.print(arena, ",\"base64Encoded\":{s},\"body\":\"{s}\"}}", .{ if (is_base64) "true" else "false", body_field }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, buf.items);
 }
 
 fn handleSetContent(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
@@ -6674,7 +7508,24 @@ fn handleDispatch(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const js = std.fmt.allocPrint(arena, "function() {{ this.dispatchEvent(new Event('{s}', {{bubbles:true,cancelable:true}})); return 'dispatched'; }}", .{escaped_type}) catch {
+    // Dispatching a plain `new Event(type, ...)` never triggers the browser's
+    // native default action for an untrusted event — a bare 'click' never
+    // navigates a link and a bare 'submit' never actually submits a form,
+    // only JS listeners fire. For the types where that matters, call the
+    // real native method (el.click() / form.requestSubmit()) instead. Mouse
+    // types need a real MouseEvent (listeners often read e.button/e.view);
+    // pointer types (canvas apps, custom sliders, DnD libraries that listen
+    // for pointerdown/pointermove) need a real PointerEvent with pointerId/
+    // pointerType/clientX/clientY set, or `instanceof PointerEvent` checks
+    // and coordinate reads silently see undefined; keyboard types need a
+    // real KeyboardEvent for the same reason (dedicated /keydown, /keyup,
+    // /keyboard/type already cover the common case via genuine
+    // Input.dispatchKeyEvent, this is for symmetry/generic dispatch). Other
+    // types (change, input, ...) have no native default action and a plain
+    // bubbling+cancelable Event is exactly what listeners expect.
+    const js = std.fmt.allocPrint(arena,
+        \\function() {{ var t='{s}'; if (t==='click') {{ this.click(); return 'dispatched'; }} if (t==='submit') {{ var f = (this.tagName==='FORM') ? this : this.form; if (f) {{ if (f.requestSubmit) f.requestSubmit(); else f.submit(); return 'dispatched'; }} this.dispatchEvent(new Event('submit',{{bubbles:true,cancelable:true}})); return 'dispatched'; }} if (t==='dblclick'||t==='mousedown'||t==='mouseup'||t==='mouseover'||t==='mouseout'||t==='mouseenter'||t==='mouseleave') {{ this.dispatchEvent(new MouseEvent(t,{{bubbles:true,cancelable:true,view:window}})); return 'dispatched'; }} if (t==='pointerdown'||t==='pointerup'||t==='pointermove'||t==='pointerover'||t==='pointerout'||t==='pointerenter'||t==='pointerleave'||t==='pointercancel') {{ var r = this.getBoundingClientRect(); var cx = r.left + r.width/2, cy = r.top + r.height/2; this.dispatchEvent(new PointerEvent(t,{{bubbles:true,cancelable:true,view:window,pointerId:1,pointerType:'mouse',isPrimary:true,clientX:cx,clientY:cy}})); return 'dispatched'; }} if (t==='keydown'||t==='keyup'||t==='keypress') {{ this.dispatchEvent(new KeyboardEvent(t,{{bubbles:true,cancelable:true,view:window}})); return 'dispatched'; }} this.dispatchEvent(new Event(t,{{bubbles:true,cancelable:true}})); return 'dispatched'; }}
+    , .{escaped_type}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -6697,6 +7548,23 @@ fn handleDispatch(request: *std.http.Server.Request, arena: std.mem.Allocator, b
     resp.sendJson(request, body);
 }
 
+/// Resolve the directory Chrome should save downloads into: `?dir=` query
+/// param (percent-decoded) if given, else a fixed fallback. Both /download
+/// and /wait/download call this instead of each hardcoding the same
+/// literal path with no way for a caller to override it.
+///
+/// (An environment-variable tier was considered too, but this Zig
+/// toolchain's `std.process` no longer exposes a plain
+/// `getEnvVarOwned(allocator, key)` — env vars now go through
+/// `std.process.Environ`/`Environ.Map`, which needs an already-scanned
+/// environ handle this per-request code path doesn't have one of. Not
+/// worth pulling that machinery in for a single fallback tier when the
+/// query param already makes this configurable.)
+fn resolveDownloadDir(arena: std.mem.Allocator, target: []const u8) []const u8 {
+    if (getDecodedQueryParamAlloc(arena, target, "dir")) |d| return d;
+    return "/tmp/kuri-downloads";
+}
+
 fn handleDownload(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
@@ -6708,7 +7576,19 @@ fn handleDownload(request: *std.http.Server.Request, arena: std.mem.Allocator, b
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    _ = client.send(arena, "Page.setDownloadBehavior", "{\"behavior\":\"allow\",\"downloadPath\":\"/tmp/kuri-downloads\"}") catch {};
+    const download_dir = resolveDownloadDir(arena, target);
+    const escaped_dir = jsonEscapeAlloc(arena, download_dir) orelse {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const behavior_params = std.fmt.allocPrint(arena, "{{\"behavior\":\"allow\",\"downloadPath\":\"{s}\"}}", .{escaped_dir}) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    _ = client.send(arena, "Page.setDownloadBehavior", behavior_params) catch {
+        resp.sendError(request, 502, "Page.setDownloadBehavior failed");
+        return;
+    };
     const escaped_url = jsonEscapeAlloc(arena, url) orelse {
         resp.sendError(request, 500, "Internal Server Error");
         return;
@@ -6849,15 +7729,79 @@ fn handleExpose(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    _ = client.send(arena, "Runtime.addBinding", params) catch {
+    // Runtime.bindingCalled is only delivered once the Runtime domain is
+    // enabled -- without this, Runtime.addBinding silently succeeds but the
+    // endpoint's whole purpose (observing page -> host calls) never fires.
+    _ = client.send(arena, protocol.Methods.runtime_enable, null) catch {};
+    _ = client.send(arena, protocol.Methods.runtime_add_binding, params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
-    const body = std.fmt.allocPrint(arena, "{{\"ok\":true,\"action\":\"expose\",\"name\":\"{s}\"}}", .{escaped_name}) catch {
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"ok\":true,\"action\":\"expose\",\"name\":\"{s}\",\"tab_id\":\"{s}\",\"retrieve_calls_at\":\"/expose/calls?tab_id={s}&name={s}\"}}",
+        .{ escaped_name, tab_id, tab_id, escaped_name },
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
     resp.sendJson(request, body);
+}
+
+/// Retrieval half of /expose: without this, `window.<name>(...)` calls the
+/// page makes into the binding it just registered are captured by
+/// `CdpClient`'s BindingCallRing (see client.zig's Case 2 collector) but
+/// nothing ever hands them back out -- the whole reason /expose exists.
+/// `?name=` filters to one binding; `?clear=true` drains the ring after
+/// reading (so repeated polling doesn't see the same calls twice).
+fn handleExposeCalls(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
+    const target = request.head.target;
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
+    const client = bridge.getCdpClient(tab_id) orelse {
+        resp.sendError(request, 404, "Tab not found");
+        return;
+    };
+    const name_filter = getDecodedQueryParamAlloc(arena, target, "name");
+    const should_clear = if (getQueryParam(target, "clear")) |v| std.mem.eql(u8, v, "true") else false;
+
+    // Best-effort: pull any bindingCalled events already sitting on the
+    // socket into the ring before snapshotting -- see the "paused CDP
+    // events only make forward progress while a command is in flight"
+    // design limit noted on the collector accessors in client.zig. No-op
+    // on Windows (see drainWsEvents).
+    client.drainWsEvents(arena, 1);
+
+    const calls = client.snapshotBindingCalls(arena) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    var buf: std.ArrayList(u8) = .empty;
+    buf.appendSlice(arena, "{\"ok\":true,\"calls\":[") catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    var written: usize = 0;
+    for (calls) |call| {
+        if (name_filter) |wanted| {
+            if (!std.mem.eql(u8, call.name, wanted)) continue;
+        }
+        if (written > 0) buf.appendSlice(arena, ",") catch return;
+        buf.appendSlice(arena, "{") catch return;
+        writeJsonField(&buf, arena, "name", call.name) catch return;
+        buf.appendSlice(arena, ",") catch return;
+        writeJsonField(&buf, arena, "payload", call.payload) catch return;
+        buf.print(arena, ",\"truncated\":{s},\"timestamp\":{d}}}", .{ if (call.truncated) "true" else "false", call.timestamp }) catch return;
+        written += 1;
+    }
+    buf.print(arena, "],\"count\":{d},\"tab_id\":\"{s}\"}}", .{ written, tab_id }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+
+    if (should_clear) client.clearBindingCalls();
+
+    resp.sendJson(request, buf.items);
 }
 
 fn handleMultiSelect(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
@@ -6982,10 +7926,56 @@ fn handleVitals(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
         \\  var fcp = 0; paint.forEach(function(e) { if (e.name === 'first-contentful-paint') fcp = e.startTime; });
         \\  var ttfb = nav.responseStart || 0;
         \\  var domInteractive = nav.domInteractive || 0;
-        \\  var lcp = 0; try { var entries = performance.getEntriesByType('largest-contentful-paint'); if (entries.length) lcp = entries[entries.length-1].startTime; } catch(e) {}
-        \\  var cls = 0; try { var entries = performance.getEntriesByType('layout-shift'); entries.forEach(function(e) { if (!e.hadRecentInput) cls += e.value; }); } catch(e) {}
-        \\  var fid = 0; try { var entries = performance.getEntriesByType('first-input'); if (entries.length) fid = entries[0].processingStart - entries[0].startTime; } catch(e) {}
-        \\  return JSON.stringify({lcp:lcp,cls:cls,fid:fid,ttfb:ttfb,fcp:fcp,domInteractive:domInteractive});
+        \\  // lcp/cls/fid entry types are buffered by Chromium from navigation
+        \\  // start regardless of whether a PerformanceObserver was ever
+        \\  // registered, so getEntriesByType legitimately retrieves real,
+        \\  // already-occurred values here (same technique /perf/lcp uses).
+        \\  var lcp = 0, lcpMeasured = false;
+        \\  try {
+        \\    var lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+        \\    if (lcpEntries.length) { lcp = lcpEntries[lcpEntries.length - 1].startTime; lcpMeasured = true; }
+        \\  } catch (e) {}
+        \\  var cls = 0, clsMeasured = false;
+        \\  try {
+        \\    var clsEntries = performance.getEntriesByType('layout-shift');
+        \\    clsMeasured = clsEntries.length > 0;
+        \\    // Windowed CLS: group shifts into "sessions" (gap < 1s between
+        \\    // consecutive shifts, session <= 5s total) and report the max
+        \\    // session sum. This is the official web-vitals algorithm --
+        \\    // unlike a lifetime running sum, it doesn't overstate CLS on
+        \\    // long-lived SPA pages that accumulate many small unrelated
+        \\    // shifts over a long session.
+        \\    var sessionValue = 0, sessionEntries = [], maxSessionValue = 0;
+        \\    clsEntries.forEach(function(e) {
+        \\      if (e.hadRecentInput) return;
+        \\      var first = sessionEntries[0];
+        \\      var last = sessionEntries[sessionEntries.length - 1];
+        \\      if (sessionValue && first && (e.startTime - last.startTime) < 1000 && (e.startTime - first.startTime) < 5000) {
+        \\        sessionValue += e.value;
+        \\        sessionEntries.push(e);
+        \\      } else {
+        \\        sessionValue = e.value;
+        \\        sessionEntries = [e];
+        \\      }
+        \\      if (sessionValue > maxSessionValue) maxSessionValue = sessionValue;
+        \\    });
+        \\    cls = maxSessionValue;
+        \\  } catch (e) {}
+        \\  var fid = 0, fidMeasured = false;
+        \\  try {
+        \\    var fidEntries = performance.getEntriesByType('first-input');
+        \\    if (fidEntries.length) { fid = fidEntries[0].processingStart - fidEntries[0].startTime; fidMeasured = true; }
+        \\  } catch (e) {}
+        \\  // *_measured distinguishes "genuinely zero" from "hasn't happened
+        \\  // yet" -- fid/cls legitimately read 0 if called before any
+        \\  // input/layout-shift has occurred, which looks identical to a
+        \\  // real zero without this flag.
+        \\  return JSON.stringify({
+        \\    lcp: lcp, lcp_measured: lcpMeasured,
+        \\    cls: cls, cls_measured: clsMeasured,
+        \\    fid: fid, fid_measured: fidMeasured,
+        \\    ttfb: ttfb, fcp: fcp, domInteractive: domInteractive
+        \\  });
         \\})()
     ;
     const escaped = jsonEscapeAlloc(arena, js) orelse {
@@ -7007,6 +7997,121 @@ fn handleVitals(request: *std.http.Server.Request, arena: std.mem.Allocator, bri
     resp.sendJson(request, val);
 }
 
+/// Extract the raw JSON array *interior* (without the enclosing `[`/`]`)
+/// for `key` (e.g. "childFrames"), using the same string-aware
+/// bracket-depth counting `jsonscan.extractObject` uses for `{`/`}`.
+/// Returns null if `key` isn't present as an array or it never closes.
+fn extractArrayInterior(json: []const u8, key: []const u8) ?[]const u8 {
+    var key_buf: [64]u8 = undefined;
+    const needle = std.fmt.bufPrint(&key_buf, "\"{s}\":[", .{key}) catch return null;
+    const key_pos = std.mem.indexOf(u8, json, needle) orelse return null;
+    const arr_start = key_pos + needle.len - 1; // points at '['
+    var depth: usize = 0;
+    var in_string = false;
+    var escaped = false;
+    var i = arr_start;
+    while (i < json.len) : (i += 1) {
+        const c = json[i];
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (c) {
+            '"' => in_string = true,
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if (depth == 0) return json[arr_start + 1 .. i];
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+const JsonArrayElement = struct { slice: []const u8, next: usize };
+
+/// Find the next top-level `{...}` object inside a JSON array's interior
+/// (as returned by `extractArrayInterior`), scanning from `from`. Returns
+/// the object slice plus the index just past its closing `}`, or null once
+/// no more objects remain. String- and depth-aware, same idiom as
+/// `jsonscan.extractObject`, so a nested `childFrames` array inside an
+/// element (or a literal `,`/`{`/`}` inside a frame's URL string) never
+/// causes a false split.
+fn nextArrayObject(interior: []const u8, from: usize) ?JsonArrayElement {
+    var depth: usize = 0;
+    var in_string = false;
+    var escaped = false;
+    var start: ?usize = null;
+    var i = from;
+    while (i < interior.len) : (i += 1) {
+        const c = interior[i];
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (c) {
+            '"' => in_string = true,
+            '{' => {
+                if (depth == 0) start = i;
+                depth += 1;
+            },
+            '}' => {
+                depth -= 1;
+                if (depth == 0) {
+                    if (start) |s| return .{ .slice = interior[s .. i + 1], .next = i + 1 };
+                    start = null;
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// Recursively search a `Page.getFrameTree` node (`{"frame":{...},
+/// "childFrames":[...]}`) for a frame whose `name` matches exactly or
+/// whose `url` contains `url_substr`, at ANY nesting depth. This is what
+/// replaces `document.querySelector('iframe[...]')` against the top
+/// document, which can only ever see the top document's *direct* iframe
+/// children and is blind to a frame nested inside another frame. Returns
+/// the matching frame's CDP frameId, borrowed from `tree_json`.
+fn findFrameIdInTree(tree_json: []const u8, name: ?[]const u8, url_substr: ?[]const u8) ?[]const u8 {
+    const frame_obj = jsonscan.extractObject(tree_json, "frame") orelse return null;
+    const matches = blk: {
+        if (name) |n| {
+            const frame_name = jsonscan.extractField(frame_obj, "name") orelse break :blk false;
+            break :blk std.mem.eql(u8, frame_name, n);
+        }
+        if (url_substr) |u| {
+            const frame_url = jsonscan.extractField(frame_obj, "url") orelse break :blk false;
+            break :blk std.mem.indexOf(u8, frame_url, u) != null;
+        }
+        break :blk false;
+    };
+    if (matches) return jsonscan.extractField(frame_obj, "id");
+
+    const children = extractArrayInterior(tree_json, "childFrames") orelse return null;
+    var cursor: usize = 0;
+    while (nextArrayObject(children, cursor)) |elem| {
+        if (findFrameIdInTree(elem.slice, name, url_substr)) |found| return found;
+        cursor = elem.next;
+    }
+    return null;
+}
+
 fn handleFrame(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
@@ -7020,38 +8125,64 @@ fn handleFrame(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
         resp.sendError(request, 400, "Missing name or url parameter");
         return;
     }
-    const selector = if (name) |n| blk: {
-        const escaped_n = jsonEscapeAlloc(arena, n) orelse {
-            resp.sendError(request, 500, "Internal Server Error");
-            return;
-        };
-        break :blk std.fmt.allocPrint(arena, "iframe[name=\\'{s}\\']", .{escaped_n}) catch {
-            resp.sendError(request, 500, "Internal Server Error");
-            return;
-        };
-    } else blk: {
-        const escaped_u = jsonEscapeAlloc(arena, url.?) orelse {
-            resp.sendError(request, 500, "Internal Server Error");
-            return;
-        };
-        break :blk std.fmt.allocPrint(arena, "iframe[src*=\\'{s}\\']", .{escaped_u}) catch {
-            resp.sendError(request, 500, "Internal Server Error");
-            return;
-        };
+
+    // Walk the full recursive frame tree (Page.getFrameTree, same call
+    // /frames already uses) instead of `document.querySelector('iframe[...]
+    // ')` against the top document -- that approach can only ever see the
+    // top document's *direct* iframe children and is blind to a frame
+    // nested inside another frame.
+    _ = client.send(arena, protocol.Methods.page_enable, null) catch {};
+    const tree_response = client.send(arena, protocol.Methods.page_get_frame_tree, null) catch {
+        resp.sendError(request, 502, "Page.getFrameTree failed");
+        return;
     };
-    const js = std.fmt.allocPrint(arena, "(function() {{ var f = document.querySelector('{s}'); if (!f) return JSON.stringify({{error:'iframe not found'}}); try {{ return JSON.stringify({{ok:true,title:f.contentDocument.title,url:f.contentWindow.location.href}}); }} catch(e) {{ return JSON.stringify({{ok:true,crossOrigin:true,src:f.src}}); }} }})()", .{selector}) catch {
+    const frame_tree = jsonscan.extractObject(tree_response, "frameTree") orelse {
+        resp.sendError(request, 500, "Could not parse Page.getFrameTree response");
+        return;
+    };
+    const frame_id = findFrameIdInTree(frame_tree, name, url) orelse {
+        resp.sendError(request, 404, "No frame in the frame tree (searched recursively) matches that name/url");
+        return;
+    };
+
+    // Resolve an execution context scoped to exactly that frame via an
+    // isolated world, then evaluate *inside* the target frame's own realm
+    // -- so document/location are its own regardless of whether the frame
+    // is cross-origin relative to the top document. This is why the old
+    // `f.contentDocument.title`/`f.contentWindow.location.href` crossOrigin
+    // fallback is gone: that check only existed because it was reaching
+    // into the frame from the *parent's* realm, which same-origin policy
+    // blocks; evaluating inside the frame's own context has no such check.
+    const escaped_frame_id = jsonEscapeAlloc(arena, frame_id) orelse {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const escaped = jsonEscapeAlloc(arena, js) orelse {
+    const isolated_params = std.fmt.allocPrint(arena, "{{\"frameId\":\"{s}\",\"worldName\":\"kuri_frame_probe\"}}", .{escaped_frame_id}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped}) catch {
+    const isolated_response = client.send(arena, "Page.createIsolatedWorld", isolated_params) catch {
+        // Honest failure case: this frame exists in the tree but this CDP
+        // session can't attach an isolated world to it (e.g. a genuine
+        // out-of-process cross-origin subframe not attached to this
+        // target) -- report that rather than fabricating a result.
+        resp.sendError(request, 502, "Page.createIsolatedWorld failed (frame may not be attached to this CDP session)");
+        return;
+    };
+    const context_id = jsonscan.extractField(isolated_response, "executionContextId") orelse {
+        resp.sendError(request, 502, "Page.createIsolatedWorld returned no executionContextId");
+        return;
+    };
+    const js = "(function() { try { return JSON.stringify({ok:true,title:document.title,url:location.href}); } catch(e) { return JSON.stringify({ok:false,error:e.message}); } })()";
+    const escaped_js = jsonEscapeAlloc(arena, js) orelse {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
+    const eval_params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"contextId\":{s},\"returnByValue\":true}}", .{ escaped_js, context_id }) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    const response = client.send(arena, protocol.Methods.runtime_evaluate, eval_params) catch {
         resp.sendError(request, 502, "CDP command failed");
         return;
     };
@@ -7063,9 +8194,34 @@ fn handleFrame(request: *std.http.Server.Request, arena: std.mem.Allocator, brid
 }
 
 fn handleMainFrame(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
-    _ = arena;
-    _ = bridge;
-    resp.sendJson(request, "{\"ok\":true,\"frame\":\"main\"}");
+    const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
+    const client = bridge.getCdpClient(tab_id) orelse {
+        resp.sendError(request, 404, "Tab not found");
+        return;
+    };
+    const response = client.send(arena, protocol.Methods.page_get_frame_tree, null) catch {
+        resp.sendError(request, 502, "Page.getFrameTree failed");
+        return;
+    };
+    // Response shape: {"id":N,"result":{"frameTree":{"frame":{"id":...,"loaderId":...,"url":...},...}}}
+    // Search from "frameTree" onward so the top-level JSON-RPC "id" (a bare
+    // number, not a string) is never mistaken for the frame's own "id".
+    const frametree_pos = std.mem.indexOf(u8, response, "\"frameTree\"") orelse {
+        resp.sendJson(request, "{\"ok\":true,\"frame\":\"main\"}");
+        return;
+    };
+    const frame_id = extractSimpleJsonString(response, frametree_pos, "\"id\"") orelse "";
+    const loader_id = extractSimpleJsonString(response, frametree_pos, "\"loaderId\"") orelse "";
+    const frame_url = extractSimpleJsonString(response, frametree_pos, "\"url\"") orelse "";
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"ok\":true,\"frame\":\"main\",\"tab_id\":\"{s}\",\"frameId\":\"{s}\",\"loaderId\":\"{s}\",\"url\":\"{s}\"}}",
+        .{ tab_id, frame_id, loader_id, frame_url },
+    ) catch {
+        resp.sendError(request, 500, "Internal Server Error");
+        return;
+    };
+    resp.sendJson(request, body);
 }
 
 fn handleGetAttribute(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
@@ -7191,66 +8347,175 @@ fn handleInputValue(request: *std.http.Server.Request, arena: std.mem.Allocator,
     resp.sendJson(request, body);
 }
 
+fn clampU32(s: ?[]const u8, default: u32, max: u32) u32 {
+    const v = if (s) |str| (std.fmt.parseInt(u32, str, 10) catch default) else default;
+    return @min(v, max);
+}
+
+fn callValueObject(arena: std.mem.Allocator, client: *CdpClient, object_id: []const u8, function_declaration: []const u8) ?[]const u8 {
+    const escaped_fn = jsonEscapeAlloc(arena, function_declaration) orelse return null;
+    const params = std.fmt.allocPrint(arena, "{{\"objectId\":\"{s}\",\"functionDeclaration\":\"{s}\",\"returnByValue\":true}}", .{ object_id, escaped_fn }) catch return null;
+    const response = client.send(arena, protocol.Methods.runtime_call_function_on, params) catch return null;
+    return extractJsonObjectField(response, "\"value\"");
+}
+
+/// Build the `{"id":"..."}` or `{"selector":"..."}` opts object passed to
+/// window.__kuri_react.inspect(). Exactly one of id/selector is expected to
+/// be non-null (enforced by the caller); selector is caller-controlled text
+/// so it must be escaped before it lands inside a JS expression, same as
+/// every other user-supplied string embedded elsewhere in this file.
+fn buildReactInspectOpts(arena: std.mem.Allocator, id: ?[]const u8, selector: ?[]const u8) ?[]const u8 {
+    if (id) |i| {
+        const escaped_id = jsonEscapeAlloc(arena, i) orelse return null;
+        return std.fmt.allocPrint(arena, "{{\"id\":\"{s}\"}}", .{escaped_id}) catch null;
+    }
+    if (selector) |s| {
+        const escaped_sel = jsonEscapeAlloc(arena, s) orelse return null;
+        return std.fmt.allocPrint(arena, "{{\"selector\":\"{s}\"}}", .{escaped_sel}) catch null;
+    }
+    return null;
+}
+
+/// React introspection. Dispatches into the persistent window.__kuri_react
+/// library (src/cdp/js/react_fiber.js, injected by discoverTabs) instead of
+/// rebuilding the fiber walk in an inline JS string per request. Every
+/// __kuri_react.* entry point returns {"react":false} on pages with no React
+/// (no fiber keys found on any DOM node) -- that check happens once, inside
+/// the JS library, not per-endpoint here, so all four modes degrade the same
+/// way. Responses come back via evalValueObject/callValueObject, i.e. as a
+/// raw object slice -- never double-JSON-encoded through an internal
+/// JSON.stringify like the old hook-gated stub did.
 fn handleReact(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, mode: []const u8) void {
+    const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
     const client = bridge.getCdpClient(tab_id) orelse {
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    const escaped_mode = jsonEscapeAlloc(arena, mode) orelse {
-        resp.sendError(request, 500, "Internal Server Error");
+
+    if (std.mem.eql(u8, mode, "tree")) {
+        // Hard caps enforced here regardless of what the caller requests --
+        // the number that actually matters is the 2MB CDP response ceiling
+        // (client.zig's receiveMessageAlloc), not anything the JS itself
+        // could sensibly self-limit to.
+        const max_nodes = clampU32(getQueryParam(target, "max_nodes"), 500, 3000);
+        const max_depth = clampU32(getQueryParam(target, "max_depth"), 40, 150);
+        const include_text = if (getQueryParam(target, "include_host_text")) |v| std.mem.eql(u8, v, "true") else false;
+        const expr = std.fmt.allocPrint(
+            arena,
+            "window.__kuri_react ? window.__kuri_react.tree({{\"maxNodes\":{d},\"maxDepth\":{d},\"includeHostText\":{s}}}) : {{\"react\":false}}",
+            .{ max_nodes, max_depth, if (include_text) "true" else "false" },
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const val = evalValueObject(arena, client, expr) orelse {
+            resp.sendError(request, 502, "CDP command failed");
+            return;
+        };
+        resp.sendJson(request, val);
         return;
-    };
-    const js = std.fmt.allocPrint(arena,
-        \\(function() {{
-        \\  var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-        \\  if (!hook) return JSON.stringify({{error:'React DevTools hook not found'}});
-        \\  var mode = '{s}';
-        \\  if (mode === 'tree') {{
-        \\    var fiberRoots = [];
-        \\    hook.getFiberRoots && hook.getFiberRoots(1).forEach(function(root) {{
-        \\      function walk(fiber, depth) {{
-        \\        if (!fiber || depth > 20) return null;
-        \\        var name = fiber.type ? (fiber.type.displayName || fiber.type.name || 'Anonymous') : '#text';
-        \\        var children = [];
-        \\        var child = fiber.child;
-        \\        while (child) {{ var c = walk(child, depth+1); if (c) children.push(c); child = child.sibling; }}
-        \\        return {{name:name,children:children}};
-        \\      }}
-        \\      fiberRoots.push(walk(root.current, 0));
-        \\    }});
-        \\    return JSON.stringify({{ok:true,mode:'tree',roots:fiberRoots}});
-        \\  }} else if (mode === 'inspect') {{
-        \\    var renderers = []; hook.renderers && hook.renderers.forEach(function(v,k) {{ renderers.push({{id:k,version:v.version||'unknown'}}); }});
-        \\    return JSON.stringify({{ok:true,mode:'inspect',renderers:renderers}});
-        \\  }} else if (mode === 'renders') {{
-        \\    return JSON.stringify({{ok:true,mode:'renders',message:'Use React Profiler API for render tracking'}});
-        \\  }} else if (mode === 'suspense') {{
-        \\    return JSON.stringify({{ok:true,mode:'suspense',message:'Suspense boundaries detected via fiber walk'}});
-        \\  }}
-        \\  return JSON.stringify({{error:'unknown mode'}});
-        \\}})()
-    , .{escaped_mode}) catch {
-        resp.sendError(request, 500, "Internal Server Error");
+    }
+
+    if (std.mem.eql(u8, mode, "inspect")) {
+        // ref: reuse the existing a11y-snapshot ref-resolution flow verbatim
+        // (same shape as handleGetAttribute / handleBoundingBox) -- resolve
+        // to a live DOM object, then call inspectElement(this) on it.
+        if (getQueryParam(target, "ref")) |r| {
+            bridge.mu.lockShared();
+            const cache = bridge.snapshots.get(tab_id);
+            bridge.mu.unlockShared();
+            const bid = if (cache) |c| c.refs.get(r) else null;
+            if (bid == null) {
+                resp.sendError(request, 400, "Ref not found");
+                return;
+            }
+            const rp = std.fmt.allocPrint(arena, "{{\"backendNodeId\":{d}}}", .{bid.?}) catch {
+                resp.sendError(request, 500, "Internal Server Error");
+                return;
+            };
+            const rr = client.send(arena, protocol.Methods.dom_resolve_node, rp) catch {
+                resp.sendError(request, 502, "DOM.resolveNode failed");
+                return;
+            };
+            const oid = extractSimpleJsonString(rr, 0, "\"objectId\"") orelse {
+                resp.sendError(request, 500, "Could not resolve element");
+                return;
+            };
+            const val = callValueObject(
+                arena,
+                client,
+                oid,
+                "function(){ return window.__kuri_react ? window.__kuri_react.inspectElement(this) : {react:false}; }",
+            ) orelse {
+                resp.sendError(request, 502, "CDP command failed");
+                return;
+            };
+            resp.sendJson(request, val);
+            return;
+        }
+
+        // id (from a prior /react/tree or /react/suspense call) or selector.
+        const id = getQueryParam(target, "id");
+        const selector = getDecodedQueryParamAlloc(arena, target, "selector");
+        if (id == null and selector == null) {
+            resp.sendError(request, 400, "Provide one of: ref, id, selector");
+            return;
+        }
+        const opts_json = buildReactInspectOpts(arena, id, selector) orelse {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const expr = std.fmt.allocPrint(
+            arena,
+            "window.__kuri_react ? window.__kuri_react.inspect({s}) : {{\"react\":false}}",
+            .{opts_json},
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const val = evalValueObject(arena, client, expr) orelse {
+            resp.sendError(request, 502, "CDP command failed");
+            return;
+        };
+        resp.sendJson(request, val);
         return;
-    };
-    const escaped = jsonEscapeAlloc(arena, js) orelse {
-        resp.sendError(request, 500, "Internal Server Error");
+    }
+
+    if (std.mem.eql(u8, mode, "renders")) {
+        // Not the React Profiler API (a much heavier commitment -- explicit
+        // start/stopProfiling against a profiling bundle). This is a real,
+        // bounded commit log fed by a hook stub that never depends on
+        // __REACT_DEVTOOLS_GLOBAL_HOOK__ already existing; honest about its
+        // one real limitation via hookAttachedBeforeInit/note in the payload
+        // rather than a canned "not supported" or a made-up capability.
+        const val = evalValueObject(arena, client, "window.__kuri_react ? window.__kuri_react.renders() : {\"react\":false}") orelse {
+            resp.sendError(request, 502, "CDP command failed");
+            return;
+        };
+        resp.sendJson(request, val);
         return;
-    };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped}) catch {
-        resp.sendError(request, 500, "Internal Server Error");
+    }
+
+    if (std.mem.eql(u8, mode, "suspense")) {
+        const max_nodes = clampU32(getQueryParam(target, "max_nodes"), 500, 3000);
+        const expr = std.fmt.allocPrint(
+            arena,
+            "window.__kuri_react ? window.__kuri_react.suspense({{\"maxNodes\":{d}}}) : {{\"react\":false}}",
+            .{max_nodes},
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        const val = evalValueObject(arena, client, expr) orelse {
+            resp.sendError(request, 502, "CDP command failed");
+            return;
+        };
+        resp.sendJson(request, val);
         return;
-    };
-    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
-        resp.sendError(request, 502, "CDP command failed");
-        return;
-    };
-    const val = extractSimpleJsonString(response, 0, "\"value\"") orelse {
-        resp.sendJson(request, response);
-        return;
-    };
-    resp.sendJson(request, val);
+    }
+
+    resp.sendError(request, 400, "Unknown react mode");
 }
 
 fn handleRecording(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge, mode: []const u8) void {
@@ -7340,6 +8605,21 @@ fn handleRequestDetail(request: *std.http.Server.Request, arena: std.mem.Allocat
     resp.sendJson(request, response);
 }
 
+/// Scale a caller-supplied timeout (ms) into a `waitForEvent` attempt
+/// count. Loosely calibrated, not exact: each attempt reads one message off
+/// the CDP socket, which blocks for up to the socket's fixed ~10s read
+/// timeout when idle, so on a truly idle connection the real wait is
+/// bounded below by that single read timeout regardless of this value; on
+/// a busy tab (other events arriving) this bounds how many unrelated
+/// events get consumed before giving up. Same approximation existing call
+/// sites (`waitForEvent(..., 1_000)`, `waitForEvent(..., 400)`) already
+/// accept; clamped to a sane range either way.
+fn timeoutMsToAttempts(timeout_ms: u64) u32 {
+    const scaled: u64 = timeout_ms / 50;
+    const clamped: u64 = if (scaled < 20) 20 else if (scaled > 20000) 20000 else scaled;
+    return @intCast(clamped);
+}
+
 fn handleWaitForDownload(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
     const target = request.head.target;
     const tab_id = requireEffectiveTabId(arena, request, bridge) orelse return;
@@ -7349,28 +8629,62 @@ fn handleWaitForDownload(request: *std.http.Server.Request, arena: std.mem.Alloc
         resp.sendError(request, 404, "Tab not found");
         return;
     };
-    _ = client.send(arena, "Page.setDownloadBehavior", "{\"behavior\":\"allow\",\"downloadPath\":\"/tmp/kuri-downloads\"}") catch {};
-    const js = std.fmt.allocPrint(arena, "(function() {{ return JSON.stringify({{ok:true,action:'waitForDownload',timeout:{d},message:'Download behavior set to allow'}}); }})()", .{timeout_ms}) catch {
+    const download_dir = resolveDownloadDir(arena, target);
+    const escaped_dir = jsonEscapeAlloc(arena, download_dir) orelse {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const escaped = jsonEscapeAlloc(arena, js) orelse {
+    const behavior_params = std.fmt.allocPrint(arena, "{{\"behavior\":\"allow\",\"downloadPath\":\"{s}\"}}", .{escaped_dir}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped}) catch {
+    _ = client.send(arena, "Page.setDownloadBehavior", behavior_params) catch {
+        resp.sendError(request, 502, "Page.setDownloadBehavior failed");
+        return;
+    };
+    // Page.downloadWillBegin needs the Page domain enabled to fire at all.
+    _ = client.send(arena, protocol.Methods.page_enable, null) catch {};
+
+    // Wait for a real CDP signal instead of unconditionally returning a
+    // canned success unrelated to whether a download ever happens.
+    // Page.downloadWillBegin fires exactly once, at the moment Chrome
+    // commits to a download, so a `waitForEvent` match unambiguously means
+    // a download started.
+    //
+    // Known, deliberate limitation: `waitForEvent` only reports whether the
+    // *method name* matched an incoming message -- client.zig's in-read-
+    // loop dispatcher frees the actual event payload (guid/url/
+    // suggestedFilename) before this call ever sees it, so this endpoint
+    // can confirm a download *began* but cannot report its guid/path or
+    // whether it later completed/canceled (Page.downloadProgress carries
+    // that, but is a repeating multi-state stream and the same payload-
+    // discarding limitation applies there too). Surfacing guid/completion
+    // state honestly would require CdpClient to expose the matched event
+    // body to callers, which is out of scope for a router.zig-only change
+    // -- flagging that rather than fabricating a guid/state this endpoint
+    // never actually observed.
+    const began = client.waitForEvent(arena, "Page.downloadWillBegin", timeoutMsToAttempts(timeout_ms));
+    if (!began) {
+        const body = std.fmt.allocPrint(
+            arena,
+            "{{\"ok\":false,\"action\":\"waitForDownload\",\"detected\":false,\"error\":\"no Page.downloadWillBegin event observed within timeout\",\"timeout_ms\":{d}}}",
+            .{timeout_ms},
+        ) catch {
+            resp.sendError(request, 500, "Internal Server Error");
+            return;
+        };
+        resp.sendJson(request, body);
+        return;
+    }
+    const body = std.fmt.allocPrint(
+        arena,
+        "{{\"ok\":true,\"action\":\"waitForDownload\",\"detected\":true,\"event\":\"Page.downloadWillBegin\",\"note\":\"confirms a download started; per-download guid/path/completion state is not exposed by this endpoint\"}}",
+        .{},
+    ) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch {
-        resp.sendError(request, 502, "CDP command failed");
-        return;
-    };
-    const val = extractSimpleJsonString(response, 0, "\"value\"") orelse {
-        resp.sendJson(request, response);
-        return;
-    };
-    resp.sendJson(request, val);
+    resp.sendJson(request, body);
 }
 
 fn handleRemoveInitScript(request: *std.http.Server.Request, arena: std.mem.Allocator, bridge: *Bridge) void {
@@ -7418,11 +8732,9 @@ fn handleEvalHandle(request: *std.http.Server.Request, arena: std.mem.Allocator,
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
-    const escaped_expr = jsonEscapeAlloc(arena, expr) orelse {
-        resp.sendError(request, 500, "Internal Server Error");
-        return;
-    };
-    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":false}}", .{escaped_expr}) catch {
+    // Escape exactly once — `expr` is already escaped. Double-escaping turns a
+    // newline into a literal backslash+n and makes Chrome reject the script.
+    const params = std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":false}}", .{expr}) catch {
         resp.sendError(request, 500, "Internal Server Error");
         return;
     };
@@ -8006,6 +9318,35 @@ test "keyboard/type route parameters" {
     try std.testing.expectEqualStrings("hello", getQueryParam(target, "text").?);
 }
 
+test "keyboard/type must iterate text by Unicode codepoint, not raw byte" {
+    // handleKeyboardType used to do `for (text) |ch|`, splitting any
+    // multi-byte UTF-8 character into individual invalid bytes. Confirm the
+    // fix's iteration mechanism (std.unicode.Utf8Iterator) walks "héllo" as
+    // 5 codepoints (h, é, l, l, o) — a raw byte loop would see 6 bytes
+    // because é is 2 bytes in UTF-8.
+    const text = "héllo";
+    try std.testing.expectEqual(@as(usize, 6), text.len);
+
+    var utf8_iter: std.unicode.Utf8Iterator = .{ .bytes = text, .i = 0 };
+    var count: usize = 0;
+    var codepoints: [8][]const u8 = undefined;
+    while (utf8_iter.nextCodepointSlice()) |cp| : (count += 1) {
+        codepoints[count] = cp;
+    }
+    try std.testing.expectEqual(@as(usize, 5), count);
+    try std.testing.expectEqualStrings("h", codepoints[0]);
+    try std.testing.expectEqualStrings("é", codepoints[1]);
+    try std.testing.expectEqualStrings("l", codepoints[2]);
+    try std.testing.expectEqualStrings("l", codepoints[3]);
+    try std.testing.expectEqualStrings("o", codepoints[4]);
+
+    // jsonEscapeAlloc must pass the multi-byte codepoint through unmangled
+    // (it only escapes '"', '\\', and control chars < 0x20).
+    const escaped = jsonEscapeAlloc(std.testing.allocator, codepoints[1]);
+    try std.testing.expect(escaped != null);
+    try std.testing.expectEqualStrings("é", escaped.?);
+}
+
 test "set/offline route parameters" {
     const target = "/set/offline?tab_id=t1&mode=on";
     try std.testing.expectEqualStrings("t1", getQueryParam(target, "tab_id").?);
@@ -8044,6 +9385,104 @@ test "highlight route with selector" {
     try std.testing.expectEqualStrings("div.main", getQueryParam(target, "selector").?);
 }
 
+test "screenshot/annotated route requires a ref, resolved via the snapshot cache like /upload" {
+    const target = "/screenshot/annotated?tab_id=t1&ref=e7";
+    try std.testing.expectEqualStrings("t1", getQueryParam(target, "tab_id").?);
+    try std.testing.expectEqualStrings("e7", getQueryParam(target, "ref").?);
+    try std.testing.expect(getQueryParam("/screenshot/annotated?tab_id=t1", "ref") == null);
+}
+
+test "dispatch route parameters" {
+    const target = "/dispatch?tab_id=t1&ref=e2&type=click";
+    try std.testing.expectEqualStrings("t1", getQueryParam(target, "tab_id").?);
+    try std.testing.expectEqualStrings("e2", getQueryParam(target, "ref").?);
+    try std.testing.expectEqualStrings("click", getQueryParam(target, "type").?);
+}
+
+test "dispatch route parses pointer and keyboard event types" {
+    // These types fall into the PointerEvent/KeyboardEvent branches added
+    // to handleDispatch's generated JS, instead of the generic-Event
+    // fallback that used to leave e.g. e.pointerId/e.clientX/e.key
+    // undefined for any listener that checked them.
+    const pointer_target = "/dispatch?tab_id=t1&ref=e2&type=pointerdown";
+    try std.testing.expectEqualStrings("pointerdown", getQueryParam(pointer_target, "type").?);
+    const key_target = "/dispatch?tab_id=t1&ref=e2&type=keydown";
+    try std.testing.expectEqualStrings("keydown", getQueryParam(key_target, "type").?);
+}
+
+test "resolveDownloadDir prefers the dir query param over the fixed default" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const target = "/download?tab_id=t1&url=https://example.com/file&dir=/custom/downloads";
+    try std.testing.expectEqualStrings("/custom/downloads", resolveDownloadDir(arena_state.allocator(), target));
+}
+
+test "resolveDownloadDir falls back to the fixed default with no dir param or env var" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const target = "/download?tab_id=t1&url=https://example.com/file";
+    try std.testing.expectEqualStrings("/tmp/kuri-downloads", resolveDownloadDir(arena_state.allocator(), target));
+}
+
+test "timeoutMsToAttempts clamps to a sane range" {
+    try std.testing.expectEqual(@as(u32, 20), timeoutMsToAttempts(0));
+    try std.testing.expectEqual(@as(u32, 20), timeoutMsToAttempts(500));
+    try std.testing.expectEqual(@as(u32, 600), timeoutMsToAttempts(30_000));
+    try std.testing.expectEqual(@as(u32, 20000), timeoutMsToAttempts(10_000_000));
+}
+
+test "findFrameIdInTree finds a direct child by name" {
+    const tree =
+        \\{"frame":{"id":"MAIN","url":"https://example.com/"},"childFrames":[
+        \\  {"frame":{"id":"CHILD1","name":"payment","url":"https://pay.example.com/"}}
+        \\]}
+    ;
+    try std.testing.expectEqualStrings("CHILD1", findFrameIdInTree(tree, "payment", null).?);
+}
+
+test "findFrameIdInTree finds a frame nested two levels deep by url substring" {
+    // This is exactly the case document.querySelector('iframe[...]') on the
+    // top document cannot see: a frame nested inside another frame.
+    const tree =
+        \\{"frame":{"id":"MAIN","url":"https://example.com/"},"childFrames":[
+        \\  {"frame":{"id":"MID","url":"https://widgets.example.com/"},"childFrames":[
+        \\    {"frame":{"id":"DEEP","url":"https://checkout.example.com/pay?ref=1"}}
+        \\  ]}
+        \\]}
+    ;
+    try std.testing.expectEqualStrings("DEEP", findFrameIdInTree(tree, null, "checkout.example.com").?);
+}
+
+test "findFrameIdInTree returns null when nothing in the tree matches" {
+    const tree =
+        \\{"frame":{"id":"MAIN","url":"https://example.com/"},"childFrames":[
+        \\  {"frame":{"id":"CHILD1","url":"https://ads.example.com/"}}
+        \\]}
+    ;
+    try std.testing.expect(findFrameIdInTree(tree, "nope", null) == null);
+    try std.testing.expect(findFrameIdInTree(tree, null, "nowhere.example.com") == null);
+}
+
+test "extractArrayInterior and nextArrayObject split a childFrames array despite a literal comma in a url string" {
+    const tree =
+        \\{"frame":{"id":"MAIN"},"childFrames":[
+        \\  {"frame":{"id":"A","url":"https://example.com/?a=1,2"}},
+        \\  {"frame":{"id":"B","url":"https://example.com/b"}}
+        \\]}
+    ;
+    const interior = extractArrayInterior(tree, "childFrames").?;
+    const first = nextArrayObject(interior, 0).?;
+    try std.testing.expectEqualStrings("A", jsonscan.extractField(jsonscan.extractObject(first.slice, "frame").?, "id").?);
+    const second = nextArrayObject(interior, first.next).?;
+    try std.testing.expectEqualStrings("B", jsonscan.extractField(jsonscan.extractObject(second.slice, "frame").?, "id").?);
+    try std.testing.expect(nextArrayObject(interior, second.next) == null);
+}
+
+test "mainframe route accepts an explicit tab_id" {
+    const target = "/mainframe?tab_id=t1";
+    try std.testing.expectEqualStrings("t1", getQueryParam(target, "tab_id").?);
+}
+
 test "tab/new route with url" {
     const target = "/tab/new?url=https://example.com";
     try std.testing.expectEqualStrings("https://example.com", getQueryParam(target, "url").?);
@@ -8074,50 +9513,58 @@ test "action check/uncheck routes" {
 }
 
 test "total endpoint count" {
-    // Verify we have the expected number of routes
+    // Verify we have the expected number of routes. This list is documentation
+    // (grouped roughly by when each tier landed); the actual source of truth is
+    // the `Route` enum in `route()` -- the compiler's exhaustive switch already
+    // guarantees every enum variant has a handler, so we only need to check here
+    // that this list hasn't drifted from that enum's variant count.
     const routes = [_][]const u8{
-        "/health",              "/tabs",            "/discover",            "/navigate",              "/snapshot",          "/action",
-        "/text",                "/screenshot",      "/evaluate",            "/browdie",               "/har/start",         "/har/stop",
-        "/har/status",          "/close",           "/cookies",             "/cookies/clear",         "/cookies/delete",    "/cookies/set",
-        "/storage/local",       "/storage/session", "/storage/local/clear", "/storage/session/clear", "/get",               "/back",
-        "/forward",             "/reload",          "/diff/snapshot",       "/emulate",               "/geolocation",       "/upload",
-        "/session/save",        "/session/load",    "/auth/profile/save",   "/auth/profile/load",     "/auth/profile/list", "/auth/profile/delete",
-        "/auth/extract",        "/debug/enable",    "/debug/disable",       "/screenshot/annotated",  "/screenshot/diff",   "/screencast/start",
-        "/screencast/stop",     "/video/start",     "/video/stop",          "/console",               "/intercept/start",   "/intercept/stop",
-        "/intercept/requests",  "/markdown",        "/links",               "/pdf",                   "/dom/query",         "/dom/html",
-        "/headers",             "/script/inject",   "/stop",
+        "/health",            "/tabs",                "/page/info",          "/discover",        "/navigate",              "/snapshot",
+        "/action",            "/text",                "/screenshot",         "/evaluate",        "/browdie",               "/har/start",
+        "/har/stop",          "/har/status",          "/har/replay",         "/close",           "/cookies",               "/cookies/clear",
+        "/cookies/delete",    "/cookies/set",         "/storage/local",      "/storage/session", "/storage/local/clear",   "/storage/session/clear",
+        "/get",               "/back",                "/forward",            "/reload",          "/diff/snapshot",         "/emulate",
+        "/geolocation",       "/upload",              "/session/save",       "/session/load",    "/auth/profile/save",     "/auth/profile/load",
+        "/auth/profile/list", "/auth/profile/delete", "/auth/extract",       "/debug/enable",    "/debug/disable",         "/screenshot/annotated",
+        "/screenshot/diff",   "/screencast/start",    "/screencast/stop",    "/video/start",     "/video/stop",            "/console",
+        "/intercept/start",   "/intercept/stop",      "/intercept/requests", "/intercept/rules", "/intercept/rules/clear", "/markdown",
+        "/links",             "/pdf",                 "/dom/query",          "/dom/html",        "/headers",               "/script/inject",
+        "/stop",
         // Tier 1 new endpoints
-                       "/scrollintoview",        "/drag",              "/keyboard/type",
-        "/keyboard/inserttext", "/keydown",         "/keyup",               "/wait",                  "/tab/new",           "/tab/close",
-        "/highlight",           "/errors",          "/set/offline",         "/set/media",             "/set/credentials",
+                     "/scrollintoview",      "/drag",               "/keyboard/type",   "/keyboard/inserttext",   "/keydown",
+        "/keyup",             "/wait",                "/tab/current",        "/tab/new",         "/tab/close",             "/highlight",
+        "/errors",            "/set/offline",         "/set/media",          "/set/credentials",
         // Tier 2 new endpoints
-          "/find",
-        "/trace/start",         "/trace/stop",      "/profiler/start",      "/profiler/stop",         "/inspect",           "/window/new",
-        "/session/list",        "/set/viewport",    "/set/useragent",       "/dom/attributes",        "/frames",            "/network",
-        "/perf/lcp",
+        "/find",                  "/trace/start",
+        "/trace/stop",        "/profiler/start",      "/profiler/stop",      "/inspect",         "/window/new",            "/session/list",
+        "/set/viewport",      "/set/useragent",       "/dom/attributes",     "/frames",          "/network",               "/perf/lcp",
         // Tier 3 new endpoints
-                   "/ws/start",        "/ws/stop",
+        "/ws/start",          "/ws/stop",
         // Tier 4 new endpoints
-                    "/batch",                 "/element/state",
+                    "/batch",              "/element/state",
         // Tier 5 new endpoints
-            "/find-element",
-        "/dialog/auto",         "/dialog/accept",   "/dialog/dismiss",      "/mouse/move",            "/mouse/down",        "/mouse/up",
-        "/mouse/wheel",         "/page/state",
+          "/find-element",          "/dialog/auto",
+        "/dialog/accept",     "/dialog/dismiss",      "/mouse/move",         "/mouse/down",      "/mouse/up",              "/mouse/wheel",
+        "/page/state",
         // Tier 6 new endpoints
-             "/clipboard/read",      "/clipboard/write",       "/clear",             "/boundingbox",
-        "/wait/function",       "/response/body",   "/setcontent",          "/selectall",             "/setvalue",          "/timezone",
-        "/locale",              "/permissions",     "/tap",                 "/dispatch",              "/download",
+               "/clipboard/read",      "/clipboard/write",    "/clear",           "/boundingbox",           "/wait/function",
+        "/response/body",     "/setcontent",          "/selectall",          "/setvalue",        "/timezone",              "/locale",
+        "/permissions",       "/tap",                 "/dispatch",           "/download",
         // Tier 7 new endpoints
-                 "/addstyle",
-        "/bringtofront",        "/pushstate",       "/expose",              "/multiselect",           "/swipe",             "/vitals",
-        "/frame",               "/mainframe",       "/getattribute",        "/inputvalue",            "/react/tree",        "/react/inspect",
-        "/react/renders",       "/react/suspense",  "/recording/start",     "/recording/stop",        "/request/detail",    "/wait/download",
-        "/initscript/remove",   "/evalhandle",      "/diff/url",
+               "/addstyle",              "/bringtofront",
+        "/pushstate",         "/expose",              "/multiselect",        "/swipe",           "/vitals",                "/frame",
+        "/mainframe",         "/getattribute",        "/inputvalue",         "/react/tree",      "/react/inspect",         "/react/renders",
+        "/react/suspense",    "/recording/start",     "/recording/stop",     "/request/detail",  "/wait/download",         "/initscript/remove",
+        "/evalhandle",        "/diff/url",
         // Advanced features
-                   "/cache/set",             "/cache/get",         "/cache/clear",
-        "/cache/list",          "/screenshot/som",  "/snapshot/changes",    "/recording/export",
+                   "/cache/set",          "/cache/get",       "/cache/clear",           "/cache/list",
+        "/screenshot/som",    "/snapshot/changes",    "/recording/export",
+        // Collector retrieval endpoints
+          "/expose/calls",
     };
-    try std.testing.expectEqual(@as(usize, 142), routes.len);
+    const route_variant_count = @typeInfo(Route).@"enum".field_names.len;
+    try std.testing.expectEqual(route_variant_count, routes.len);
+    try std.testing.expectEqual(@as(usize, 148), routes.len);
 }
 
 test "buildGetExpression title" {
@@ -8232,6 +9679,24 @@ test "extractSimpleJsonString with offset" {
     try std.testing.expectEqualStrings("first", first.?);
 }
 
+test "handleMainFrame frame tree parsing must not read the top-level response id" {
+    // Real Page.getFrameTree shape: the JSON-RPC envelope's own "id" (a bare
+    // number, the command id) sits before "frameTree" — extractSimpleJsonString
+    // only matches quoted string values, so searching from position 0 for
+    // "id" must fail here (proving why handleMainFrame searches from the
+    // "frameTree" offset instead of from 0).
+    const response = "{\"id\":7,\"result\":{\"frameTree\":{\"frame\":{\"id\":\"F123\",\"loaderId\":\"L456\",\"url\":\"https://example.com/\"},\"childFrames\":[]}}}";
+    try std.testing.expect(extractSimpleJsonString(response, 0, "\"id\"") == null);
+
+    const frametree_pos = std.mem.indexOf(u8, response, "\"frameTree\"").?;
+    const frame_id = extractSimpleJsonString(response, frametree_pos, "\"id\"");
+    const loader_id = extractSimpleJsonString(response, frametree_pos, "\"loaderId\"");
+    const frame_url = extractSimpleJsonString(response, frametree_pos, "\"url\"");
+    try std.testing.expectEqualStrings("F123", frame_id.?);
+    try std.testing.expectEqualStrings("L456", loader_id.?);
+    try std.testing.expectEqualStrings("https://example.com/", frame_url.?);
+}
+
 test "extractSimpleJsonInt extracts number" {
     const json = "{\"backendDOMNodeId\":42,\"nodeId\":\"n1\"}";
     const val = extractSimpleJsonInt(json, 0, "\"backendDOMNodeId\"");
@@ -8342,6 +9807,24 @@ test "jsonEscapeAlloc escapes special chars" {
     try std.testing.expectEqualStrings("line1\\nline2\\r\\n", nl);
 }
 
+test "jsonEscapeAlloc applied twice corrupts JS source — escape exactly once" {
+    const arena = std.testing.allocator;
+    // Regression guard for the /evaluate + /script/inject double-escape bug.
+    // Escaping once is correct: a newline becomes the two-char sequence \n,
+    // which JSON-decodes back to a real newline in the JS source.
+    const once = jsonEscapeAlloc(arena, "return 1;\nreturn 2;").?;
+    defer arena.free(once);
+    try std.testing.expectEqualStrings("return 1;\\nreturn 2;", once);
+
+    // Escaping the ALREADY-escaped string turns the backslash into `\\`, so
+    // Chrome receives a literal backslash+n in the source and answers with
+    // "SyntaxError: Invalid or unexpected token" instead of running anything.
+    const twice = jsonEscapeAlloc(arena, once).?;
+    defer arena.free(twice);
+    try std.testing.expectEqualStrings("return 1;\\\\nreturn 2;", twice);
+    try std.testing.expect(!std.mem.eql(u8, once, twice));
+}
+
 test "parseCdpAddress falls back to managed chrome port" {
     const addr = parseCdpAddress(null, 9224);
     try std.testing.expectEqualStrings("127.0.0.1", addr.host);
@@ -8381,4 +9864,302 @@ test "perf/lcp route parameters" {
     try std.testing.expectEqualStrings("/perf/lcp", clean);
     try std.testing.expect(getQueryParam(path, "tab_id") != null);
     try std.testing.expect(getQueryParam(path, "url") != null);
+}
+
+test "intercept/rules route matching" {
+    const path = "/intercept/rules?tab_id=abc";
+    const clean = path[0..std.mem.indexOfScalar(u8, path, '?').?];
+    try std.testing.expectEqualStrings("/intercept/rules", clean);
+}
+
+test "intercept/rules/clear route matching" {
+    const path = "/intercept/rules/clear?tab_id=abc";
+    const clean = path[0..std.mem.indexOfScalar(u8, path, '?').?];
+    try std.testing.expectEqualStrings("/intercept/rules/clear", clean);
+}
+
+test "intercept/start patterns query param parsing" {
+    const target = "/intercept/start?tab_id=abc&patterns=*.png,*.jpg";
+    try std.testing.expectEqualStrings("abc", getQueryParam(target, "tab_id").?);
+    try std.testing.expectEqualStrings("*.png,*.jpg", getQueryParam(target, "patterns").?);
+    // Missing patterns falls back to "*" at the handler level, not here.
+    try std.testing.expect(getQueryParam("/intercept/start?tab_id=abc", "patterns") == null);
+}
+
+test "parseInterceptRuleBody parses a fulfill rule" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const body =
+        \\{"url_pattern":"api.example.com","action":"fulfill","status":204,"content_type":"text/plain","body":"blocked"}
+    ;
+    const rule = parseInterceptRuleBody(arena, body).?;
+    try std.testing.expectEqualStrings("api.example.com", rule.url_substring);
+    try std.testing.expectEqual(InterceptRule.Action.fulfill, rule.action);
+    try std.testing.expectEqual(@as(u16, 204), rule.status);
+    try std.testing.expectEqualStrings("text/plain", rule.content_type);
+    try std.testing.expectEqualStrings("blocked", rule.body);
+}
+
+test "parseInterceptRuleBody parses an abort rule with error_reason" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const body =
+        \\{"url_pattern":"ads.","action":"abort","error_reason":"BlockedByClient"}
+    ;
+    const rule = parseInterceptRuleBody(arena, body).?;
+    try std.testing.expectEqualStrings("ads.", rule.url_substring);
+    try std.testing.expectEqual(InterceptRule.Action.abort, rule.action);
+    try std.testing.expectEqualStrings("BlockedByClient", rule.error_reason);
+}
+
+test "parseInterceptRuleBody treats a bare * pattern as catch-all" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const body =
+        \\{"url_pattern":"*","action":"continue"}
+    ;
+    const rule = parseInterceptRuleBody(arena, body).?;
+    try std.testing.expectEqualStrings("", rule.url_substring);
+    try std.testing.expectEqual(InterceptRule.Action.@"continue", rule.action);
+}
+
+test "parseInterceptRuleBody rejects an invalid action" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const body =
+        \\{"url_pattern":"x","action":"redirect"}
+    ;
+    try std.testing.expect(parseInterceptRuleBody(arena, body) == null);
+}
+
+test "writeInterceptRuleJson serializes all rule fields" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var buf: std.ArrayList(u8) = .empty;
+    try writeInterceptRuleJson(&buf, arena, .{
+        .url_substring = "/blocked",
+        .action = .abort,
+        .error_reason = "Failed",
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"url_pattern\":\"/blocked\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"action\":\"abort\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"error_reason\":\"Failed\"") != null);
+}
+
+test "network route mode=list parameter" {
+    const target = "/network?tab_id=t1&mode=list&url=example.com";
+    try std.testing.expectEqualStrings("list", getQueryParam(target, "mode").?);
+    try std.testing.expectEqualStrings("example.com", getQueryParam(target, "url").?);
+}
+
+test "expose/calls route parses tab_id, name, and clear parameters" {
+    const target = "/expose/calls?tab_id=t1&name=myBinding&clear=true";
+    try std.testing.expectEqualStrings("t1", getQueryParam(target, "tab_id").?);
+    try std.testing.expectEqualStrings("myBinding", getQueryParam(target, "name").?);
+    try std.testing.expectEqualStrings("true", getQueryParam(target, "clear").?);
+}
+
+test "expose/calls route matches cleanly" {
+    const clean = if (std.mem.indexOfScalar(u8, "/expose/calls?tab_id=1&name=foo", '?')) |idx|
+        "/expose/calls?tab_id=1&name=foo"[0..idx]
+    else
+        "/expose/calls?tab_id=1&name=foo";
+    try std.testing.expectEqualStrings("/expose/calls", clean);
+}
+
+test "screencast/stop frames query parameter defaults to latest when absent" {
+    const target = "/screencast/stop?tab_id=t1";
+    try std.testing.expectEqualStrings("latest", getQueryParam(target, "frames") orelse "latest");
+}
+
+test "screencast/stop frames=all and frames=none are both parseable" {
+    try std.testing.expectEqualStrings("all", getQueryParam("/screencast/stop?tab_id=t1&frames=all", "frames").?);
+    try std.testing.expectEqualStrings("none", getQueryParam("/screencast/stop?tab_id=t1&frames=none", "frames").?);
+}
+
+test "response/body route accepts either request_id or url parameter" {
+    try std.testing.expectEqualStrings("abc123", getQueryParam("/response/body?tab_id=t1&request_id=abc123", "request_id").?);
+    try std.testing.expectEqualStrings("example.com", getQueryParam("/response/body?tab_id=t1&url=example.com", "url").?);
+}
+
+test "writeScreencastFrameJson serializes all frame fields" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var buf: std.ArrayList(u8) = .empty;
+    try writeScreencastFrameJson(&buf, arena, .{
+        .data_b64 = "Zm9v",
+        .timestamp = 12345.5,
+        .device_width = 1280,
+        .device_height = 720,
+        .session_id = 7,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"data_b64\":\"Zm9v\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"device_width\":1280") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"device_height\":720") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"session_id\":7") != null);
+}
+
+test "writeNetworkRecordJson serializes all request fields" {
+    var arena_impl = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var buf: std.ArrayList(u8) = .empty;
+    try writeNetworkRecordJson(&buf, arena, .{
+        .request_id = "req-1",
+        .url = "https://example.com/api",
+        .url_truncated = false,
+        .method = "GET",
+        .mime_type = "application/json",
+        .timestamp = 1000,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"request_id\":\"req-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"url\":\"https://example.com/api\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"method\":\"GET\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mime_type\":\"application/json\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"url_truncated\":false") != null);
+}
+
+test "trace/start requests transferMode ReturnAsStream so /trace/stop can drain a stream" {
+    // Guards against silently dropping the transferMode param in a future
+    // edit: without it, Tracing.tracingComplete carries no `stream` handle
+    // and /trace/stop has nothing to read.
+    const params_fmt = "{{\"categories\":\"{s}\",\"options\":\"sampling-frequency=10000\",\"transferMode\":\"ReturnAsStream\"}}";
+    var buf: [256]u8 = undefined;
+    const rendered = try std.fmt.bufPrint(&buf, params_fmt, .{"test.category"});
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "\"transferMode\":\"ReturnAsStream\"") != null);
+}
+
+test "video/start and video/stop are their own route entries, not screencast aliases" {
+    // Regression guard: video/* used to be `const handleVideoStart =
+    // handleScreencastStart;` -- a pure alias with no distinct wiring. Both
+    // route paths must still resolve, and to a different function value
+    // than the screencast handlers (thin wrappers around a shared core,
+    // not the exact same function).
+    try std.testing.expect(@TypeOf(handleVideoStart) == @TypeOf(handleScreencastStart));
+    try std.testing.expect(&handleVideoStart != &handleScreencastStart);
+    try std.testing.expect(&handleVideoStop != &handleScreencastStop);
+}
+
+// --- X-Kuri-Session resolution across handler shapes ---
+//
+// resolveEffectiveTabIdAlloc is the single shared resolver behind every
+// handler shape in this file:
+//   - `const tab_id = requireEffectiveTabId(...) orelse return;` (the vast
+//     majority of handlers -- requireEffectiveTabId is a thin wrapper that
+//     just adds the 400 sendError)
+//   - `const tab_id = resolveEffectiveTabIdAlloc(...) orelse { sendError(...);
+//     return; };` (the inline form used by /console, /errors, and the
+//     /intercept/* handlers)
+//   - `const tab_id = resolveEffectiveTabIdAlloc(...);` with no error at all,
+//     used where a missing tab_id has its own fallback behavior (/navigate,
+//     /close)
+// A real std.http.Server.Request can't be constructed without a live
+// connection, but Request itself only needs `head` (parsed request line) and
+// `head_buffer` (raw bytes for iterateHeaders) populated -- exactly the
+// pattern std.http.Server.Request's own `test iterateHeaders` uses.
+fn testRequest(target: []const u8, head_buffer: []const u8, server: *std.http.Server) std.http.Server.Request {
+    return .{
+        .server = server,
+        .head = .{
+            .method = .GET,
+            .target = target,
+            .version = .@"HTTP/1.1",
+            .expect = null,
+            .content_type = null,
+            .content_length = null,
+            .transfer_encoding = .none,
+            .transfer_compression = .identity,
+            .keep_alive = true,
+        },
+        .head_buffer = @constCast(head_buffer),
+    };
+}
+
+test "resolveEffectiveTabIdAlloc resolves session across representative handler shapes" {
+    const allocator = std.testing.allocator;
+
+    var bridge = Bridge.init(allocator);
+    defer bridge.deinit();
+    try bridge.setCurrentTab("sess-abc", "tab-from-session");
+
+    var server: std.http.Server = .{
+        .reader = .{
+            .in = undefined,
+            .state = .received_head,
+            .interface = undefined,
+            .max_head_len = 4096,
+        },
+        .out = undefined,
+    };
+
+    // Shape 1: explicit ?tab_id= wins even when a session header also
+    // resolves -- the path every `requireEffectiveTabId(...) orelse return;`
+    // handler takes for a normal, fully-specified call.
+    {
+        var request = testRequest(
+            "/console?tab_id=explicit-tab",
+            "GET /console?tab_id=explicit-tab HTTP/1.1\r\nX-Kuri-Session: sess-abc\r\n\r\n",
+            &server,
+        );
+        const resolved = resolveEffectiveTabIdAlloc(allocator, &request, &bridge).?;
+        defer allocator.free(resolved);
+        try std.testing.expectEqualStrings("explicit-tab", resolved);
+    }
+
+    // Shape 2: no tab_id, X-Kuri-Session header -- the case the audit flagged
+    // as broken; exercised by both requireEffectiveTabId callers and the
+    // inline resolveEffectiveTabIdAlloc callers (/console, /errors,
+    // /intercept/*).
+    {
+        var request = testRequest(
+            "/console",
+            "GET /console HTTP/1.1\r\nX-Kuri-Session: sess-abc\r\n\r\n",
+            &server,
+        );
+        const resolved = resolveEffectiveTabIdAlloc(allocator, &request, &bridge).?;
+        defer allocator.free(resolved);
+        try std.testing.expectEqualStrings("tab-from-session", resolved);
+    }
+
+    // Shape 3: no tab_id, no header, session carried via ?session= query
+    // param -- the fallback getSessionId offers callers that can't set
+    // custom headers.
+    {
+        var request = testRequest(
+            "/errors?session=sess-abc",
+            "GET /errors?session=sess-abc HTTP/1.1\r\n\r\n",
+            &server,
+        );
+        const resolved = resolveEffectiveTabIdAlloc(allocator, &request, &bridge).?;
+        defer allocator.free(resolved);
+        try std.testing.expectEqualStrings("tab-from-session", resolved);
+    }
+
+    // Shape 4: no tab_id and no session at all -- resolves to null so the
+    // caller's own orelse (requireEffectiveTabId's sendError, or an inline
+    // one) is what fires, not a silent wrong-tab fallback.
+    {
+        var request = testRequest(
+            "/intercept/requests",
+            "GET /intercept/requests HTTP/1.1\r\n\r\n",
+            &server,
+        );
+        try std.testing.expect(resolveEffectiveTabIdAlloc(allocator, &request, &bridge) == null);
+    }
 }


### PR DESCRIPTION
Seven HTTP routes returned results they never obtained from the browser. Each answered `200` with a well-formed body, so no caller could tell "Chrome reported nothing" apart from "kuri never asked Chrome".

## Routes that fabricated their answers

| route | before | after |
| --- | --- | --- |
| `/react/tree` | `{"react":false}` on every React page | real tree — `FunctionComponent`, `Context.Consumer`, `HostComponent`, depths |
| `/trace/stop` | empty ack, nothing written | ~400 KB of real trace on disk |
| `/expose` | binding registered, invocations dropped | captures the call with its payload |
| `/network` | canned `{"status":"ok"}` | real requests with url, method, mime |
| `/mainframe` | same hard-coded string for every caller | real `frameId`, `loaderId`, `url` |
| `/screencast/stop` | canned ok | real `frame_count` |
| `/console`, `/errors` | regressed to empty | capturing again |

`/react/tree` is the interesting one. React double-buffers fibers, and `__reactContainer$…` is stamped at mount, so after the first commit it addresses the off-screen side of the pair, whose `.child` is `null` — detection concluded there was no React at all. Confirmed on React 19.2.5: `hasChild:false`, `altHasChild:true`. It now follows whichever side actually rendered.

## Script injection

- **`/evaluate` and `/evalhandle` escaped their expression twice.** A newline became `\n`, then `\\n`, which decodes back to a literal backslash-n *in the JS source* — Chrome rejected every multi-line or quote-containing expression with `SyntaxError`. The two routes whose whole purpose is running arbitrary JS could not run any non-trivial JS.
- **`stealth.js` polluted every page's error stream.** A top-level `const` in a file injected twice by design (`addScriptToEvaluateOnNewDocument` plus a one-shot evaluate into the loaded page). Re-running it in the same global re-declared the const; the `SyntaxError` aborted the whole re-injection at parse time and surfaced in the page's own error stream, so `/errors` reported a kuri-internal failure as if it were the page's. Now an IIFE behind an idempotence guard.

## Memory safety

- The event rings handed out pointers into storage the next wrapping event would overwrite — a use-after-free reachable from ordinary traffic. All four rings now dupe into a caller-supplied per-request arena.
- `extractObject`/`extractField` scanned for a closing brace or quote without honouring `\"`, truncating any string value with an escaped quote and ending early on unbalanced literal braces (a GraphQL query sent over GET, for instance).

## Performance

- **Route dispatch ~13× faster.** A linear chain of 148 `std.mem.eql` comparisons — cost depended on position, and every unknown path paid all 148 — replaced by a comptime `StaticStringMap` feeding an exhaustive switch. ~81ns → ~6ns average, ~150ns → ~15ns worst case. `zig build bench` carries a permanent guard over all 148 routes.
- **`CdpClient` 520 KiB → 62 KiB per tab (−88%).** `ws_read_buf` was 512 KiB of which ~97% was unreachable headroom (message bodies allocate their own buffer); `ws_write_buf` had no readers anywhere.

## Tests

378 in the main suite, 76 for `kuri-fetch`, 22 for `kuri-browse` — all passing, with a regression test per fix. Clean `ReleaseFast` build. The dispatch rewrite was checked live against Chrome (`storage/local` → `LOCAL_VAL` vs `storage/session` → `SESSION_VAL`, clipboard read ≠ write, unknown path still 404s), which was its catastrophic-if-wrong failure mode, plus intercept and dialog round-trips.

## Note on macOS assets

This repository has **no** GitHub Actions secrets, so the workflow's sign-and-notarize step takes its `signed=false` branch and CI publishes unsigned macOS binaries. The macOS tarballs for this release are signed with `Developer ID Application: Rachit Pradhan (WWP9DLJ27P)` and notarized locally via the `codedb-notary` profile, then uploaded over CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yzwAh6c95Ygb4LYttdVCs
