### PR TITLE
ci: give publish-channel the repo it copies install.sh from

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,15 @@ jobs:
         with:
           ref: release-channel
           path: channel
+      # The tagged source tree. This job used to check out only the channel
+      # branch, so when publishing install.sh from the repo was added below
+      # there was no repo to copy it from: `cp install.sh` failed, and with
+      # `set -e` the whole job died before writing anything at all. v0.4.13
+      # published to GitHub Releases but never reached the channel, leaving
+      # `kuri update` and the curl-installer serving the previous release.
+      - uses: actions/checkout@v4
+        with:
+          path: repo
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -148,7 +157,7 @@ jobs:
           # people actually `curl` did not, so every install produced a kuri
           # whose `android`/`ios` subcommands could not exec their sibling
           # binary. The file users run must be generated from the tagged tree.
-          cp install.sh channel/stable/install.sh
+          cp repo/install.sh channel/stable/install.sh
 
           python3 - <<'PY'
           from pathlib import Path


### PR DESCRIPTION
`75e0c3c` made the channel publish `cp install.sh channel/stable/install.sh`, so the installer people `curl` is generated from the tagged tree rather than remembered by hand. But `publish-channel` checks out **only** the `release-channel` branch, into `channel/` — the repo tree is never checked out, so there is no `install.sh` at the workspace root to copy.

v0.4.13 was the first release to run it:

```
cp: cannot stat 'install.sh': No such file or directory
##[error]Process completed with exit code 1
```

`set -e` took the job down before it wrote anything, and `publish-github-release` succeeded independently — so the release looked published while `stable/latest.json` still pointed at v0.4.12. Every `kuri update` and `curl … install.sh | sh` kept serving the previous release. A fix meant to stop the installer drifting instead stopped the channel updating at all.

This checks the repo out into `repo/` and copies from there.

v0.4.13's channel entry has already been published by hand (with signed and notarized macOS tarballs); this is what makes v0.4.14 work on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yzwAh6c95Ygb4LYttdVCs