### PR TITLE
fix(agent): eval awaits async expressions instead of returning the pending Promise (#177)

### DIFF
--- a/src/agent_main.zig
+++ b/src/agent_main.zig
@@ -822,7 +822,10 @@ fn cmdViewport(arena: std.mem.Allocator, client: *CdpClient, args: []const []con
 
 fn cmdEval(arena: std.mem.Allocator, client: *CdpClient, expr: []const u8) !void {
     const escaped = try escapeForJson(arena, expr);
-    const params = try std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true}}", .{escaped});
+    // #177: without awaitPromise an async expression returns the pending
+    // Promise object (value lost); with it, CDP resolves first — same flag the
+    // HTTP /evaluate route and cmdHeaders/cmdAudit already pass.
+    const params = try std.fmt.allocPrint(arena, "{{\"expression\":\"{s}\",\"returnByValue\":true,\"awaitPromise\":true}}", .{escaped});
     const response = client.send(arena, protocol.Methods.runtime_evaluate, params) catch |err| {
         jsonError("eval failed: {s}", .{@errorName(err)});
         std.process.exit(1);


### PR DESCRIPTION
Fixes #177. `cmdEval` sent `Runtime.evaluate` with `returnByValue` only, so an async expression returned the pending Promise and the resolved value was lost. This passes `awaitPromise:true` — the same flag the HTTP `/evaluate` route and `cmdHeaders`/`cmdAudit` already pass — so CDP resolves before serializing. 378/378 tests pass. Note: the v0.5.x release line has the identical missing flag at its own cmdEval and needs this same one-liner when the lines reunify.